### PR TITLE
🔧 fix: resolve all 23 mypy type errors for CI green

### DIFF
--- a/settfex/services/set/list.py
+++ b/settfex/services/set/list.py
@@ -172,17 +172,12 @@ class StockListService:
             # Get optimized headers for SET API
             headers = AsyncDataFetcher.get_set_api_headers()
 
-            # Use provided session cookies or generate Incapsula-aware cookies
-            cookies = self.session_cookies or AsyncDataFetcher.generate_incapsula_cookies()
-
-            # Fetch JSON data
-            data = await fetcher.fetch_json(
-                url, headers=headers, cookies=cookies, use_random_cookies=False
-            )
+            # SessionManager handles cookies automatically — no manual cookie needed
+            data = await fetcher.fetch_json(url, headers=headers)
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
             )  # noqa: E501
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 # Convenience function for quick access

--- a/settfex/services/set/stock/chart_quotation.py
+++ b/settfex/services/set/stock/chart_quotation.py
@@ -195,7 +195,7 @@ class ChartQuotationService:
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
             )
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 async def get_chart_quotation(

--- a/settfex/services/set/stock/highlight_data.py
+++ b/settfex/services/set/stock/highlight_data.py
@@ -240,7 +240,7 @@ class StockHighlightDataService:
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
             )
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 # Convenience function for quick access

--- a/settfex/services/set/stock/latest_historical_trading.py
+++ b/settfex/services/set/stock/latest_historical_trading.py
@@ -173,7 +173,7 @@ class LatestHistoricalTradingService:
                 raise
 
             logger.debug(f"Raw response keys: {list(data.keys())}")
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 async def get_latest_historical_trading(

--- a/settfex/services/set/stock/price_performance.py
+++ b/settfex/services/set/stock/price_performance.py
@@ -250,7 +250,7 @@ class PricePerformanceService:
                 raise ValueError(error_msg)
 
             logger.debug(f"Raw response keys: {data.keys()}")
-            return data  # type: ignore[return-value]
+            return data
 
 
 # Convenience function for quick access

--- a/settfex/services/set/stock/profile_company.py
+++ b/settfex/services/set/stock/profile_company.py
@@ -284,7 +284,7 @@ class CompanyProfileService:
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
             )
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 # Convenience function for quick access

--- a/settfex/services/set/stock/profile_stock.py
+++ b/settfex/services/set/stock/profile_stock.py
@@ -234,22 +234,12 @@ class StockProfileService:
             referer = f"https://www.set.or.th/en/market/product/stock/quote/{symbol}/price"
             headers = AsyncDataFetcher.get_set_api_headers(referer=referer)
 
-            # Cookie handling (priority: session_cookies > use_cookies > no cookies)
-            # HAR analysis shows real Chrome sends no cookies by default
-            cookies = None
-            if self.session_cookies:
-                cookies = self.session_cookies
-            elif self.use_cookies:
-                cookies = AsyncDataFetcher.generate_incapsula_cookies(landing_url=referer)
-
-            # Fetch JSON data
-            data = await fetcher.fetch_json(
-                url, headers=headers, cookies=cookies, use_random_cookies=False
-            )
+            # SessionManager handles cookies automatically — no manual cookie needed
+            data = await fetcher.fetch_json(url, headers=headers)
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
             )
-            return data
+            return data  # type: ignore[no-any-return]
 
 
 # Convenience function for quick access

--- a/settfex/services/set/stock/trading_stat.py
+++ b/settfex/services/set/stock/trading_stat.py
@@ -235,7 +235,7 @@ class TradingStatService:
                 raise ValueError(error_msg)
 
             logger.debug(f"Raw response: {len(data)} records")
-            return data  # type: ignore[return-value]
+            return data
 
 
 # Convenience function for quick access

--- a/settfex/utils/session_cache.py
+++ b/settfex/utils/session_cache.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-import diskcache
+import diskcache  # type: ignore[import-untyped]
 from loguru import logger
 
 
@@ -98,7 +98,7 @@ class SessionCache:
             value = self.cache.get(key)
             if value is not None:
                 logger.debug(f"Cache HIT: {key}")
-                return value
+                return value  # type: ignore[no-any-return]
             else:
                 logger.debug(f"Cache MISS: {key}")
                 return None
@@ -158,7 +158,7 @@ class SessionCache:
             result = self.cache.delete(key)
             if result:
                 logger.debug(f"Deleted from cache: {key}")
-            return result
+            return bool(result)
         except Exception as e:
             logger.error(f"Failed to delete from cache: {e}")
             return False
@@ -188,7 +188,7 @@ class SessionCache:
         else:
             logger.debug(f"Cache valid: {key} (age={age:.0f}s < max={max_age}s)")
 
-        return is_expired
+        return bool(is_expired)
 
     def clear(self) -> None:
         """Clear all cached data."""
@@ -226,7 +226,7 @@ class SessionCache:
         """Context manager entry."""
         return self
 
-    def __exit__(self, *args) -> None:
+    def __exit__(self, *args: object) -> None:
         """Context manager exit."""
         self.close()
 


### PR DESCRIPTION
## Summary

Fix all 23 mypy errors blocking CI from passing.

### Issues fixed

| Category | Files | Count |
|---|---|---|
| Legacy cookie code (removed params) | `profile_stock.py`, `list.py` | 10 |
| Returning Any from `dict[str, Any]` functions | 6 files (`*_raw` methods) | 7 |
| Unused `type: ignore` comments | `price_performance.py`, `trading_stat.py` | 2 |
| Session cache type issues | `session_cache.py` | 4 |

### Details

- **Removed dead cookie code**: `session_cookies`, `use_cookies`, `generate_incapsula_cookies` references removed — SessionManager handles all cookies automatically since the 2025-10-03 refactoring
- **Removed invalid kwargs**: `cookies` and `use_random_cookies` no longer accepted by `fetch_json()`
- **Added `# type: ignore[no-any-return]`**: For `fetch_*_raw` methods where `response.json()` returns `Any`
- **Fixed `session_cache.py`**: Added `import-untyped` ignore for `diskcache`, wrapped return values with `bool()`, added missing `__exit__` type annotation

### Verification
```
$ uv run mypy settfex/
Success: no issues found in 31 source files

$ uv run ruff check .
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)