### PR TITLE
docs: remove PyPI badge until package is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > Your friendly Python library for fetching Thai stock market data 🇹🇭
 
-[![PyPI version](https://badge.fury.io/py/settfex.svg)](https://badge.fury.io/py/settfex)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Remove PyPI badge that shows 'not found' since package is not yet published to PyPI