### PR TITLE
fix(release): repair GitHub Release step (changelog notes via body_path)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,6 @@ jobs:
           path: dist/
 
       - name: Extract changelog section
-        id: changelog
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
           python3 - "$VERSION" <<'PYEOF'
@@ -152,19 +151,14 @@ jobs:
           match = re.search(pattern, content, re.DOTALL)
           notes = match.group(1).strip() if match else f"Release v{version}"
           with open("release_notes.txt", "w") as f:
-              f.write(notes)
+              f.write(notes + "\n")
           PYEOF
-          {
-            echo 'notes<<CHANGELOG_EOF'
-            cat release_notes.txt
-            echo 'CHANGELOG_EOF'
-          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: "settfex v${{ needs.validate.outputs.version }}"
-          body: ${{ steps.changelog.outputs.notes }}
+          body_path: release_notes.txt
           prerelease: ${{ needs.validate.outputs.is_prerelease }}
           files: dist/*
           make_latest: ${{ needs.validate.outputs.is_prerelease == 'false' }}


### PR DESCRIPTION
## Why

With the PyPI Trusted Publisher now configured, the `v0.2.1` release workflow got all the way to the **GitHub Release** job, which then failed at *Extract changelog section*:

```
##[error]Invalid value. Matching delimiter not found 'CHANGELOG_EOF'
```

Root cause: the step wrote the notes with `.strip()` (no trailing newline), then piped the file into the `$GITHUB_OUTPUT` `notes<<CHANGELOG_EOF` heredoc. Without a trailing newline, `cat` glued the closing `CHANGELOG_EOF` onto the last content line, so the runner never found a standalone delimiter. (This job had never run before — the v0.2.0 release died earlier at the CI gate — so the bug only surfaced now.)

## Fix
- Drop the fragile `$GITHUB_OUTPUT` multiline dance; pass the notes file straight to `softprops/action-gh-release` via **`body_path: release_notes.txt`**.
- Write a trailing newline for good measure.

Verified locally: the extraction yields the `## [x.y.z]` body and the file ends in a newline.

## Status of v0.2.1
- ✅ PyPI publish via OIDC works (Trusted Publisher configured).
- ✅ `v0.2.1` GitHub Release was **backfilled manually** (the one-time casualty of this bug) and is marked Latest.
- This PR makes the **next** release (0.2.2+) go green end-to-end with no manual step.

> Note: the Node-20 action deprecation warnings (`actions/checkout`, `setup-uv`, `download-artifact`) are separate and already covered by the open Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)