### PR TITLE
fix: update PyPI badge to use shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Your friendly Python library for fetching Thai stock market data 🇹🇭
 
-[![PyPI version](https://badge.fury.io/py/settfex.svg)](https://badge.fury.io/py/settfex)
+[![PyPI version](https://img.shields.io/pypi/v/settfex.svg)](https://pypi.org/project/settfex/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## 🎯 Problem
The PyPI badge was showing 'not found' on GitHub even though the package is published on PyPI. This is because badge.fury.io was caching the old 'not found' response.

## 🔧 Solution
Switch to shields.io badge service which:
- Has better cache handling
- Updates faster when packages are published
- More reliable for PyPI badges

## 📝 Changes
- Changed badge URL from `badge.fury.io` to `shields.io`
- Badge will now correctly show version 0.1.0

## ✅ Result
The badge will display correctly on GitHub showing the current PyPI version.