### PR TITLE
Hardening pass: financial-data robustness, concurrency fixes, and 0.2.1 release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.py]
+indent_size = 4
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug to help us improve settfex
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to reproduce
+
+```python
+# Minimal async snippet that triggers the bug
+```
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened — include the full error message / traceback or logs.
+
+## Service / endpoint
+
+Which settfex service is involved (e.g. `get_highlight_data`, `Stock`,
+`get_stock_list`, TFEX series list) and the symbol used, if relevant.
+
+## Environment
+
+- OS: [e.g. macOS 15, Ubuntu 24.04]
+- Python version: [e.g. 3.11.9]
+- settfex version: [from `pip show settfex` or `uv pip show settfex`]
+- uv version: [from `uv --version`, if applicable]
+
+## Additional context
+
+Add any other context (network/proxy setup, intermittent vs reproducible, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new service, data field, or improvement for settfex
+labels: enhancement
+---
+
+## Problem
+
+Describe the problem this feature would solve (e.g. "settfex has no service for
+X data that the SET/TFEX website exposes").
+
+## Proposed solution
+
+Describe what you'd like to happen. If it's a new data service, include the
+endpoint URL / API shape if you know it.
+
+## Alternatives considered
+
+Describe any alternative solutions or workarounds you've tried.
+
+## Additional context
+
+Add any other context, links to SET/TFEX pages, or sample responses.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- Briefly describe what this PR does. -->
+
+## Changes
+
+<!-- List the key changes with file paths. -->
+
+- ...
+
+## Test plan
+
+<!-- Check the boxes after verifying each step locally. -->
+
+- [ ] `uv run ruff check .` passes
+- [ ] `uv run ruff format --check .` passes
+- [ ] `uv run mypy settfex/` passes
+- [ ] `uv run pytest` passes (coverage gate met)
+- [ ] New/changed behavior is covered by tests (external API calls mocked)
+- [ ] Docs / docstrings / `CHANGELOG.md` updated if user-facing
+
+## Related
+
+<!-- Link to issues or discussions. -->
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Python dependencies (uv.lock / pyproject.toml).
+  # If your Dependabot version rejects the "uv" ecosystem, change it to "pip".
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+
+  # GitHub Actions used in workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "**/*.py"
       - "pyproject.toml"
+      - "uv.lock"
       - "tests/**"
       - ".github/workflows/ci.yml"
   push:
@@ -18,12 +19,13 @@ on:
     paths:
       - "**/*.py"
       - "pyproject.toml"
+      - "uv.lock"
       - "tests/**"
       - ".github/workflows/ci.yml"
 
 jobs:
-  ruff:
-    name: Ruff
+  lint:
+    name: Lint & Type
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,18 +34,23 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: "uv.lock"
 
       - run: uv python install 3.11
-      - run: uv sync --group dev
+      - run: uv sync --group dev --frozen
 
       - run: uv run ruff check .
       - run: uv run ruff format --check .
+      - run: uv run mypy settfex/
 
-  quality:
-    name: Type & Tests
+  test:
+    name: Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    needs: ruff
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -51,15 +58,15 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: "uv.lock"
 
-      - run: uv python install 3.11
-      - run: uv sync --group dev
+      - run: uv python install ${{ matrix.python-version }}
+      - run: uv sync --group dev --frozen
 
-      - run: uv run mypy settfex/
       - run: uv run pytest --cov=settfex --cov-branch --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           files: coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: "uv.lock"
 
       - run: uv python install 3.11
-      - run: uv sync --group dev
+      - run: uv sync --group dev --frozen
 
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -89,7 +89,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: "uv.lock"
 
       - run: uv python install 3.11
       - run: uv run python -m build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,62 @@
+name: Security
+
+on:
+  schedule:
+    - cron: "23 3 * * 3" # Wednesdays at 03:23 UTC
+  push:
+    branches: [main]
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/security.yml"
+  workflow_dispatch:
+
+jobs:
+  bandit:
+    name: Bandit (static analysis)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - run: uv python install 3.12
+      - run: uv sync --group dev --frozen
+
+      # `|| true` so a finding uploads the report instead of failing the job;
+      # review findings in the artifact.
+      - run: uv run bandit -c pyproject.toml -r settfex -f json -o bandit-results.json || true
+
+      - name: Upload Bandit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-results
+          path: bandit-results.json
+          retention-days: 7
+
+  pip-audit:
+    name: pip-audit (dependency CVEs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - run: uv python install 3.12
+      - run: uv sync --group dev --frozen
+
+      # Non-blocking: surfaces dependency CVEs for triage without blocking PRs.
+      # Some advisories are transitive or not-yet-fixed upstream (e.g. no fix
+      # released), so review results and bump deps in a dedicated PR.
+      - run: uv run pip-audit --desc
+        continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Pre-commit hooks mirroring the CI quality gate.
+#   Install once:   uv run pre-commit install
+#   Run manually:   uv run pre-commit run --all-files
+#   Update revs:    uv run pre-commit autoupdate
+repos:
+  # Ruff: lint (with autofix) + format — matches CI `ruff check` / `ruff format`.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Standard hygiene hooks.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  # mypy runs as a local hook via `uv run` so it uses the project environment
+  # and the strict config in pyproject.toml — identical to CI (`mypy settfex/`).
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (settfex)
+        entry: uv run mypy settfex/
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^settfex/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-06-17
+
+Robustness and concurrency hardening release. No public API changes — function
+signatures, return types, Pydantic model fields, and `en`/`th` + symbol normalization
+are all preserved. See `COMPREHENSIVE_AUDIT.md` for full details and benchmarks.
+
+### Fixed
+
+- **Silent financial-data corruption:** `NaN`/`Infinity` values from the SET/TFEX APIs were
+  silently accepted into numeric model fields (prices, P/E, margins). They are now rejected at
+  decode time with a clear error that includes the originating symbol and endpoint.
+- Parse and validation failures now raise with **symbol + endpoint context** (and per-item
+  index for lists) instead of a bare, context-free `ValidationError`/`JSONDecodeError`.
+- Replaced unsafe `assert isinstance(data, dict)` in the TFEX trading-statistics and
+  series-list raw paths — `assert` is stripped under `python -O` — with explicit, contextful
+  errors.
+- **Session warm-up stampede:** concurrent cold-start callers each fired their own warm-up
+  round-trip (which can trip bot detection); warm-up is now serialized to run at most once.
+- Offloaded blocking cache initialization (directory creation + opening the on-disk cache) off
+  the asyncio event loop.
+
+### Changed
+
+- Centralized JSON decode + Pydantic validation across all SET/TFEX services into a shared
+  internal helper (`settfex/utils/parsing.py`), removing ~111 lines of duplicated boilerplate.
+- Hoisted static request headers in `AsyncDataFetcher.fetch()` to a module-level constant.
+- Added regression tests for malformed/NaN/partial responses and TFEX coverage
+  (test suite 116 → 149; coverage 49% → 61%).
+
 ## [0.2.0] - 2026-06-09
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at b@candythink.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/COMPREHENSIVE_AUDIT.md
+++ b/COMPREHENSIVE_AUDIT.md
@@ -1,0 +1,139 @@
+# settfex Hardening Pass — Comprehensive Audit
+
+**Branch:** `claude-settfex-overhaul` (off `chore/adopt-python-template-tooling`)
+**Scope:** robustness / financial-correctness + performance / concurrency hardening of the
+SET/TFEX async client, with the public API contract preserved exactly.
+
+---
+
+## 1. Executive summary
+
+| Metric | Before | After |
+|---|---|---|
+| Tests passing | 116 | **149** (+33) |
+| Test runtime | 3.77 s | 2.81 s |
+| Coverage (gate = 45%) | 49.26% | **61.25%** (+11.99 pts) |
+| `ruff check` / `ruff format` / `mypy --strict` | clean | clean |
+
+- **5 classes of defect fixed** — the headline one being **silent NaN/Infinity acceptance**
+  into financial models (prices, P/E, margins), plus context-free parse failures, an
+  `assert`-based type check stripped under `python -O`, a cold-start **warmup stampede**, and
+  blocking disk I/O on the event loop.
+- **~15 service parse sites** routed through one hardened helper, **removing ~111 net lines**
+  of duplicated decode/validation boilerplate while *adding* guarantees.
+- **+33 regression tests**; two previously-0%-covered TFEX services now tested.
+- **Performance:** measured every candidate; applied only the wins that benchmarks justified
+  (header hoist; warmup stampede 25→1). Notably, **blanket lazy-logging was measured to be a
+  regression here and deliberately NOT applied** (see §3).
+- **Public API:** unchanged — verified by signature/return-type/field smoke test (§6).
+
+---
+
+## 2. Bugs & robustness
+
+The shared fix is a new internal module **`settfex/utils/parsing.py`**
+(`decode_json`, `validate_or_raise`, `validate_list_or_raise`, `ResponseParseError`), routed
+into every service. Untrusted payloads still go through **full** Pydantic validation
+(`model_validate`) — no `model_construct` bypass.
+
+| # | Location (pre-change) | Trigger (malformed input) | Root cause | Fix | Regression test |
+|---|---|---|---|---|---|
+| 1 | All numeric models, via every service decode + `data_fetcher.fetch_json` | API returns `{"pe": NaN}` / `Infinity` / `-Infinity` | `json.loads` accepts non-finite literals by default and Pydantic `float` defaults to `allow_inf_nan=True`, so a non-finite **price/P-E/margin enters the model silently** | `decode_json` parses with `parse_constant=` a hook that **rejects** NaN/Infinity, raising `ResponseParseError` with symbol+endpoint context | `test_parsing.py::TestDecodeJson::test_nonfinite_rejected`; end-to-end `test_shareholder.py::...rejects_nan`, `test_financial.py::...rejects_nan_in_financial_amount`, `test_data_fetcher.py::...rejects_nonfinite` |
+| 2 | Every `Model(**data)` / `[Model(**x) for x in data]` across ~15 services | Any missing key / wrong type / partial record | Bare `pydantic.ValidationError` surfaced with **no symbol/endpoint**, so logs/tracebacks weren't actionable | `validate_or_raise` / `validate_list_or_raise` log `symbol (endpoint)` (+ item index for lists) and re-raise; decode failures wrapped in `ResponseParseError` carrying context | `test_parsing.py` (unit); `test_board_of_director/corporate_action/shareholder ...json_decode_error` now assert the symbol appears |
+| 3 | `tfex/trading_statistics.py:210`, `tfex/list.py:276` | Raw endpoint returns a JSON array (or `null`) instead of an object | `assert isinstance(data, dict)` is **stripped under `python -O`** and yields a context-free `AssertionError` | Explicit `if not isinstance(data, dict): raise ResponseParseError(... symbol/endpoint ...)` | `test_trading_statistics.py::...raw_rejects_non_dict_response`, `test_list.py::...raw_rejects_non_dict_response` |
+| 4 | `session_manager.py::ensure_initialized` | N concurrent fetches on a cold cache (first use) | Method was unguarded: every coroutine passed the `not _initialized` check before any finished warming up → **N duplicate warmup round-trips** (wasteful; can trip Incapsula bot detection) | Per-instance `asyncio.Lock` serializes init; double-checked so the rest reuse the warmed session. **Measured 25 → 1** | `test_session_manager.py::...concurrent_cold_start_warms_once` |
+| 5 | `session_cache.py::get_global_cache` | First cache use (cold) | `SessionCache.__init__` does blocking `mkdir` + opens the diskcache SQLite DB **directly on the event loop** | Construction offloaded via `asyncio.to_thread` | covered by session-manager init path; existing cache tests still green |
+
+Also hardened in passing: the existing list-shape guards (`Expected list response …`) were
+**kept** for defense-in-depth and backward-compatible non-list behavior; `validate_list_or_raise`
+adds the same guard centrally with per-item index context.
+
+---
+
+## 3. Performance & memory
+
+Method: throwaway `timeit`/`tracemalloc` micro-benchmarks (200k iterations, loguru at ERROR so
+`debug()` is disabled — the production default), deleted before finishing. Numbers are µs/call.
+
+| Hot path | Change | Before | After | Verdict |
+|---|---|---|---|---|
+| Cold-start warmup under concurrency | per-instance init lock | **25** round-trips (25 callers) | **1** round-trip | **Real correctness + latency + politeness win** (avoids bot-detection risk) |
+| `fetch()` request headers | hoist 11-entry literal → module constant, copy per call | 0.378 / 0.385 | **0.146** | Real ~2.6× micro-win (≈0.2µs/call; negligible vs network, zero-risk, de-duplicates) |
+| JSON decode NaN guard | `json.loads(parse_constant=…)` on finite payload | 53.7 | ~50–52 | **Free** — within run-to-run noise; the hook fires only on NaN/Inf tokens |
+| Pydantic build | `Model(**d)` → `model_validate(d)` | 2.11 | ~2.09 | Equivalent within noise (~0.3µs); no regression from the switch |
+| Decode/validate de-duplication | ~15 inline `import json` + try/except blocks → 1 helper | — | — | **−111 net LOC**; fewer per-call closures/objects, single maintained path |
+| Debug logging (`text[:500]`, `list(keys())`) | **considered `logger.opt(lazy=True)`; rejected** | eager 0.755 | lazy **1.841** | **Lazy is WORSE here** — `.opt()` overhead exceeds the bounded/cheap interpolation it would defer; kept eager (see note) |
+
+**Lazy-logging note (evidence over assumption).** The brief suggested converting eager debug
+logs to loguru lazy form. Benchmarks show that for this codebase's debug statements — all cheap,
+bounded interpolations (`text[:500]`, `list(data.keys())` over ~15–40 keys) — `logger.opt(lazy=True)`
+*adds* ~1µs/call of its own overhead and is a net regression when the level is disabled. There are
+no debug logs inside hot loops or over unbounded data. So lazy conversion was **measured and
+declined** rather than applied blindly; the logging win instead came from **removing ~15 duplicated
+decode-error log lines** into the single helper. (At request scale all of these are <2µs vs ~50µs
+JSON parse + network I/O, i.e. noise either way — reported honestly, not inflated.)
+
+---
+
+## 4. Test summary
+
+| | Before | After |
+|---|---|---|
+| Passing | 116 | 149 |
+| Runtime | 3.77 s | 2.81 s |
+| Coverage | 49.26% | 61.25% |
+
+New tests (+33): `tests/utils/test_parsing.py` (18), `tests/utils/test_session_manager.py` (3),
+`tests/services/tfex/test_trading_statistics.py` (5), `tests/services/tfex/test_list.py` (4),
+plus end-to-end NaN/decode cases in `test_data_fetcher.py`, `test_shareholder.py`,
+`test_financial.py`. Three existing JSON-decode tests were updated from the over-specific
+`json.JSONDecodeError` to the new context-rich `ResponseParseError` (now also asserting the symbol).
+
+Coverage movers: `utils/parsing.py` 100%; `tfex/list.py` 0% → ~80%;
+`tfex/trading_statistics.py` 0% → covered; `session_manager.py` 14% → 45%.
+
+**Slowest-tests delta:** unchanged in shape — the four `test_data_fetcher` retry/rate-limit tests
+(~0.30 s each) still dominate because they exercise real `retry_delay`/`rate_limit_delay`
+`asyncio.sleep`s. The new concurrency and NaN tests run in ~0.01 s; no new slow tests introduced.
+
+---
+
+## 5. Risks / deferred (intentionally not changed)
+
+- **NaN rejection is coarse.** A single non-finite field fails the whole record (with context),
+  chosen deliberately for financial correctness over silently dropping data. `parse_constant`
+  catches the realistic case (a backend serializing the `NaN`/`Infinity` literal). It does **not**
+  catch numeric *overflow* to `inf` (e.g. `1e999`, which `json` parses to `float('inf')` without a
+  constant token). **Recommendation:** add `model_config = ConfigDict(allow_inf_nan=False)` to the
+  numeric-heavy models as a belt-and-suspenders follow-up; deferred here to avoid touching every
+  model's config in this pass.
+- **Module/class-scope `asyncio.Lock`** (`session_manager._lock`, `session_cache._cache_lock`):
+  reviewed and left as-is. On Python 3.11 (the project floor) `asyncio.Lock()` binds to the running
+  loop lazily on first `await` (since 3.10), so construction at import/class scope is safe for the
+  normal single-event-loop process. Caveat: code that drives the singletons from *multiple* event
+  loops in one process could hit "bound to a different loop"; this pre-exists and the constraint to
+  not introduce new global state / respect the singleton argued against changing it now.
+- **Monetary/price fields use `float`, not `Decimal`.** This is the existing **public** Pydantic
+  contract; switching would break field types, so per the brief it is **documented, not changed**.
+  Worth a future decision if exact decimal precision becomes a requirement.
+- **No comma/locale-formatted numeric coercion was added.** An early hypothesis was that the API
+  might return `"1,234.56"` strings (which would fail `float()`); the test fixtures and observed
+  payloads use **native JSON numbers**, and adding silent comma-stripping coercion risks masking
+  malformed data. Left out by design; flagged as a watch item if such a payload is ever observed.
+
+---
+
+## 6. Public API compatibility
+
+Confirmed unchanged (smoke-tested via `inspect.signature` + attribute checks):
+
+- `fetch_*()` (models), `fetch_*_raw()` (dicts), and `get_*()` convenience functions keep identical
+  signatures and return types (`symbol`, `lang="en"`, `config=None`); the unified
+  `Stock` class and all its accessor methods are present; `en`/`th` + symbol normalization
+  (`Stock("cpall").symbol == "CPALL"`) is intact.
+- Pydantic model class names, field names, and field types are untouched.
+- The new `settfex/utils/parsing.py` is **internal** (not exported from `settfex.utils.__all__`).
+- Exception types: the documented `Raises: ValueError` contract is preserved —
+  `ResponseParseError` subclasses `ValueError`, and original exceptions are chained (`from e`) or
+  re-raised unchanged (`ValidationError`), so existing `except ValueError`/`Exception` handlers and
+  `pytest.raises` continue to work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to settfex
+
+Thanks for your interest in improving **settfex** — an async Python library for
+SET (Stock Exchange of Thailand) and TFEX (Thailand Futures Exchange) data.
+
+## Prerequisites
+
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) for dependency management
+
+## Getting started
+
+```bash
+git clone https://github.com/lumduan/settfex.git
+cd settfex
+uv sync --group dev
+uv run pre-commit install   # run the quality gate automatically on every commit
+```
+
+All Python work goes through `uv` — use `uv add <pkg>` / `uv add --group dev <pkg>`
+to manage dependencies (never `pip`/`poetry`/`conda`), and run code with
+`uv run python ...`. `uv.lock` is committed and must stay in sync.
+
+## Quality gate
+
+Every change must pass the same checks CI runs:
+
+```bash
+uv run ruff check .            # lint
+uv run ruff format --check .   # formatting
+uv run mypy settfex/           # strict type checking
+uv run pytest                  # tests + coverage gate
+```
+
+Or run everything via the pre-commit hooks:
+
+```bash
+uv run pre-commit run --all-files
+```
+
+## Conventions
+
+- **Type safety**: full type hints on all functions; mypy strict mode.
+- **Async-first**: all I/O uses `async`/`await`.
+- **Pydantic models** for all inputs/outputs.
+- **Tests**: add tests for new behavior and **mock all external API calls** — the
+  suite must run offline. Target ≥80% coverage (the CI floor is raised over time).
+- **Service pattern**: new services follow the existing pattern — `fetch_*()`
+  (Pydantic) + `fetch_*_raw()` (dict) + a `get_*()` convenience function, with
+  `en`/`th` and symbol normalization. See `CLAUDE.md` and existing services under
+  `settfex/services/` for reference.
+- **Conventional Commits**: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, etc.
+
+Detailed engineering guidelines live in [`.github/instructions/`](.github/instructions/).
+
+## Pull requests
+
+1. Branch off `main` (e.g. `feature/...`, `fix/...`).
+2. Make your change with tests and docs.
+3. Update `CHANGELOG.md` under `## [Unreleased]` if the change is user-facing.
+4. Ensure the quality gate passes.
+5. Open a PR using the template and link any related issue.
+
+## Reporting security issues
+
+Please do **not** open public issues for vulnerabilities — see
+[`SECURITY.md`](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.x     | :white_check_mark: |
+
+settfex is pre-1.0; security fixes target the latest released `0.x` version.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately via one of:
+
+- GitHub's [private vulnerability reporting](https://github.com/lumduan/settfex/security/advisories/new)
+  (Security → Report a vulnerability), or
+- Email **b@candythink.com**.
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Affected version(s) (or commit hash)
+- Any suggested mitigations
+
+You will receive an acknowledgment within 48 hours and a status update within
+7 days. Once resolved, we will coordinate disclosure timing with you.
+
+## Security tooling
+
+This project runs automated scans (see `.github/workflows/security.yml`):
+
+- **Bandit** — static analysis for common Python security issues.
+- **pip-audit** — checks dependencies for known CVEs.
+
+To run locally:
+
+```bash
+uv run bandit -c pyproject.toml -r settfex
+uv run pip-audit
+```
+
+## Scope note
+
+settfex fetches public market data from SET/TFEX endpoints. It is **not**
+officially affiliated with SET or TFEX. Never commit credentials or API tokens;
+handle any sensitive configuration via environment variables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.2.0"
+version = "0.2.1"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --strict-markers --cov=settfex --cov-report=term-missing"
+# --cov-fail-under is a regression floor set just below current coverage (~49%).
+# Goal is 80%; raise this incrementally as unit-test coverage improves.
+addopts = "-v --strict-markers --cov=settfex --cov-report=term-missing --cov-fail-under=45"
 
 [tool.coverage.run]
 source = ["settfex"]
@@ -87,13 +89,19 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+# E/F/W=pycodestyle+pyflakes, I=isort, N=pep8-naming, UP=pyupgrade,
+# B=flake8-bugbear, SIM=flake8-simplify
+select = ["E", "F", "I", "N", "W", "UP", "B", "SIM"]
 ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
-"*.ipynb" = ["E501", "E402"]
-"tests/**" = ["E501"]
+# Notebooks: long lines/late imports are illustrative; zip strict= and nested-if
+# rewrites add noise to example code.
+"*.ipynb" = ["E501", "E402", "B905", "SIM102"]
+# Tests: blind `pytest.raises(Exception)` is an accepted pattern for asserting
+# that *some* error propagates.
+"tests/**" = ["E501", "B017"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -101,6 +109,12 @@ strict = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", "scripts"]
+
+[tool.uv]
+default-groups = ["dev"]
 
 [project.optional-dependencies]
 examples = [
@@ -112,8 +126,11 @@ examples = [
 
 [dependency-groups]
 dev = [
+    "bandit>=1.7",
     "build>=1.0.0",
     "mypy>=1.18.2",
+    "pip-audit>=2.7",
+    "pre-commit>=3.7",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.1"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/list.py
+++ b/settfex/services/set/list.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_LIST_ENDPOINT
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import validate_or_raise
 
 
 class StockSymbol(BaseModel):
@@ -140,8 +141,8 @@ class StockListService:
             # Fetch JSON data from API - SessionManager handles cookies automatically
             data = await fetcher.fetch_json(url, headers=headers)
 
-            # Parse and validate response using Pydantic
-            response = StockListResponse(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            response = validate_or_raise(StockListResponse, data, context="set stock-list")
 
             logger.info(f"Successfully fetched {response.count} stock symbols from SET API")
 

--- a/settfex/services/set/stock/board_of_director.py
+++ b/settfex/services/set/stock/board_of_director.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_BOARD_OF_DIRECTOR_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_list_or_raise
 
 
 class Director(BaseModel):
@@ -98,14 +99,7 @@ class BoardOfDirectorService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (board-of-director)")
 
             # Validate that data is a list
             if not isinstance(data, list):
@@ -115,8 +109,10 @@ class BoardOfDirectorService:
                 logger.error(error_msg)
                 raise Exception(error_msg)
 
-            # Parse and validate response using Pydantic
-            directors = [Director(**director_data) for director_data in data]
+            # Validate each director using Pydantic (context-rich on failure)
+            directors = validate_list_or_raise(
+                Director, data, context=f"{symbol} (board-of-director)"
+            )
 
             logger.info(f"Successfully fetched {len(directors)} board members for {symbol}")
 
@@ -179,14 +175,7 @@ class BoardOfDirectorService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (board-of-director)")
 
             # Validate that data is a list
             if not isinstance(data, list):

--- a/settfex/services/set/stock/chart_quotation.py
+++ b/settfex/services/set/stock/chart_quotation.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_CHART_QUOTATION_ENDPOINT
 from settfex.services.set.stock.utils import normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 PeriodType = Literal["1D", "5D", "1M", "3M", "6M", "1Y", "3Y", "5Y", "MAX"]
 
@@ -121,16 +122,9 @@ class ChartQuotationService:
                 logger.error(error_msg)
                 raise Exception(error_msg)
 
-            import json
+            data = decode_json(response.text, context=f"{symbol} (chart-quotation)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            result = ChartQuotation(**data)
+            result = validate_or_raise(ChartQuotation, data, context=f"{symbol} (chart-quotation)")
             logger.info(
                 f"Successfully fetched chart quotation for {symbol}: "
                 f"{len(result.quotations)} data points, prior={result.prior}"
@@ -183,14 +177,7 @@ class ChartQuotationService:
                 logger.error(error_msg)
                 raise Exception(error_msg)
 
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (chart-quotation)")
 
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"

--- a/settfex/services/set/stock/corporate_action.py
+++ b/settfex/services/set/stock/corporate_action.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_CORPORATE_ACTION_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_list_or_raise
 
 
 class CorporateAction(BaseModel):
@@ -166,14 +167,7 @@ class CorporateActionService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (corporate-action)")
 
             # Data should be a list
             if not isinstance(data, list):
@@ -181,8 +175,10 @@ class CorporateActionService:
                 logger.error(error_msg)
                 raise ValueError(error_msg)
 
-            # Parse and validate each corporate action using Pydantic
-            corporate_actions = [CorporateAction(**item) for item in data]
+            # Validate each corporate action using Pydantic (context-rich on failure)
+            corporate_actions = validate_list_or_raise(
+                CorporateAction, data, context=f"{symbol} (corporate-action)"
+            )
 
             logger.info(
                 f"Successfully fetched {len(corporate_actions)} corporate action(s) for {symbol}"
@@ -257,14 +253,7 @@ class CorporateActionService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (corporate-action)")
 
             # Data should be a list
             if not isinstance(data, list):

--- a/settfex/services/set/stock/financial/financial.py
+++ b/settfex/services/set/stock/financial/financial.py
@@ -14,6 +14,7 @@ from settfex.services.set.constants import (
 )
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_list_or_raise
 
 
 class Account(BaseModel):
@@ -166,14 +167,7 @@ class FinancialService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} ({account_type})")
 
             # Validate response is a list
             if not isinstance(data, list):
@@ -209,7 +203,9 @@ class FinancialService:
         data = await self._fetch_financial_data(
             symbol=symbol, account_type="balance_sheet", lang=lang
         )
-        balance_sheets = [BalanceSheet(**item) for item in data]
+        balance_sheets = validate_list_or_raise(
+            BalanceSheet, data, context=f"{symbol} (balance-sheet)"
+        )
         logger.info(f"Parsed {len(balance_sheets)} balance sheet statements for {symbol}")
         return balance_sheets
 
@@ -263,7 +259,9 @@ class FinancialService:
         data = await self._fetch_financial_data(
             symbol=symbol, account_type="income_statement", lang=lang
         )
-        income_statements = [IncomeStatement(**item) for item in data]
+        income_statements = validate_list_or_raise(
+            IncomeStatement, data, context=f"{symbol} (income-statement)"
+        )
         logger.info(f"Parsed {len(income_statements)} income statement statements for {symbol}")
         return income_statements
 
@@ -317,7 +315,7 @@ class FinancialService:
             ...     print(f"{stmt.quarter} {stmt.year}: {stmt.status}")
         """
         data = await self._fetch_financial_data(symbol=symbol, account_type="cash_flow", lang=lang)
-        cash_flows = [CashFlow(**item) for item in data]
+        cash_flows = validate_list_or_raise(CashFlow, data, context=f"{symbol} (cash-flow)")
         logger.info(f"Parsed {len(cash_flows)} cash flow statements for {symbol}")
         return cash_flows
 

--- a/settfex/services/set/stock/highlight_data.py
+++ b/settfex/services/set/stock/highlight_data.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_HIGHLIGHT_DATA_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class StockHighlightData(BaseModel):
@@ -153,17 +154,12 @@ class StockHighlightDataService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
+            data = decode_json(response.text, context=f"{symbol} (highlight-data)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            # Parse and validate response using Pydantic
-            highlight_data = StockHighlightData(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            highlight_data = validate_or_raise(
+                StockHighlightData, data, context=f"{symbol} (highlight-data)"
+            )
 
             logger.info(
                 f"Successfully fetched highlight data for {symbol}: "
@@ -228,14 +224,7 @@ class StockHighlightDataService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (highlight-data)")
 
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"

--- a/settfex/services/set/stock/latest_historical_trading.py
+++ b/settfex/services/set/stock/latest_historical_trading.py
@@ -12,6 +12,7 @@ from settfex.services.set.constants import (
 )
 from settfex.services.set.stock.utils import normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class LatestHistoricalTrading(BaseModel):
@@ -109,16 +110,11 @@ class LatestHistoricalTradingService:
                 logger.error(error_msg)
                 raise Exception(error_msg)
 
-            import json
+            data = decode_json(response.text, context=f"{symbol} (latest-historical-trading)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            result = LatestHistoricalTrading(**data)
+            result = validate_or_raise(
+                LatestHistoricalTrading, data, context=f"{symbol} (latest-historical-trading)"
+            )
             logger.info(
                 f"Successfully fetched latest historical trading for {symbol}: "
                 f"close={result.close}, change={result.percent_change}%, "
@@ -163,14 +159,7 @@ class LatestHistoricalTradingService:
                 logger.error(error_msg)
                 raise Exception(error_msg)
 
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (latest-historical-trading)")
 
             logger.debug(f"Raw response keys: {list(data.keys())}")
             return data  # type: ignore[no-any-return]

--- a/settfex/services/set/stock/nvdr_holder.py
+++ b/settfex/services/set/stock/nvdr_holder.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_NVDR_HOLDER_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class NVDRHolder(BaseModel):
@@ -141,17 +142,12 @@ class NVDRHolderService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
+            data = decode_json(response.text, context=f"{symbol} (nvdr-holder)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            # Parse and validate response using Pydantic
-            nvdr_holder_data = NVDRHolderData(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            nvdr_holder_data = validate_or_raise(
+                NVDRHolderData, data, context=f"{symbol} (nvdr-holder)"
+            )
 
             logger.info(
                 f"Successfully fetched NVDR holder data for {symbol}: "
@@ -215,14 +211,7 @@ class NVDRHolderService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (nvdr-holder)")
 
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"

--- a/settfex/services/set/stock/price_performance.py
+++ b/settfex/services/set/stock/price_performance.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_PRICE_PERFORMANCE_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class PricePerformanceMetrics(BaseModel):
@@ -144,14 +145,7 @@ class PricePerformanceService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (price-performance)")
 
             # Validate response is a dict
             if not isinstance(data, dict):
@@ -167,8 +161,10 @@ class PricePerformanceService:
                 logger.error(error_msg)
                 raise ValueError(error_msg)
 
-            # Parse and validate using Pydantic
-            price_performance = PricePerformanceData(**data)
+            # Validate using Pydantic (context-rich on failure)
+            price_performance = validate_or_raise(
+                PricePerformanceData, data, context=f"{symbol} (price-performance)"
+            )
 
             logger.info(
                 f"Successfully fetched price performance for {symbol}: "
@@ -234,14 +230,7 @@ class PricePerformanceService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (price-performance)")
 
             # Validate response is a dict
             if not isinstance(data, dict):

--- a/settfex/services/set/stock/profile_company.py
+++ b/settfex/services/set/stock/profile_company.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_COMPANY_PROFILE_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class Auditor(BaseModel):
@@ -216,17 +217,10 @@ class CompanyProfileService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
+            data = decode_json(response.text, context=f"{symbol} (company-profile)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            # Parse and validate response using Pydantic
-            profile = CompanyProfile(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            profile = validate_or_raise(CompanyProfile, data, context=f"{symbol} (company-profile)")
 
             logger.info(
                 f"Successfully fetched company profile for {symbol}: "

--- a/settfex/services/set/stock/profile_stock.py
+++ b/settfex/services/set/stock/profile_stock.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_PROFILE_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class StockProfile(BaseModel):
@@ -171,17 +172,10 @@ class StockProfileService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
+            data = decode_json(response.text, context=f"{symbol} (stock-profile)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            # Parse and validate response using Pydantic
-            profile = StockProfile(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            profile = validate_or_raise(StockProfile, data, context=f"{symbol} (stock-profile)")
 
             logger.info(
                 f"Successfully fetched profile for {symbol}: "

--- a/settfex/services/set/stock/shareholder.py
+++ b/settfex/services/set/stock/shareholder.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_SHAREHOLDER_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
 
 
 class MajorShareholder(BaseModel):
@@ -153,17 +154,12 @@ class ShareholderService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
+            data = decode_json(response.text, context=f"{symbol} (shareholder)")
 
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
-
-            # Parse and validate response using Pydantic
-            shareholder_data = ShareholderData(**data)
+            # Validate response using Pydantic (context-rich on failure)
+            shareholder_data = validate_or_raise(
+                ShareholderData, data, context=f"{symbol} (shareholder)"
+            )
 
             logger.info(
                 f"Successfully fetched shareholder data for {symbol}: "
@@ -227,14 +223,7 @@ class ShareholderService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (shareholder)")
 
             logger.debug(
                 f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"

--- a/settfex/services/set/stock/trading_stat.py
+++ b/settfex/services/set/stock/trading_stat.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from settfex.services.set.constants import SET_BASE_URL, SET_TRADING_STAT_ENDPOINT
 from settfex.services.set.stock.utils import normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_list_or_raise
 
 
 class TradingStat(BaseModel):
@@ -140,14 +141,7 @@ class TradingStatService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (trading-stat)")
 
             # Validate response is a list
             if not isinstance(data, list):
@@ -155,8 +149,10 @@ class TradingStatService:
                 logger.error(error_msg)
                 raise ValueError(error_msg)
 
-            # Parse and validate each record using Pydantic
-            trading_stats = [TradingStat(**record) for record in data]
+            # Validate each record using Pydantic (context-rich on failure)
+            trading_stats = validate_list_or_raise(
+                TradingStat, data, context=f"{symbol} (trading-stat)"
+            )
 
             logger.info(
                 f"Successfully fetched {len(trading_stats)} trading statistics records for {symbol}"
@@ -219,14 +215,7 @@ class TradingStatService:
                 raise Exception(error_msg)
 
             # Parse JSON
-            import json
-
-            try:
-                data = json.loads(response.text)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Response text: {response.text[:500]}")
-                raise
+            data = decode_json(response.text, context=f"{symbol} (trading-stat)")
 
             # Validate response is a list
             if not isinstance(data, list):

--- a/settfex/services/tfex/list.py
+++ b/settfex/services/tfex/list.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from settfex.services.tfex.constants import TFEX_BASE_URL, TFEX_SERIES_LIST_ENDPOINT
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import ResponseParseError, validate_or_raise
 
 
 class TFEXSeries(BaseModel):
@@ -213,8 +214,8 @@ class TFEXSeriesListService:
             # Fetch JSON data from API - SessionManager handles cookies automatically
             data = await fetcher.fetch_json(url, headers=headers)
 
-            # Parse and validate response using Pydantic
-            response = TFEXSeriesListResponse(**data)
+            # Parse and validate response using Pydantic (context-rich on failure)
+            response = validate_or_raise(TFEXSeriesListResponse, data, context="tfex series-list")
 
             logger.info(
                 f"Successfully fetched {response.count} TFEX series from TFEX API "
@@ -269,11 +270,12 @@ class TFEXSeriesListService:
 
             # Fetch JSON data
             data: Any = await fetcher.fetch_json(url, headers=headers)
-            logger.debug(
-                f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
-            )
-            # Type assertion for return value
-            assert isinstance(data, dict)
+            # Guard the documented dict return type explicitly (asserts are stripped under -O).
+            if not isinstance(data, dict):
+                raise ResponseParseError(
+                    f"Expected a JSON object for tfex series-list, got {type(data).__name__}"
+                )
+            logger.debug(f"Raw response keys: {list(data.keys())}")
             return data
 
 

--- a/settfex/services/tfex/trading_statistics.py
+++ b/settfex/services/tfex/trading_statistics.py
@@ -11,6 +11,7 @@ from settfex.services.tfex.constants import (
     TFEX_TRADING_STATISTICS_ENDPOINT,
 )
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import ResponseParseError, validate_or_raise
 
 
 class TradingStatistics(BaseModel):
@@ -140,8 +141,10 @@ class TradingStatisticsService:
             # Fetch JSON data from API - SessionManager handles cookies automatically
             data = await fetcher.fetch_json(url, headers=headers)
 
-            # Parse and validate response using Pydantic
-            statistics = TradingStatistics(**data)
+            # Parse and validate response using Pydantic (context-rich on failure)
+            statistics = validate_or_raise(
+                TradingStatistics, data, context=f"{normalized_symbol} (tfex trading-statistics)"
+            )
 
             logger.info(
                 f"Successfully fetched trading statistics for {normalized_symbol}: "
@@ -203,11 +206,13 @@ class TradingStatisticsService:
 
             # Fetch JSON data
             data: Any = await fetcher.fetch_json(url, headers=headers)
-            logger.debug(
-                f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
-            )
-            # Type assertion for return value
-            assert isinstance(data, dict)
+            # Guard the documented dict return type explicitly (asserts are stripped under -O).
+            if not isinstance(data, dict):
+                raise ResponseParseError(
+                    f"Expected a JSON object for {normalized_symbol} "
+                    f"(tfex trading-statistics), got {type(data).__name__}"
+                )
+            logger.debug(f"Raw response keys: {list(data.keys())}")
             return data
 
 

--- a/settfex/utils/data_fetcher.py
+++ b/settfex/utils/data_fetcher.py
@@ -8,6 +8,8 @@ from curl_cffi import requests
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from settfex.utils.parsing import decode_json
+
 
 class FetcherConfig(BaseModel):
     """Configuration for the data fetcher."""
@@ -341,7 +343,9 @@ class AsyncDataFetcher:
             Parsed JSON data (dict, list, or primitive)
 
         Raises:
-            Exception: If request fails or response is not valid JSON
+            ResponseParseError: If the response body is not valid JSON or contains a
+                NaN/Infinity literal (rejected to avoid silent financial-data corruption).
+            Exception: If the request itself fails after all retries.
         """
         # Add JSON accept header
         json_headers = {"Accept": "application/json"}
@@ -350,17 +354,11 @@ class AsyncDataFetcher:
 
         response = await self.fetch(url, headers=json_headers)
 
-        try:
-            # Use standard json parsing which handles Unicode correctly
-            import json
-
-            data = json.loads(response.text)
-            logger.debug(f"Parsed JSON response from {url}")
-            return data
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON from {url}: {e}")
-            logger.debug(f"Response text: {response.text[:500]}")
-            raise
+        # Decode via the shared helper: rejects NaN/Infinity (silent-corruption guard)
+        # and raises ResponseParseError (a ValueError) with URL context on bad JSON.
+        data = decode_json(response.text, context=url)
+        logger.debug(f"Parsed JSON response from {url}")
+        return data
 
     async def __aenter__(self) -> "AsyncDataFetcher":
         """Enter async context manager."""

--- a/settfex/utils/data_fetcher.py
+++ b/settfex/utils/data_fetcher.py
@@ -10,6 +10,23 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from settfex.utils.parsing import decode_json
 
+# Static default request headers, built once at import and copied per request. Copying a
+# module constant is cheaper than re-materializing the literal on every fetch() call and
+# keeps per-request mutations isolated (no shared-state race across concurrent fetches).
+_DEFAULT_FETCH_HEADERS: dict[str, str] = {
+    "Accept": "text/html,application/json,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",  # noqa: E501
+    "Accept-Language": "th-TH,th;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "DNT": "1",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Cache-Control": "max-age=0",
+}
+
 
 class FetcherConfig(BaseModel):
     """Configuration for the data fetcher."""
@@ -231,20 +248,8 @@ class AsyncDataFetcher:
             ...     response = await fetcher.fetch("https://api.set.or.th/data")
             ...     print(response.text)  # Properly decoded Thai text
         """
-        # Prepare headers
-        default_headers = {
-            "Accept": "text/html,application/json,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",  # noqa: E501
-            "Accept-Language": "th-TH,th;q=0.9,en-US;q=0.8,en;q=0.7",
-            "Accept-Encoding": "gzip, deflate, br",
-            "DNT": "1",
-            "Connection": "keep-alive",
-            "Upgrade-Insecure-Requests": "1",
-            "Sec-Fetch-Dest": "document",
-            "Sec-Fetch-Mode": "navigate",
-            "Sec-Fetch-Site": "none",
-            "Sec-Fetch-User": "?1",
-            "Cache-Control": "max-age=0",
-        }
+        # Prepare headers (copy module defaults so per-request mutations stay isolated)
+        default_headers = dict(_DEFAULT_FETCH_HEADERS)
 
         # Add custom user agent if provided
         if self.config.user_agent:

--- a/settfex/utils/parsing.py
+++ b/settfex/utils/parsing.py
@@ -1,0 +1,123 @@
+"""Context-rich JSON decoding and Pydantic validation for SET/TFEX API responses.
+
+These helpers centralize the *decode -> validate* step shared by every service so that
+malformed financial data fails **loudly** with the originating symbol/endpoint context
+instead of surfacing as a bare, context-free ``ValidationError`` or ``AssertionError``.
+
+Hardening guarantees:
+
+- ``NaN`` / ``Infinity`` / ``-Infinity`` JSON literals are **rejected**. Python's default
+  ``json.loads`` accepts them, which would let a non-finite price, P/E, or margin flow
+  silently into a model -- the primary silent-corruption vector for a financial library.
+- Decode and structural-validation failures are re-raised with the ``symbol``/``endpoint``
+  context that produced them, so logs and tracebacks are actionable.
+- Untrusted payloads always go through **full** Pydantic validation
+  (``model_validate``); no ``model_construct`` / validation bypass is used.
+"""
+
+import json
+from typing import Any, TypeVar
+
+from loguru import logger
+from pydantic import BaseModel, ValidationError
+
+__all__ = [
+    "ResponseParseError",
+    "decode_json",
+    "validate_list_or_raise",
+    "validate_or_raise",
+]
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+class ResponseParseError(ValueError):
+    """Raised when an API response cannot be decoded or fails structural validation.
+
+    Subclasses :class:`ValueError` to remain compatible with the service layer's
+    documented ``Raises: ValueError`` contract while carrying actionable context
+    (the symbol/endpoint that produced the bad payload).
+    """
+
+
+def _reject_nonfinite(token: str) -> float:
+    """``json.loads`` ``parse_constant`` hook: reject NaN/Infinity rather than accept them."""
+    raise ValueError(f"non-finite JSON constant {token!r} is not valid in financial data")
+
+
+def decode_json(text: str, *, context: str) -> Any:
+    """Decode a JSON response body, rejecting non-finite numbers, with error context.
+
+    Args:
+        text: Raw response body.
+        context: Human-readable origin used in any raised error/log line, e.g.
+            ``"CPALL (balance_sheet)"`` or the request URL.
+
+    Returns:
+        The decoded JSON value (``dict``, ``list``, or primitive).
+
+    Raises:
+        ResponseParseError: If the body is not valid JSON, or contains a
+            ``NaN``/``Infinity``/``-Infinity`` literal.
+    """
+    try:
+        # parse_constant fires only for NaN/Infinity/-Infinity tokens, so it adds no
+        # measurable overhead on well-formed numeric payloads.
+        return json.loads(text, parse_constant=_reject_nonfinite)
+    except ValueError as exc:  # JSONDecodeError and the parse_constant guard are ValueErrors
+        logger.error(f"Failed to decode JSON response for {context}: {exc}")
+        logger.debug(f"Undecodable response body for {context} (first 500 chars): {text[:500]}")
+        raise ResponseParseError(f"Failed to decode JSON response for {context}: {exc}") from exc
+
+
+def validate_or_raise(model_cls: type[ModelT], data: Any, *, context: str) -> ModelT:
+    """Validate ``data`` into ``model_cls``, logging symbol/endpoint context on failure.
+
+    The original :class:`pydantic.ValidationError` is re-raised unchanged so callers that
+    catch it keep working; the actionable context is emitted to the error log.
+
+    Args:
+        model_cls: Target Pydantic model.
+        data: Decoded payload to validate.
+        context: Human-readable origin (symbol/endpoint) for the log line.
+
+    Returns:
+        A validated ``model_cls`` instance.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` does not satisfy the model.
+    """
+    try:
+        return model_cls.model_validate(data)
+    except ValidationError:
+        logger.error(f"Validation failed for {context} ({model_cls.__name__})")
+        raise
+
+
+def validate_list_or_raise(model_cls: type[ModelT], data: Any, *, context: str) -> list[ModelT]:
+    """Validate a JSON array into a list of ``model_cls`` instances, with per-item context.
+
+    Args:
+        model_cls: Target Pydantic model for each element.
+        data: Decoded payload expected to be a ``list``.
+        context: Human-readable origin (symbol/endpoint) for any log line.
+
+    Returns:
+        A list of validated ``model_cls`` instances (empty if ``data`` is an empty list).
+
+    Raises:
+        ResponseParseError: If ``data`` is not a list.
+        pydantic.ValidationError: If any element fails validation (logged with its index).
+    """
+    if not isinstance(data, list):
+        raise ResponseParseError(f"Expected a JSON array for {context}, got {type(data).__name__}")
+    validated: list[ModelT] = []
+    for index, item in enumerate(data):
+        try:
+            validated.append(model_cls.model_validate(item))
+        except ValidationError:
+            logger.error(
+                f"Validation failed for {context} ({model_cls.__name__}) at item index {index}"
+            )
+            raise
+    return validated

--- a/settfex/utils/session_cache.py
+++ b/settfex/utils/session_cache.py
@@ -61,10 +61,7 @@ class SessionCache:
             default_ttl: Default time-to-live for cached items in seconds (default: 1 hour)
             size_limit: Maximum cache size in bytes (default: 100MB)
         """
-        if cache_dir is None:
-            cache_dir = Path.home() / ".settfex" / "cache"
-        else:
-            cache_dir = Path(cache_dir)
+        cache_dir = Path.home() / ".settfex" / "cache" if cache_dir is None else Path(cache_dir)
 
         # Create cache directory if needed
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -160,7 +157,8 @@ class SessionCache:
                 logger.debug(f"Deleted from cache: {key}")
             return bool(result)
         except Exception as e:
-            logger.error(f"Failed to delete from cache: {e}")
+            # "delete from" below is log text, not SQL (bandit B608 false positive).
+            logger.error(f"Failed to delete from cache: {e}")  # nosec B608
             return False
 
     def is_expired(self, key: str, max_age: int | None = None) -> bool:

--- a/settfex/utils/session_cache.py
+++ b/settfex/utils/session_cache.py
@@ -259,5 +259,9 @@ async def get_global_cache(
 
     async with _cache_lock:
         if _global_cache is None:
-            _global_cache = SessionCache(cache_dir=cache_dir, default_ttl=default_ttl)
+            # SessionCache.__init__ does blocking disk I/O (mkdir + opening the diskcache
+            # SQLite DB); run it off the event loop so cold cache init never blocks the loop.
+            _global_cache = await asyncio.to_thread(
+                SessionCache, cache_dir=cache_dir, default_ttl=default_ttl
+            )
         return _global_cache

--- a/settfex/utils/session_manager.py
+++ b/settfex/utils/session_manager.py
@@ -91,6 +91,8 @@ class SessionManager:
         self.warmup_site = warmup_site.lower()
         self._session: requests.Session[Any] | None = None
         self._initialized = False
+        # Serializes ensure_initialized() so a concurrent cold-start stampede warms once.
+        self._init_lock = asyncio.Lock()
         self._last_warmup_time = 0.0
         self._warmup_interval = cache_ttl
         self._cache: SessionCache | None = None
@@ -264,9 +266,18 @@ class SessionManager:
         1. **Fast Path**: Try to load from cache (if enabled)
         2. **Slow Path**: Warm up by visiting SET homepage, then cache
 
+        Initialization is serialized with a per-instance lock so a concurrent
+        cold-start stampede warms up at most once instead of firing N duplicate
+        warmup round-trips (which also risks tripping bot detection).
+
         Args:
             force_warmup: Force a new warm-up even if cache available
         """
+        async with self._init_lock:
+            await self._initialize_locked(force_warmup=force_warmup)
+
+    async def _initialize_locked(self, force_warmup: bool = False) -> None:
+        """Run the cache-load / warm-up sequence once. Caller must hold ``self._init_lock``."""
         # Fast path: Try cache first (unless forcing warmup)
         if not force_warmup and not self._initialized and await self._try_load_from_cache():
             logger.debug("Using cached session (fast path)")

--- a/settfex/utils/session_manager.py
+++ b/settfex/utils/session_manager.py
@@ -268,10 +268,9 @@ class SessionManager:
             force_warmup: Force a new warm-up even if cache available
         """
         # Fast path: Try cache first (unless forcing warmup)
-        if not force_warmup and not self._initialized:
-            if await self._try_load_from_cache():
-                logger.debug("Using cached session (fast path)")
-                return
+        if not force_warmup and not self._initialized and await self._try_load_from_cache():
+            logger.debug("Using cached session (fast path)")
+            return
 
         # Check if warmup needed
         now = time.time()
@@ -479,9 +478,6 @@ async def get_session_for_url(url: str, browser: str = "chrome120") -> SessionMa
         >>> # Automatically uses TFEX warmup
     """
     # Auto-detect warmup site based on URL
-    if "tfex.co.th" in url.lower():
-        warmup_site = "tfex"
-    else:
-        warmup_site = "set"
+    warmup_site = "tfex" if "tfex.co.th" in url.lower() else "set"
 
     return await get_shared_session(browser=browser, warmup_site=warmup_site)

--- a/tests/services/set/stock/financial/test_financial.py
+++ b/tests/services/set/stock/financial/test_financial.py
@@ -17,6 +17,7 @@ from settfex.services.set.stock.financial import (
     get_income_statement,
 )
 from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
 
 
 @pytest.fixture
@@ -557,6 +558,31 @@ class TestFinancialService:
 
             with pytest.raises(ValueError, match="Expected list response"):
                 await service.fetch_balance_sheet(symbol="CPALL", lang="en")
+
+    @pytest.mark.asyncio
+    async def test_rejects_nan_in_financial_amount(self):
+        """A NaN account amount must be rejected loudly, not flow into the model."""
+        with patch(
+            "settfex.services.set.stock.financial.financial.AsyncDataFetcher"
+        ) as mock_fetcher:
+            mock_instance = AsyncMock()
+            mock_fetcher.return_value.__aenter__.return_value = mock_instance
+            mock_fetcher.get_set_api_headers.return_value = {}
+
+            # json.dumps emits the bare `NaN` literal, which default json.loads would accept.
+            text = json.dumps([{"symbol": "CPALL", "amount": float("nan")}])
+            mock_response = FetchResponse(
+                status_code=200,
+                content=text.encode(),
+                text=text,
+                headers={},
+                url="https://www.set.or.th/api/set/factsheet/CPALL/financialstatement",
+                elapsed=0.1,
+            )
+            mock_instance.fetch = AsyncMock(return_value=mock_response)
+
+            with pytest.raises(ResponseParseError, match="CPALL"):
+                await FinancialService().fetch_balance_sheet(symbol="CPALL", lang="en")
 
 
 class TestConvenienceFunctions:

--- a/tests/services/set/test_board_of_director.py
+++ b/tests/services/set/test_board_of_director.py
@@ -11,6 +11,7 @@ from settfex.services.set.stock.board_of_director import (
     get_board_of_directors,
 )
 from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
 MOCK_BOARD_DATA = [
@@ -211,7 +212,7 @@ class TestBoardOfDirectorService:
 
         service = BoardOfDirectorService()
 
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(ResponseParseError, match="MINT"):
             await service.fetch_board_of_directors("MINT", lang="en")
 
     async def test_fetch_board_of_directors_non_list_response(self, mock_fetcher):

--- a/tests/services/set/test_corporate_action.py
+++ b/tests/services/set/test_corporate_action.py
@@ -12,6 +12,7 @@ from settfex.services.set.stock.corporate_action import (
     get_corporate_actions,
 )
 from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
 MOCK_CORPORATE_ACTION_DATA = [
@@ -206,7 +207,7 @@ class TestCorporateActionService:
 
         service = CorporateActionService()
 
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(ResponseParseError, match="AOT"):
             await service.fetch_corporate_actions("AOT", lang="en")
 
     async def test_fetch_corporate_actions_non_list_response(self, mock_fetcher):

--- a/tests/services/set/test_shareholder.py
+++ b/tests/services/set/test_shareholder.py
@@ -219,6 +219,24 @@ class TestShareholderService:
         with pytest.raises(ResponseParseError, match="MINT"):
             await service.fetch_shareholder_data("MINT", lang="en")
 
+    @pytest.mark.asyncio
+    async def test_fetch_shareholder_data_rejects_nan(self, mock_fetcher):
+        """A NaN numeric field must be rejected, not silently accepted into the model."""
+        text = json.dumps({**MOCK_SHAREHOLDER_DATA, "percentScriptless": float("nan")})
+        mock_response = FetchResponse(
+            status_code=200,
+            content=text.encode("utf-8"),
+            text=text,
+            headers={},
+            url="https://www.set.or.th/api/set/stock/MINT/shareholder?lang=en",
+            elapsed=0.5,
+        )
+        mock_fetcher.fetch.return_value = mock_response
+
+        service = ShareholderService()
+        with pytest.raises(ResponseParseError, match="MINT"):
+            await service.fetch_shareholder_data("MINT", lang="en")
+
     async def test_fetch_shareholder_data_raw_success(self, mock_fetcher):
         """Test successful fetch of raw shareholder data."""
         mock_response = FetchResponse(

--- a/tests/services/set/test_shareholder.py
+++ b/tests/services/set/test_shareholder.py
@@ -14,6 +14,7 @@ from settfex.services.set.stock.shareholder import (
     get_shareholder_data,
 )
 from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
 MOCK_SHAREHOLDER_DATA = {
@@ -215,7 +216,7 @@ class TestShareholderService:
 
         service = ShareholderService()
 
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(ResponseParseError, match="MINT"):
             await service.fetch_shareholder_data("MINT", lang="en")
 
     async def test_fetch_shareholder_data_raw_success(self, mock_fetcher):

--- a/tests/services/tfex/test_list.py
+++ b/tests/services/tfex/test_list.py
@@ -1,0 +1,73 @@
+"""Tests for TFEX series list service (validation + response-shape hardening)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from settfex.services.tfex.list import (
+    TFEXSeriesListResponse,
+    TFEXSeriesListService,
+    get_series_list,
+)
+from settfex.utils.parsing import ResponseParseError
+
+MOCK_SERIES = {
+    "symbol": "S50Z25",
+    "instrumentId": "SET50_FC",
+    "instrumentName": "SET50 Futures",
+    "marketListId": "TXI_F",
+    "marketListName": "Equity Index Futures",
+    "firstTradingDate": "2024-01-02T00:00:00+07:00",
+    "lastTradingDate": "2025-12-29T16:30:00+07:00",
+    "contractMonth": "12/2025",
+    "optionsType": "",
+    "strikePrice": None,
+    "hasNightSession": True,
+    "underlying": "SET50",
+    "active": True,
+}
+MOCK_SERIES_LIST = {"series": [MOCK_SERIES]}
+
+
+@pytest.fixture
+def mock_fetcher():
+    with patch("settfex.services.tfex.list.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        yield fetcher_instance
+
+
+class TestSeriesListService:
+    @pytest.mark.asyncio
+    async def test_fetch_success(self, mock_fetcher) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_SERIES_LIST
+        result = await TFEXSeriesListService().fetch_series_list()
+        assert isinstance(result, TFEXSeriesListResponse)
+        assert result.count == 1
+        assert result.series[0].symbol == "S50Z25"
+        assert result.get_futures()[0].symbol == "S50Z25"
+
+    @pytest.mark.asyncio
+    async def test_fetch_invalid_series_item_raises(self, mock_fetcher) -> None:
+        bad_series = {k: v for k, v in MOCK_SERIES.items() if k != "symbol"}
+        mock_fetcher.fetch_json.return_value = {"series": [bad_series]}
+        with pytest.raises(ValidationError):
+            await TFEXSeriesListService().fetch_series_list()
+
+    @pytest.mark.asyncio
+    async def test_raw_rejects_non_dict_response(self, mock_fetcher) -> None:
+        # Replaces the old `assert isinstance(data, dict)` (stripped under -O).
+        mock_fetcher.fetch_json.return_value = ["unexpected", "list"]
+        with pytest.raises(ResponseParseError, match="series-list"):
+            await TFEXSeriesListService().fetch_series_list_raw()
+
+
+class TestConvenienceFunction:
+    @pytest.mark.asyncio
+    async def test_get_series_list(self, mock_fetcher) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_SERIES_LIST
+        result = await get_series_list()
+        assert isinstance(result, TFEXSeriesListResponse)
+        assert result.count == 1

--- a/tests/services/tfex/test_trading_statistics.py
+++ b/tests/services/tfex/test_trading_statistics.py
@@ -1,0 +1,79 @@
+"""Tests for TFEX trading statistics service (validation + response-shape hardening)."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from settfex.services.tfex.trading_statistics import (
+    TradingStatistics,
+    TradingStatisticsService,
+    get_trading_statistics,
+)
+from settfex.utils.parsing import ResponseParseError
+
+MOCK_TRADING_STATS = {
+    "symbol": "S50Z25",
+    "marketTime": "2025-10-05T17:00:00+07:00",
+    "lastTradingDate": "2025-12-29T16:30:00+07:00",
+    "dayToMaturity": 85,
+    "settlementPattern": "#,##0.0",
+    "isOptions": False,
+    "theoreticalPrice": 850.5,
+    "priorSettlementPrice": 848.0,
+    "settlementPrice": 851.2,
+    "im": 9600.0,
+    "mm": 6720.0,
+    "hasTheoreticalPrice": True,
+}
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Mock AsyncDataFetcher with an async-context-manager returning fetch_json results."""
+    with patch("settfex.services.tfex.trading_statistics.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        yield fetcher_instance
+
+
+class TestTradingStatisticsService:
+    @pytest.mark.asyncio
+    async def test_fetch_success(self, mock_fetcher) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_TRADING_STATS
+        result = await TradingStatisticsService().fetch_trading_statistics("s50z25")
+        assert isinstance(result, TradingStatistics)
+        assert result.symbol == "S50Z25"
+        assert result.day_to_maturity == 85
+        assert result.settlement_price == 851.2
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_required_field_raises(self, mock_fetcher) -> None:
+        bad = {k: v for k, v in MOCK_TRADING_STATS.items() if k != "dayToMaturity"}
+        mock_fetcher.fetch_json.return_value = bad
+        with pytest.raises(ValidationError):
+            await TradingStatisticsService().fetch_trading_statistics("S50Z25")
+
+    @pytest.mark.asyncio
+    async def test_raw_rejects_non_dict_response(self, mock_fetcher) -> None:
+        # Replaces the old `assert isinstance(data, dict)` (stripped under -O).
+        mock_fetcher.fetch_json.return_value = ["unexpected", "list"]
+        with pytest.raises(ResponseParseError, match="S50Z25"):
+            await TradingStatisticsService().fetch_trading_statistics_raw("S50Z25")
+
+    @pytest.mark.asyncio
+    async def test_raw_success_returns_dict(self, mock_fetcher) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_TRADING_STATS
+        raw = await TradingStatisticsService().fetch_trading_statistics_raw("S50Z25")
+        assert raw["symbol"] == "S50Z25"
+
+
+class TestConvenienceFunction:
+    @pytest.mark.asyncio
+    async def test_get_trading_statistics(self, mock_fetcher) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_TRADING_STATS
+        result = await get_trading_statistics("S50Z25")
+        assert isinstance(result, TradingStatistics)
+        assert result.symbol == "S50Z25"

--- a/tests/utils/test_data_fetcher.py
+++ b/tests/utils/test_data_fetcher.py
@@ -12,6 +12,7 @@ from settfex.utils.data_fetcher import (
     FetcherConfig,
     FetchResponse,
 )
+from settfex.utils.parsing import ResponseParseError
 
 
 class TestFetcherConfig:
@@ -310,7 +311,7 @@ class TestAsyncDataFetcher:
 
     @pytest.mark.asyncio
     async def test_fetch_json_invalid(self) -> None:
-        """Test JSON fetch with invalid JSON."""
+        """Test JSON fetch with invalid JSON raises a context-rich error."""
         fetcher = AsyncDataFetcher()
 
         mock_response = Mock()
@@ -321,7 +322,24 @@ class TestAsyncDataFetcher:
 
         with (
             patch.object(fetcher, "_make_request", return_value=mock_response),
-            pytest.raises(json.JSONDecodeError),
+            pytest.raises(ResponseParseError, match="example.com"),
+        ):
+            await fetcher.fetch_json("https://example.com/api")
+
+    @pytest.mark.asyncio
+    async def test_fetch_json_rejects_nonfinite(self) -> None:
+        """NaN/Infinity in a numeric response must be rejected, not silently accepted."""
+        fetcher = AsyncDataFetcher()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"pe": NaN}'
+        mock_response.headers = {}
+        mock_response.url = "https://example.com/api"
+
+        with (
+            patch.object(fetcher, "_make_request", return_value=mock_response),
+            pytest.raises(ResponseParseError),
         ):
             await fetcher.fetch_json("https://example.com/api")
 

--- a/tests/utils/test_data_fetcher.py
+++ b/tests/utils/test_data_fetcher.py
@@ -260,11 +260,13 @@ class TestAsyncDataFetcher:
         config = FetcherConfig(max_retries=2, retry_delay=0.1)
         fetcher = AsyncDataFetcher(config=config)
 
-        with patch.object(
-            fetcher, "_make_request", side_effect=ConnectionError("Connection failed")
+        with (
+            patch.object(
+                fetcher, "_make_request", side_effect=ConnectionError("Connection failed")
+            ),
+            pytest.raises(Exception, match="Failed to fetch"),
         ):
-            with pytest.raises(Exception, match="Failed to fetch"):
-                await fetcher.fetch("https://example.com")
+            await fetcher.fetch("https://example.com")
 
     @pytest.mark.asyncio
     async def test_fetch_unicode_decode_fallback(self) -> None:
@@ -317,9 +319,11 @@ class TestAsyncDataFetcher:
         mock_response.headers = {}
         mock_response.url = "https://example.com/api"
 
-        with patch.object(fetcher, "_make_request", return_value=mock_response):
-            with pytest.raises(json.JSONDecodeError):
-                await fetcher.fetch_json("https://example.com/api")
+        with (
+            patch.object(fetcher, "_make_request", return_value=mock_response),
+            pytest.raises(json.JSONDecodeError),
+        ):
+            await fetcher.fetch_json("https://example.com/api")
 
     @pytest.mark.asyncio
     async def test_context_manager(self) -> None:

--- a/tests/utils/test_parsing.py
+++ b/tests/utils/test_parsing.py
@@ -1,0 +1,113 @@
+"""Tests for the shared JSON-decode + Pydantic-validation helpers."""
+
+import json
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from settfex.utils.parsing import (
+    ResponseParseError,
+    decode_json,
+    validate_list_or_raise,
+    validate_or_raise,
+)
+
+
+class _Rec(BaseModel):
+    """Representative model: a required string + a required int."""
+
+    symbol: str
+    level: int
+
+
+class TestDecodeJson:
+    """Tests for decode_json."""
+
+    def test_valid_object(self) -> None:
+        assert decode_json('{"a": 1, "b": "x"}', context="ctx") == {"a": 1, "b": "x"}
+
+    def test_valid_array(self) -> None:
+        assert decode_json("[1, 2, 3]", context="ctx") == [1, 2, 3]
+
+    def test_finite_floats_preserved(self) -> None:
+        # Guard must not disturb ordinary finite numbers.
+        assert decode_json('{"pe": 12.5, "neg": -3.0}', context="ctx") == {"pe": 12.5, "neg": -3.0}
+
+    def test_malformed_json_raises_with_context(self) -> None:
+        with pytest.raises(ResponseParseError, match="CPALL"):
+            decode_json("{not valid json", context="CPALL (highlight)")
+
+    def test_malformed_json_is_valueerror(self) -> None:
+        # Stays compatible with the documented `Raises: ValueError` contract.
+        with pytest.raises(ValueError):
+            decode_json("<<<", context="ctx")
+
+    @pytest.mark.parametrize("payload", ['{"pe": NaN}', '{"x": Infinity}', '{"x": -Infinity}'])
+    def test_nonfinite_rejected(self, payload: str) -> None:
+        # The silent-corruption vector: default json.loads would accept these.
+        with pytest.raises(ResponseParseError):
+            decode_json(payload, context="PTT (trading-stat)")
+
+    def test_nan_accepted_by_default_json_but_rejected_here(self) -> None:
+        # Document the exact behavior we are hardening against.
+        assert json.loads('{"pe": NaN}')["pe"] != json.loads('{"pe": NaN}')["pe"]  # nan != nan
+        with pytest.raises(ResponseParseError):
+            decode_json('{"pe": NaN}', context="ctx")
+
+    def test_original_exception_chained(self) -> None:
+        try:
+            decode_json("{bad", context="ctx")
+        except ResponseParseError as exc:
+            assert exc.__cause__ is not None
+        else:  # pragma: no cover - guard
+            pytest.fail("expected ResponseParseError")
+
+
+class TestValidateOrRaise:
+    """Tests for validate_or_raise."""
+
+    def test_valid(self) -> None:
+        rec = validate_or_raise(_Rec, {"symbol": "CPALL", "level": -1}, context="ctx")
+        assert isinstance(rec, _Rec)
+        assert rec.symbol == "CPALL"
+        assert rec.level == -1
+
+    def test_missing_field_raises_validationerror(self) -> None:
+        # Original ValidationError type is preserved (not wrapped).
+        with pytest.raises(ValidationError):
+            validate_or_raise(_Rec, {"symbol": "CPALL"}, context="CPALL (profile)")
+
+    def test_wrong_type_raises_validationerror(self) -> None:
+        with pytest.raises(ValidationError):
+            validate_or_raise(_Rec, {"symbol": "CPALL", "level": "not-an-int"}, context="ctx")
+
+
+class TestValidateListOrRaise:
+    """Tests for validate_list_or_raise."""
+
+    def test_valid_list(self) -> None:
+        out = validate_list_or_raise(
+            _Rec,
+            [{"symbol": "A", "level": 1}, {"symbol": "B", "level": 2}],
+            context="ctx",
+        )
+        assert [r.symbol for r in out] == ["A", "B"]
+
+    def test_empty_list(self) -> None:
+        assert validate_list_or_raise(_Rec, [], context="ctx") == []
+
+    def test_non_list_raises_response_parse_error(self) -> None:
+        with pytest.raises(ResponseParseError, match="got dict"):
+            validate_list_or_raise(_Rec, {"symbol": "A", "level": 1}, context="CPALL (financial)")
+
+    def test_none_raises_response_parse_error(self) -> None:
+        with pytest.raises(ResponseParseError, match="got NoneType"):
+            validate_list_or_raise(_Rec, None, context="ctx")
+
+    def test_bad_item_raises_validationerror(self) -> None:
+        with pytest.raises(ValidationError):
+            validate_list_or_raise(
+                _Rec,
+                [{"symbol": "A", "level": 1}, {"symbol": "B"}],  # second item missing level
+                context="ctx",
+            )

--- a/tests/utils/test_session_manager.py
+++ b/tests/utils/test_session_manager.py
@@ -1,0 +1,78 @@
+"""Tests for SessionManager, focused on warmup concurrency correctness."""
+
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+from settfex.utils.session_manager import SessionManager
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Ensure a clean singleton registry around every test."""
+    SessionManager.reset_instance()
+    yield
+    SessionManager.reset_instance()
+
+
+def _make_fake_session(counter: dict[str, int]) -> Mock:
+    """A fake curl_cffi session whose .get() records warmup calls."""
+
+    def fake_get(*_args: object, **_kwargs: object) -> Mock:
+        counter["warmups"] += 1
+        resp = Mock()
+        resp.status_code = 200
+        resp.cookies = {"incap_ses": "abc"}
+        return resp
+
+    session = Mock()
+    session.get = fake_get
+    return session
+
+
+class TestEnsureInitializedConcurrency:
+    """ensure_initialized() must warm up at most once, even under a cold-start stampede."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_start_warms_once(self) -> None:
+        counter = {"warmups": 0}
+        manager = SessionManager(browser="chrome120", enable_cache=False, warmup_site="set")
+
+        with patch(
+            "settfex.utils.session_manager.requests.Session",
+            return_value=_make_fake_session(counter),
+        ):
+            # Fire many concurrent initializations at a cold instance.
+            await asyncio.gather(*[manager.ensure_initialized() for _ in range(25)])
+
+        # Without the per-instance lock this would be 25 warmup round-trips.
+        assert counter["warmups"] == 1
+        assert manager._initialized is True
+
+    @pytest.mark.asyncio
+    async def test_single_call_warms_once(self) -> None:
+        counter = {"warmups": 0}
+        manager = SessionManager(browser="chrome120", enable_cache=False, warmup_site="set")
+
+        with patch(
+            "settfex.utils.session_manager.requests.Session",
+            return_value=_make_fake_session(counter),
+        ):
+            await manager.ensure_initialized()
+            # A second sequential call is already initialized and must not re-warm.
+            await manager.ensure_initialized()
+
+        assert counter["warmups"] == 1
+
+
+class TestGetInstance:
+    """Singleton behavior."""
+
+    @pytest.mark.asyncio
+    async def test_get_instance_is_singleton_per_site(self) -> None:
+        a = await SessionManager.get_instance(warmup_site="set")
+        b = await SessionManager.get_instance(warmup_site="set")
+        c = await SessionManager.get_instance(warmup_site="tfex")
+        assert a is b
+        assert a is not c

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -171,6 +186,15 @@ css = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -182,6 +206,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -261,6 +303,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -581,6 +632,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/54/40d741cb605229cddcf9ec689b0fd401e39e2e70c2fe9cc728923b983b8e/cyclonedx_python_lib-11.10.0.tar.gz", hash = "sha256:d03d6ea271e26feaf123b8b1b34468a305f33a338c5763f56e397a8408f9b290", size = 1429036, upload-time = "2026-06-11T10:36:27.633Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/21/01c9b957ec3a778de86e010c1b54ea433ebf2fc50b810a3ca0ce8000782f/cyclonedx_python_lib-11.10.0-py3-none-any.whl", hash = "sha256:ffb9510b8d00a0896cfbe0a78b97c545d28f7d2a54e9d9dd5e5dc6e91ca9b375", size = 527798, upload-time = "2026-06-11T10:36:25.985Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.17"
 source = { registry = "https://pypi.org/simple" }
@@ -633,6 +700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.23"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +733,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -764,6 +849,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1327,6 +1421,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1529,6 +1635,69 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/23/6139781ca7aadf656fa8e384fa84693ffb13f299e6931b6526427fe5e297/msgpack-1.2.0.tar.gz", hash = "sha256:8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41", size = 183017, upload-time = "2026-06-11T04:16:10.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/23/35de3182a647fcc84ab304160169edfa5dac7bbd8913fbed0a505ddc0d55/msgpack-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ec35cd3f127f50806aa10c3f74bf27b749f13ddf1d2217964ada8f38042d1653", size = 82368, upload-time = "2026-06-11T04:14:53.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/79/8d9bfdab933b1c7a02aba9518605a81aa30d38e9efd4915ec1a6b2d55778/msgpack-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:317eb298297121bfad9173d748124a04a36af27b6ac39c2bbc1db1ce57608dcf", size = 82095, upload-time = "2026-06-11T04:14:54.784Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e1/b5accbc1354edbcee107fb35ec247db0547e91c3f90e4fabdeaee500a5a6/msgpack-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50fe6434de89073273026dd032a62e8b63f8857a261d7a2df5b07c9e72f3a8f7", size = 413818, upload-time = "2026-06-11T04:14:56.1Z" },
+    { url = "https://files.pythonhosted.org/packages/82/31/1141cbbf7118d525834f20dcd614d1b85f1f2ffd33bc2a5ce710e6dd2516/msgpack-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106c6d333ff3d4eda075b7d4b9695d1752c5bcc635e40d0dbaf4e276c9ed80e1", size = 423790, upload-time = "2026-06-11T04:14:57.509Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e7/9582f2bd4d7546139fe297740de49bd1f7ef2d195eb0bb9fa5efeee88158/msgpack-1.2.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:67055a611e871cb1bd0acb732f2e9f64ca8155ca0bba1d0a5bb362e7209e5541", size = 387521, upload-time = "2026-06-11T04:14:59.08Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/12/5aadd08ff068bfd42e2ac0be6a20aa9819965df8622e87c1f0c6119c1c22/msgpack-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ceec7f8e633d5a4b4a32b0416bef90ee3cd1017ea36247f705e523072e576119", size = 406324, upload-time = "2026-06-11T04:15:00.686Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ee/3041564f0cc4c2fe7c53315aec0edf3d84807fc9b9ea714e6ac07dbdb1db/msgpack-1.2.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7ec5851160a3c2c0f77d68ddec620318cd8e7d88d94f9c058190e8ce0dfa1d31", size = 384242, upload-time = "2026-06-11T04:15:02.121Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d4/de94b3dbc266229f4c2ce84485eeb221220351b7f1931029e875995bb232/msgpack-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dd7140f7b09dbe1984a0dff3189375d840247e3e4cf4ac45c5a499b3b599c8d2", size = 420392, upload-time = "2026-06-11T04:15:03.692Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5d/c4a3fde69a292eecb202caaa87c29df7728644a65118614b821bcaddc05a/msgpack-1.2.0-cp311-cp311-win32.whl", hash = "sha256:cbfd54018d386da0951c7a2be13de0f58559d251313e613b2155e52ed1cbd8f1", size = 63976, upload-time = "2026-06-11T04:15:05.355Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/df47f83115375e7717c985265a30f3ba096c5331518e28fb647b55c46d31/msgpack-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:653373c4614c31463ba486a67776e4bb396af289921bd5353e209534b71467fa", size = 70273, upload-time = "2026-06-11T04:15:06.529Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d1/ffd02e54c064aa73b6b53aa08171f92dc406727077ff275d7050c6aca28a/msgpack-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:7a260aea1e5e7d6c7f1d9284c7360d29021627b61dc4dd7df144b81210810537", size = 64783, upload-time = "2026-06-11T04:15:07.677Z" },
+    { url = "https://files.pythonhosted.org/packages/44/07/dcb13f37e670257c8d0e944f116c799c34ac6968ecb48c83619f7e91d8b5/msgpack-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e2d6047ccd11a12c96a69f2bfe026471abef67334c3d0494a93e5310e45140a2", size = 82888, upload-time = "2026-06-11T04:15:08.992Z" },
+    { url = "https://files.pythonhosted.org/packages/84/5f/6643b2a6a36ca4bc73c7674831be1d4d581cceecc7eb019dba1915951739/msgpack-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0347e3ac0dfee99086d3b68fe959da3f5f657c0019ddbaeaaa259a85f8603422", size = 82223, upload-time = "2026-06-11T04:15:10.182Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c8/9e1668b9897358e5ab39a18142e38be3cf15807e643757782da9f4a53cb3/msgpack-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25552ff1f2ff3dc8333e27eabb94f702da5929ed0e07969688194a3e9f12e151", size = 409700, upload-time = "2026-06-11T04:15:11.441Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ed/b7728573156d70b6b094233b0f38d876fc37340826cf852347ec2c7ca8ca/msgpack-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0d94420d9d52c56568159a69200af7e45eadb29615fa9d09fada140de1c38c7", size = 420090, upload-time = "2026-06-11T04:15:12.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f7/5ea755a89868c04f9cdf6d96d2d99da4b3d198af10e76a6082dd0fceccc0/msgpack-1.2.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d16e1f2db4a9eebc07b7cc91898d71e710f2eed8358711a605fee802caff8923", size = 378538, upload-time = "2026-06-11T04:15:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2d/126e59332a439c94ffd682c38ca0102b23480e2784b3dac48d8959b0bbac/msgpack-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9cb2e700e85f1e27bbb5c9de6cc1c9a4bc5ac64d5404bdcbcb37a0dc7a947a3", size = 399468, upload-time = "2026-06-11T04:15:16.133Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f9/7abcef683a0ad2e5ab3a4940344aad9f20cdf1f42057ecb0982cf55085d6/msgpack-1.2.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:717d0b166dd176a5f786aeafff081f6439680acf5af193eb63e6266c12b04d3d", size = 374212, upload-time = "2026-06-11T04:15:17.536Z" },
+    { url = "https://files.pythonhosted.org/packages/27/23/2d62cf0e971678e96f8a3cfa9bd77fb719ddb98da73790f63c53fd847ad8/msgpack-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e87c7a21654d18111eb1a89bd5c42baba42e61887365d9e89585e112b4203f9e", size = 414361, upload-time = "2026-06-11T04:15:18.99Z" },
+    { url = "https://files.pythonhosted.org/packages/32/fb/f5c153f614037aaf802d291a4653ba1bb731f56feacba886f7c21c109e56/msgpack-1.2.0-cp312-cp312-win32.whl", hash = "sha256:967e0c891f5f23ab65762f2e5dc95922759c79f1ef99ef4c7e1fdd863e0d0af9", size = 64389, upload-time = "2026-06-11T04:15:20.237Z" },
+    { url = "https://files.pythonhosted.org/packages/90/af/8aafce6e5544b43b84cb670aca40c8bea7eb5ae8f42bfcbdc7098739987a/msgpack-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:6c23e33cee28dcffa112ae205661da4636fd7b06bd9ad1559a890623b92d060b", size = 71185, upload-time = "2026-06-11T04:15:21.51Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/08/9cc94be1fc1fe3d1379d439326259aef0344274f64623a8138feb54dff68/msgpack-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:6eeb771571f63f68045433b1a35c0256b946f31ed62f006997e40b8ad8b735af", size = 64481, upload-time = "2026-06-11T04:15:22.639Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/26/2902c6946ab5c8fe1e46e40842dfc32b8824464ad5cd4725364fd83f7a58/msgpack-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3a1d30df1f302f2b7a7404afbac2ab76d510036c34cf34dffb01f704a7288e45", size = 82621, upload-time = "2026-06-11T04:15:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/59/7e6b812629d2f919e586041bffc130e1af32079f71bb20699eed54ed6d92/msgpack-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:581e317112260d8ca488d490cad9290a5682276f309c41c7de237a85ed8799c8", size = 81866, upload-time = "2026-06-11T04:15:25.032Z" },
+    { url = "https://files.pythonhosted.org/packages/31/13/8c291196e60aafdbae38f482205d79432297749ac5d412fe638154fb6f1d/msgpack-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6827d12eacc16873eba62408a1b7bbe8ecfb4a8f7ed78a631ae9bae6ad43cf2", size = 405618, upload-time = "2026-06-11T04:15:26.235Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/63/68f5d0ea81e167db5f59ddb94dc6f837667062113feff1c73fabf8907061/msgpack-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a186027e4279efa4c8bf06ce30605498d7d0d3af0fba0b9799dce85a3fd4a93c", size = 416468, upload-time = "2026-06-11T04:15:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/73/58/567dddf5c5a2790f673bcd7d80c83466d68e5ee9a9674ebca3db8101c0c8/msgpack-1.2.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a96142c14a11cf1a509e8b9aaf72858a3b742b7613e095ce646913e88ce7bd99", size = 374464, upload-time = "2026-06-11T04:15:29.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/30/0c2342fc9092e4498045f5f60bca6ccbe4f4d87789778c2300e6fd6efe82/msgpack-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50c220579b68a6085b95408b2eaa486b259520f55d8e363ddc9b5d7ba5a6ac6d", size = 395879, upload-time = "2026-06-11T04:15:30.973Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/9565b29b58ce3c33e177b490478b7aaeb8f726ecaaeda26d815893c1db5a/msgpack-1.2.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4dcb9d12ab100ecacdfaaf37a3d72fe8392eacc7054afc1916b12d1b747c8446", size = 371749, upload-time = "2026-06-11T04:15:32.418Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/da/7bade19d60b73e2ef73fb76aaf4504c112a70cb760951b7202a0c64b5111/msgpack-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a804727188ab0ebb237fadb303b743f04925a69d8c3247292d1e33e679767c15", size = 410416, upload-time = "2026-06-11T04:15:34.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/14/c0c619571c02432208a5977a8dbdd3fc65fe1369f8226ca4b6d08cca87d8/msgpack-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1a1ac6ae1fe23298f79380e7b144c8a454e5d05616b0096584f353ba2d750114", size = 64357, upload-time = "2026-06-11T04:15:35.535Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/de06718460909aa965737fec4cfe8a15dedc6544a8c55feeb6956fa0d6e3/msgpack-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:1c3c80949d79578f9dc85fd9fb91edfe6694e8a729cd5744634d59d8455fdde3", size = 71057, upload-time = "2026-06-11T04:15:36.83Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/52/73446b0141c94a856e22b787c56709c0815fc34f185326577e15b26d8cfe/msgpack-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:fcf8f76fa587c2395fd0057c7232dbf071241f9ad280b235adb7ab585289989e", size = 64490, upload-time = "2026-06-11T04:15:38.001Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/a7e3cdafa8c0cf36c81e2fa848ec4d30cf089459af45b390ad03f9ce6f49/msgpack-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f854fa1a8b55d75d82ef9a905d9cdbeffdf7897c088f6020bd221867da5e56a5", size = 83032, upload-time = "2026-06-11T04:15:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/aa/53ddfba0e347cc4b484e95f629c5850b9e800ca8390c91ffc604407acf87/msgpack-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e90df581f80f53b372d5d9d9349078d729851a3a0d0bd74f53ccb598d01e45b8", size = 82600, upload-time = "2026-06-11T04:15:40.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fd/e64c2c776e6dbad0af3c963fe0c0dd1ee1ba09efac478b233ab1db41868f/msgpack-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b276ed50d8ac75d1f134a433ae79af8557d0fa25ee5b4737da533dfc2ce382e8", size = 404342, upload-time = "2026-06-11T04:15:41.87Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/60/fb9a08e6ccba882dfd370a5837fe3a07572938fdfe954f0f17fdf3e574b9/msgpack-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:544d972459c92aa32e63b800d07c2d9cf2734a3be29cee3a0b478a622850e9f5", size = 412351, upload-time = "2026-06-11T04:15:43.253Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4d/df5c575c274fedc68ac9c6c61d045161899efad2afcdc25138efa7edde69/msgpack-1.2.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a070147cc2cf6b8a891734e0f5c8fe8f70ed8739ab30ba140b058005a6e86af4", size = 373331, upload-time = "2026-06-11T04:15:44.754Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a4/c8b98f8191e985ed2003d87664ce3c95cca41db5d0cf6bf4f54327d32ec8/msgpack-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7685e23b0f51745a751629c31713fbefdef8896b31b2bb38299dfa4ae6c0740c", size = 394654, upload-time = "2026-06-11T04:15:46.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/49/76f036720a602ea24428cfec5ec806f2487c0380b1bff0a2aa3094e15f87/msgpack-1.2.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b9204daeee8d91a7ae5acf2d2a8e3983be9a3025f38aa21bfaefbd7eea84a7dc", size = 370624, upload-time = "2026-06-11T04:15:48.062Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/38/40af3d29232833705a43b0fce0d07425cc280a7b92ab2b29932425b40df4/msgpack-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bfc057248609742ebbabf6bcd27fea4fd99c4980584e613c168c9b002318298f", size = 408038, upload-time = "2026-06-11T04:15:49.669Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b2/f140ca450524dff4d8d0eb81eb9ed75f8f3e0b1f12e49c5b01617cfa0b1c/msgpack-1.2.0-cp314-cp314-win32.whl", hash = "sha256:a3faa7edf2388337ae849239878e92f0298b4dab4488e4f1834062f9d0c410c9", size = 65823, upload-time = "2026-06-11T04:15:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/13/6517bf966b841c7675ded30701a068ce141f3e698a27aaa35c702d8e078b/msgpack-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:1a3effc392a57744e4681e55d05f97d5ee7b598747d718340a9b4b8a970c40e1", size = 72484, upload-time = "2026-06-11T04:15:52.289Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/1d948420fdaa24de4efdb8012a6a5bebe09c82ee002b8c2ca745e9917f1f/msgpack-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:56a318f7df6bec7b40928d6b0519961f20a510d8baabf6baa393a70444588f0a", size = 66657, upload-time = "2026-06-11T04:15:53.583Z" },
+    { url = "https://files.pythonhosted.org/packages/39/16/1674faa1b7bddc19e79b465fd8e88e2cf4e3f7cae90723740701e8541068/msgpack-1.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:afa4a65ab2097795e771a74a3a81ea49534aaeba874eaf426a3332268e045ae6", size = 86093, upload-time = "2026-06-11T04:15:54.98Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/24/f241bcfdd9e96b2246289357c5a5e5a496189fd41c5844bee802c116aac7/msgpack-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:409550770632bb28daa70a11d0ed5763f7db38f40b06f7db9f11dd2794d01102", size = 86372, upload-time = "2026-06-11T04:15:56.381Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c9/57f8ab98a1b21808c27b6dd6029053e0a796ffbb9b371e460dbe997011a9/msgpack-1.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf47e3cd11ce044965a9736a322afdd390b31ed602d1c1b10211d1a841f1d587", size = 428207, upload-time = "2026-06-11T04:15:57.739Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/4fd4aa739f131ded751ca7167c8ee87d2aab32506ebbeea893b60b51d343/msgpack-1.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:204bc9f5d6e59c1718c0a4a84fc8ff71b5b4562faac257c1a68bca611ecf9b72", size = 426082, upload-time = "2026-06-11T04:15:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/db88e9a08fcd6513decaad06cbd5c168142bc3e662fb2f1aca3a563b7aa1/msgpack-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:610154307b27267266368bc1d1c7bb8aeb71da7be9356d403cb2442d9e6399f5", size = 378355, upload-time = "2026-06-11T04:16:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/eee4dd703d7a600cf46159d621c070b0b9468cf3dbade4ea8272bf5232a4/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6799f157bb63e79f11e2e590cfdb28423fc18dd60c270c3914b5b4586ae36f7e", size = 410848, upload-time = "2026-06-11T04:16:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0a/195e2c549fd4631eb7f157d016ff15a10c4c1cf82b6d0a9b1edaef5174b1/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:72bd844902cf0a5ac3af2ef742f253cd0b1e5bcd184f49b4fb9a6a1f7bf305e8", size = 376152, upload-time = "2026-06-11T04:16:04.041Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9b/bdd143fa79baec411dc658f5686fed680a18b36fcea5fccb6af1b8c7d832/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3c0bd450f78d0d81722c80da6cdbf674a856967870a9db2f6c4debc4d8b3c67c", size = 417061, upload-time = "2026-06-11T04:16:05.63Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/011ffcd8b919f55196ec53f12ae162e21c879d95afba226894314ff62c07/msgpack-1.2.0-cp314-cp314t-win32.whl", hash = "sha256:378caf74c4c718dfc17590ce68a6d710ed398ff6fcf08237de23b77755730b55", size = 70782, upload-time = "2026-06-11T04:16:07.105Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a8/9b8791ca96b1be6b9f659c718271e2cb7f99f73f58aad2dd0b30f750f6c0/msgpack-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:553b42598165c4dd3235994fd6e4b0dfb1ce5f3fd33d94ba9609442643015f38", size = 77899, upload-time = "2026-06-11T04:16:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/04/3fa2dffb87bf598696b86bde7cd642d0a7590520c3fa24cd19611dfebeb7/msgpack-1.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2825bb1da548d214ab8a810906b7dd69a10f3838b615a2cc46e5172d3cb44f6e", size = 71004, upload-time = "2026-06-11T04:16:09.556Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.18.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1674,6 +1843,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "notebook"
 version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +1967,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
+
+[[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
 ]
 
 [[package]]
@@ -1978,6 +2165,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1993,6 +2235,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -2048,6 +2306,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -2219,6 +2489,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -2681,8 +2964,11 @@ examples = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "build" },
     { name = "mypy" },
+    { name = "pip-audit" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2705,8 +2991,11 @@ provides-extras = ["examples"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.7" },
     { name = "build", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.18.2" },
+    { name = "pip-audit", specifier = ">=2.7" },
+    { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -2742,6 +3031,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2762,6 +3060,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]
@@ -2827,6 +3134,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -2932,6 +3248,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Robustness, financial-correctness, and concurrency hardening of the SET/TFEX async client, plus the **0.2.1** patch release. **No public API changes** — function signatures, return types, Pydantic model fields, and `en`/`th` + symbol normalization are all preserved (verified by smoke test). Full evidence and benchmarks in `COMPREHENSIVE_AUDIT.md`.

> ⚠️ `0.2.1` is **already published to PyPI** (via `scripts/publish.sh`). Do **not** push a `v0.2.1` tag — `release.yml` would attempt a duplicate upload. This PR also folds in the pending "adopt template tooling" commit.

## Highlights

### Fixed
- **Silent financial-data corruption** — `NaN`/`Infinity` from the APIs were silently accepted into numeric fields (prices, P/E, margins); now rejected at decode time with symbol+endpoint context.
- Parse/validation failures now raise **with symbol+endpoint context** (and per-item index for lists) instead of a bare `ValidationError`/`JSONDecodeError`.
- Replaced unsafe `assert isinstance(data, dict)` in the TFEX raw paths (stripped under `python -O`) with explicit contextful errors.
- **Warm-up stampede** — concurrent cold starts fired one warm-up round-trip per caller (could trip bot detection); now serialized to run once (measured 25 → 1).
- Offloaded blocking cache init off the asyncio event loop.

### Changed / Perf
- Centralized JSON decode + Pydantic validation into one internal helper across ~15 services (−111 LOC; no API change).
- Hoisted static request headers to a module constant.

### Tests
- 116 → **149** passing; coverage 49% → **61%**; two previously-0%-covered TFEX services now tested.

## Release
- `chore(release): 0.2.1` — bumps `pyproject.toml`, syncs `settfex/__init__.py` `__version__` (was stale at `0.1.0`), adds CHANGELOG `[0.2.1]`.

## Verification
- `uv run ruff check .` / `ruff format --check .` / `mypy settfex/` — clean
- `uv run pytest` — 149 passed, coverage 61.25% (gate 45%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)