### PR TITLE
feat(tfex): underlying-price service + release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-17
+
+### Added
+
+- **TFEX underlying-price service** (`get_underlying_price`, `TFEXUnderlyingPriceService`,
+  `UnderlyingPrice`): fetches the underlying instrument price for a TFEX series via
+  `GET /api/set/tfex/series/{symbol}/underlying-price`. For SET50 index options/futures the underlying
+  is the **SET50 index spot** — exposes last/prior/high/low, change, total volume/value, and P/E + P/BV.
+  Mirrors the existing TFEX service pattern (SessionManager/Incapsula bypass, NaN-rejecting hardened
+  parsing, `get_*` convenience function + `*_raw` variant); 100% module test coverage. Adds the
+  `verify_underlying_price.py` script and the `examples/tfex/03_underlying_price.ipynb` notebook.
+
 ## [0.2.1] - 2026-06-17
 
 Robustness and concurrency hardening release. No public API changes — function

--- a/examples/tfex/03_underlying_price.ipynb
+++ b/examples/tfex/03_underlying_price.ipynb
@@ -1,0 +1,564 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TFEX Underlying Price Service\n",
+    "\n",
+    "Learn how to fetch the **underlying instrument price** for a TFEX series — for SET50 index options and futures, the underlying instrument is the **SET50 index** itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "### What is the Underlying Price?\n",
+    "\n",
+    "Every TFEX series (a future or an option) is derived from an **underlying instrument**. For the SET50 product family (e.g. `S50M26`, `S50M26C880`, `S50M26P880`), that underlying is the **SET50 index**.\n",
+    "\n",
+    "The Underlying Price Service resolves a *series* symbol and returns the live snapshot of its *underlying* instrument:\n",
+    "\n",
+    "- **Underlying symbol & type** — e.g. `SET50`, with `underlying_type` `'I'` (index)\n",
+    "- **Prices** — `prior` (prior close), `last`, intraday `high` / `low`\n",
+    "- **Change** — absolute `change` and `percent_change` from prior close, plus a `sign` indicator\n",
+    "- **Activity** — `total_volume` and `total_value` of the underlying\n",
+    "- **Market state** — `market_status` (e.g. `Open` / `Closed`) and `market_time`\n",
+    "- **Valuation** — `pe` (price-to-earnings) and `pbv` (price-to-book-value) of the underlying\n",
+    "- **As-of** — `statistics_as_of` timestamp the figures are reported as of\n",
+    "\n",
+    "### Why It Matters\n",
+    "\n",
+    "The underlying spot price is the anchor for derivatives pricing and analysis:\n",
+    "\n",
+    "- **Basis / forward analysis** — compare the futures price against the underlying spot to measure the basis (forward premium or discount).\n",
+    "- **Moneyness** — for options, the spot level tells you how far in/out-of-the-money a strike is.\n",
+    "- **Index context** — the SET50 level, its day change, P/E and P/BV provide the market backdrop for any SET50 derivative.\n",
+    "\n",
+    "### What You Get Back\n",
+    "\n",
+    "`get_underlying_price(series_symbol)` returns an `UnderlyingPrice` model. Note that the returned `symbol` is the **underlying** (e.g. `SET50`), **not** the series you queried. Financial fields are `float | None` and reject `NaN`/`Infinity` at decode time to avoid silent financial-data corruption."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "### Installation\n",
+    "\n",
+    "You need to install the `settfex` package:\n",
+    "\n",
+    "```bash\n",
+    "pip install settfex\n",
+    "```\n",
+    "\n",
+    "For the pandas/CSV export cells at the end, also install the optional examples extras:\n",
+    "\n",
+    "```bash\n",
+    "pip install \"settfex[examples]\"\n",
+    "```\n",
+    "\n",
+    "### Required Imports\n",
+    "\n",
+    "This notebook uses:\n",
+    "- `settfex` - The main library for TFEX data\n",
+    "- `pandas` - For tabular analysis and CSV export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install settfex (uncomment to run)\n",
+    "# !pip install settfex\n",
+    "# !pip install \"settfex[examples]\"  # for the pandas/CSV export cells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required libraries\n",
+    "\n",
+    "# For data analysis\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Import TFEX services\n",
+    "from settfex.services.tfex import (\n",
+    "    TFEXUnderlyingPriceService,\n",
+    "    get_series_list,\n",
+    "    get_underlying_price,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Usage\n",
+    "\n",
+    "Let's resolve a single SET50 option series to its underlying instrument and inspect the snapshot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch the underlying price for S50M26C880 (a SET50 index option)\n",
+    "# Note: Jupyter notebooks handle async automatically in most modern versions\n",
+    "price = await get_underlying_price(\"S50M26C880\")\n",
+    "\n",
+    "# The returned symbol is the UNDERLYING instrument, not the series queried\n",
+    "print(\"Queried series:      S50M26C880\")\n",
+    "print(f\"Underlying symbol:   {price.symbol}\")\n",
+    "print(f\"Underlying type:     {price.underlying_type}  # 'I' = index\")\n",
+    "print(f\"Market status:       {price.market_status}\")\n",
+    "print(f\"Market time:         {price.market_time}\")\n",
+    "print(f\"Statistics as of:    {price.statistics_as_of}\")\n",
+    "\n",
+    "# Expected output (values vary with the market):\n",
+    "# Queried series:      S50M26C880\n",
+    "# Underlying symbol:   SET50\n",
+    "# Underlying type:     I  # 'I' = index\n",
+    "# Market status:       Open\n",
+    "# Market time:         2026-06-17 16:30:00+07:00\n",
+    "# Statistics as of:    2026-06-17 16:30:00+07:00"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Understanding the Price Fields\n",
+    "\n",
+    "The underlying snapshot carries the prior close, the intraday range, the last price, and the day's change. All financial fields are `float | None`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the underlying's pricing snapshot\n",
+    "print(f\"UNDERLYING PRICE - {price.symbol}\\n\")\n",
+    "print(f\"Prior Close: {price.prior}\")\n",
+    "print(f\"Last:        {price.last}\")\n",
+    "print(f\"High:        {price.high}\")\n",
+    "print(f\"Low:         {price.low}\")\n",
+    "print(f\"Change:      {price.change} ({price.percent_change}%)  sign='{price.sign}'\")\n",
+    "\n",
+    "# Cross-check: the reported change should equal last - prior (within rounding)\n",
+    "if price.last is not None and price.prior is not None:\n",
+    "    implied = price.last - price.prior\n",
+    "    print(f\"\\nImplied change (last - prior): {implied:+.2f}\")\n",
+    "\n",
+    "# Expected output (values vary with the market):\n",
+    "# UNDERLYING PRICE - SET50\n",
+    "#\n",
+    "# Prior Close: 925.50\n",
+    "# Last:        930.20\n",
+    "# High:        931.80\n",
+    "# Low:         923.10\n",
+    "# Change:      4.70 (0.51%)  sign='+'\n",
+    "#\n",
+    "# Implied change (last - prior): +4.70"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Activity & Valuation\n",
+    "\n",
+    "Beyond price, the underlying snapshot includes the day's traded volume/value and the index-level valuation ratios (P/E and P/BV)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the underlying's activity and valuation ratios\n",
+    "print(f\"ACTIVITY & VALUATION - {price.symbol}\\n\")\n",
+    "print(f\"Total Volume: {price.total_volume}\")\n",
+    "print(f\"Total Value:  {price.total_value}\")\n",
+    "print(f\"P/E:          {price.pe}\")\n",
+    "print(f\"P/BV:         {price.pbv}\")\n",
+    "\n",
+    "# Expected output (values vary with the market):\n",
+    "# ACTIVITY & VALUATION - SET50\n",
+    "#\n",
+    "# Total Volume: 412345678.0\n",
+    "# Total Value:  18234567890.0\n",
+    "# P/E:          16.42\n",
+    "# P/BV:         1.58"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the Service Class\n",
+    "\n",
+    "The convenience function `get_underlying_price()` wraps `TFEXUnderlyingPriceService`. Use the class directly when you want to reuse one service (and its warmed session) across many calls, or when you need the raw, unvalidated dictionary via `get_underlying_price_raw()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reuse one service instance across calls\n",
+    "service = TFEXUnderlyingPriceService()\n",
+    "\n",
+    "# Validated model\n",
+    "price = await service.get_underlying_price(\"S50M26C880\")\n",
+    "print(f\"Validated model: underlying={price.symbol}, last={price.last}\")\n",
+    "\n",
+    "# Raw dict (no Pydantic validation) - handy for debugging the API shape\n",
+    "raw = await service.get_underlying_price_raw(\"S50M26C880\")\n",
+    "print(f\"\\nRaw response keys: {list(raw.keys())}\")\n",
+    "print(\n",
+    "    f\"Raw symbol={raw.get('symbol')}, last={raw.get('last')}, underlyingType={raw.get('underlyingType')}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Case: Spot vs Futures Basis\n",
+    "\n",
+    "The **basis** is the gap between a futures price and the price of its underlying spot:\n",
+    "\n",
+    "```\n",
+    "basis = futures_price - underlying_spot\n",
+    "```\n",
+    "\n",
+    "A positive basis (futures above spot) is a forward **premium**; a negative basis is a forward **discount**. The basis converges toward zero as the contract approaches expiry.\n",
+    "\n",
+    "Because the underlying-price endpoint resolves *any* SET50 series to the same SET50 spot, you can read the spot once and compare it against the same-expiry future. The cell below reads the spot from the underlying endpoint and the future's settlement from the Trading Statistics service, then reports the basis.\n",
+    "\n",
+    "> Note: combine this with `get_trading_statistics()` (see `02_trading_statistics.ipynb`) for the future's settlement price."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Spot vs same-expiry futures forward (basis)\n",
+    "from settfex.services.tfex import get_trading_statistics\n",
+    "\n",
+    "future_symbol = \"S50M26\"  # June 2026 SET50 future\n",
+    "\n",
+    "# Underlying spot (SET50 index) resolved from the future series\n",
+    "spot = await get_underlying_price(future_symbol)\n",
+    "\n",
+    "# Same-expiry future's settlement price\n",
+    "fut_stats = await get_trading_statistics(future_symbol)\n",
+    "\n",
+    "if spot.last is not None:\n",
+    "    basis = fut_stats.settlement_price - spot.last\n",
+    "    pct = (basis / spot.last) * 100\n",
+    "    direction = \"premium\" if basis > 0 else \"discount\" if basis < 0 else \"flat\"\n",
+    "\n",
+    "    print(f\"BASIS ANALYSIS - {future_symbol}\\n\")\n",
+    "    print(f\"Underlying ({spot.symbol}) spot last: {spot.last:.2f}\")\n",
+    "    print(f\"Future settlement price:            {fut_stats.settlement_price:.2f}\")\n",
+    "    print(f\"Days to maturity:                   {fut_stats.day_to_maturity}\")\n",
+    "    print(f\"\\nBasis (future - spot): {basis:+.2f} ({pct:+.2f}%) -> forward {direction}\")\n",
+    "else:\n",
+    "    print(\"Underlying last price unavailable (market may be closed) - basis not computable.\")\n",
+    "\n",
+    "# Expected output (values vary with the market):\n",
+    "# BASIS ANALYSIS - S50M26\n",
+    "#\n",
+    "# Underlying (SET50) spot last: 930.20\n",
+    "# Future settlement price:            931.50\n",
+    "# Days to maturity:                   12\n",
+    "#\n",
+    "# Basis (future - spot): +1.30 (+0.14%) -> forward premium"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple Series Share One Underlying\n",
+    "\n",
+    "A future and its options on the same product all resolve to the **same** underlying (the SET50 index). The cell below confirms that and builds a small comparison table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resolve several SET50 series and collect their (shared) underlying snapshot\n",
+    "series_symbols = [\"S50M26\", \"S50M26C880\", \"S50M26P880\"]\n",
+    "\n",
+    "rows = []\n",
+    "for sym in series_symbols:\n",
+    "    try:\n",
+    "        p = await get_underlying_price(sym)\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"series\": sym,\n",
+    "                \"underlying\": p.symbol,\n",
+    "                \"type\": p.underlying_type,\n",
+    "                \"last\": p.last,\n",
+    "                \"change\": p.change,\n",
+    "                \"percent_change\": p.percent_change,\n",
+    "                \"pe\": p.pe,\n",
+    "                \"pbv\": p.pbv,\n",
+    "                \"market_status\": p.market_status,\n",
+    "            }\n",
+    "        )\n",
+    "    except Exception as e:\n",
+    "        print(f\"{sym}: Error - {e}\")\n",
+    "\n",
+    "df = pd.DataFrame(rows)\n",
+    "\n",
+    "print(\"UNDERLYING SNAPSHOT BY SERIES:\\n\")\n",
+    "print(df.to_string(index=False))\n",
+    "\n",
+    "# All SET50 series should resolve to one underlying instrument\n",
+    "underlyings = set(df[\"underlying\"]) if not df.empty else set()\n",
+    "if len(underlyings) == 1:\n",
+    "    print(f\"\\n✓ All {len(df)} series share the same underlying: {next(iter(underlyings))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Resolve Underlyings for Active Series\n",
+    "\n",
+    "Pull a few active futures from the series-list service and resolve each to its underlying."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resolve the underlying for active futures discovered via the series list\n",
+    "series_list = await get_series_list()\n",
+    "active_futures = [s for s in series_list.get_futures() if s.active][:5]\n",
+    "\n",
+    "print(f\"Resolving underlyings for {len(active_futures)} active futures...\\n\")\n",
+    "print(f\"{'Series':<14} {'Underlying':<12} {'Last':<12} {'%Chg':<10} {'Status':<10}\")\n",
+    "print(\"-\" * 60)\n",
+    "\n",
+    "for series in active_futures:\n",
+    "    try:\n",
+    "        p = await get_underlying_price(series.symbol)\n",
+    "        last = \"n/a\" if p.last is None else f\"{p.last:.2f}\"\n",
+    "        pct = \"n/a\" if p.percent_change is None else f\"{p.percent_change:+.2f}%\"\n",
+    "        print(f\"{series.symbol:<14} {p.symbol:<12} {last:<12} {pct:<10} {p.market_status:<10}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"{series.symbol:<14} Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to CSV\n",
+    "\n",
+    "Snapshot the underlying for a set of series and write it to a timestamped CSV for downstream analysis (consistent with the other TFEX/SET notebooks)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "\n",
+    "async def export_underlying_snapshot(series_symbols: list[str]) -> tuple[pd.DataFrame, str]:\n",
+    "    \"\"\"Resolve underlyings for a list of series and export to a timestamped CSV.\"\"\"\n",
+    "    records = []\n",
+    "    for sym in series_symbols:\n",
+    "        try:\n",
+    "            p = await get_underlying_price(sym)\n",
+    "            records.append(\n",
+    "                {\n",
+    "                    \"series\": sym,\n",
+    "                    \"underlying\": p.symbol,\n",
+    "                    \"underlying_type\": p.underlying_type,\n",
+    "                    \"prior\": p.prior,\n",
+    "                    \"last\": p.last,\n",
+    "                    \"high\": p.high,\n",
+    "                    \"low\": p.low,\n",
+    "                    \"change\": p.change,\n",
+    "                    \"percent_change\": p.percent_change,\n",
+    "                    \"total_volume\": p.total_volume,\n",
+    "                    \"total_value\": p.total_value,\n",
+    "                    \"pe\": p.pe,\n",
+    "                    \"pbv\": p.pbv,\n",
+    "                    \"market_status\": p.market_status,\n",
+    "                    \"market_time\": p.market_time,\n",
+    "                    \"statistics_as_of\": p.statistics_as_of,\n",
+    "                }\n",
+    "            )\n",
+    "        except Exception as e:\n",
+    "            print(f\"{sym}: Error - {e}\")\n",
+    "\n",
+    "    frame = pd.DataFrame(records)\n",
+    "\n",
+    "    timestamp = datetime.now().strftime(\"%Y%m%d_%H%M%S\")\n",
+    "    filename = f\"tfex_underlying_price_{timestamp}.csv\"\n",
+    "    frame.to_csv(filename, index=False)\n",
+    "    return frame, filename\n",
+    "\n",
+    "\n",
+    "snapshot_df, csv_file = await export_underlying_snapshot([\"S50M26\", \"S50M26C880\", \"S50M26P880\"])\n",
+    "\n",
+    "print(f\"Underlying snapshot ({len(snapshot_df)} rows):\\n\")\n",
+    "print(snapshot_df.to_string(index=False))\n",
+    "print(f\"\\nExported to: {csv_file}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error Handling\n",
+    "\n",
+    "Wrap calls defensively: the request can fail, the symbol may not resolve, and a malformed payload (e.g. a `NaN` price literal) is rejected at decode time rather than silently corrupting your data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Safe fetch with error handling\n",
+    "async def safe_underlying_price(symbol: str):\n",
+    "    \"\"\"Fetch the underlying price with comprehensive error handling.\"\"\"\n",
+    "    try:\n",
+    "        p = await get_underlying_price(symbol)\n",
+    "        print(f\"✓ {symbol} -> underlying {p.symbol} (last={p.last})\")\n",
+    "        return p\n",
+    "    except ConnectionError as e:\n",
+    "        print(f\"✗ Network error for {symbol}: {e}\")\n",
+    "        print(\"  Check your internet connection and try again.\")\n",
+    "        return None\n",
+    "    except Exception as e:\n",
+    "        print(f\"✗ Could not resolve underlying for {symbol}: {e}\")\n",
+    "        print(\"  Verify the series exists using the series list service.\")\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "print(\"Valid series:\")\n",
+    "await safe_underlying_price(\"S50M26C880\")\n",
+    "\n",
+    "print(\"\\nPotentially invalid series:\")\n",
+    "await safe_underlying_price(\"INVALID123\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify the series exists before resolving its underlying\n",
+    "async def verify_and_resolve(symbol: str):\n",
+    "    \"\"\"Confirm the symbol is in the TFEX series list, then resolve its underlying.\"\"\"\n",
+    "    print(f\"Verifying {symbol}...\")\n",
+    "    series_list = await get_series_list()\n",
+    "    series = series_list.get_symbol(symbol)\n",
+    "\n",
+    "    if not series:\n",
+    "        print(f\"✗ Symbol {symbol} not found in the TFEX series list\")\n",
+    "        prefix = symbol[:3]\n",
+    "        similar = [s.symbol for s in series_list.series if s.symbol.startswith(prefix)][:5]\n",
+    "        if similar:\n",
+    "            print(f\"  Symbols starting with '{prefix}': {', '.join(similar)}\")\n",
+    "        return None\n",
+    "\n",
+    "    if not series.active:\n",
+    "        print(f\"⚠️  {symbol} exists but is NOT ACTIVE (expiry {series.last_trading_date.date()})\")\n",
+    "\n",
+    "    print(\"✓ Symbol verified. Resolving underlying...\")\n",
+    "    return await get_underlying_price(symbol)\n",
+    "\n",
+    "\n",
+    "price = await verify_and_resolve(\"S50M26C880\")\n",
+    "if price:\n",
+    "    print(f\"\\n✓ Underlying: {price.symbol}, last={price.last}, change={price.change}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "You now know how to resolve any TFEX series to its underlying instrument and read the underlying's live price, change, valuation ratios, and market status.\n",
+    "\n",
+    "### Related Notebooks\n",
+    "- **01_series_list.ipynb** - Discover and filter available TFEX contracts\n",
+    "- **02_trading_statistics.ipynb** - Settlement prices, margin (IM/MM), and days to maturity (pair with this for basis analysis)\n",
+    "\n",
+    "### Documentation\n",
+    "- [TFEX Series List Docs](../../docs/settfex/services/tfex/list.md) - Contract discovery and filtering\n",
+    "- [TFEX Trading Statistics Docs](../../docs/settfex/services/tfex/trading_statistics.md) - Settlement, margin, theoretical price\n",
+    "\n",
+    "### Key Takeaways\n",
+    "\n",
+    "1. The endpoint resolves a **series** symbol to its **underlying** instrument (SET50 index for SET50 derivatives).\n",
+    "2. The returned `symbol` is the **underlying** (e.g. `SET50`), not the series you queried.\n",
+    "3. All SET50 series (future + its options) share the **same** underlying.\n",
+    "4. Financial fields are `float | None` and reject `NaN`/`Infinity` at decode time.\n",
+    "5. **Basis** = future price - underlying spot; a positive basis is a forward premium.\n",
+    "6. Use `get_underlying_price_raw()` to inspect the raw API payload during debugging.\n",
+    "\n",
+    "Happy trading! 📊"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "settfex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.2.1"
+version = "0.3.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/tfex/__init__.py
+++ b/settfex/services/tfex/__init__.py
@@ -4,6 +4,7 @@ from settfex.services.tfex.constants import (
     TFEX_BASE_URL,
     TFEX_SERIES_LIST_ENDPOINT,
     TFEX_TRADING_STATISTICS_ENDPOINT,
+    TFEX_UNDERLYING_PRICE_ENDPOINT,
 )
 from settfex.services.tfex.list import (
     TFEXSeries,
@@ -16,12 +17,18 @@ from settfex.services.tfex.trading_statistics import (
     TradingStatisticsService,
     get_trading_statistics,
 )
+from settfex.services.tfex.underlying_price import (
+    TFEXUnderlyingPriceService,
+    UnderlyingPrice,
+    get_underlying_price,
+)
 
 __all__ = [
     # Constants
     "TFEX_BASE_URL",
     "TFEX_SERIES_LIST_ENDPOINT",
     "TFEX_TRADING_STATISTICS_ENDPOINT",
+    "TFEX_UNDERLYING_PRICE_ENDPOINT",
     # Series List Service
     "TFEXSeries",
     "TFEXSeriesListResponse",
@@ -31,4 +38,8 @@ __all__ = [
     "TradingStatistics",
     "TradingStatisticsService",
     "get_trading_statistics",
+    # Underlying Price Service
+    "TFEXUnderlyingPriceService",
+    "UnderlyingPrice",
+    "get_underlying_price",
 ]

--- a/settfex/services/tfex/constants.py
+++ b/settfex/services/tfex/constants.py
@@ -6,3 +6,4 @@ TFEX_BASE_URL = "https://www.tfex.co.th"
 # API endpoints
 TFEX_SERIES_LIST_ENDPOINT = "/api/set/tfex/series/list"
 TFEX_TRADING_STATISTICS_ENDPOINT = "/api/set/tfex/series/{symbol}/trading-statistics"
+TFEX_UNDERLYING_PRICE_ENDPOINT = "/api/set/tfex/series/{symbol}/underlying-price"

--- a/settfex/services/tfex/underlying_price.py
+++ b/settfex/services/tfex/underlying_price.py
@@ -1,0 +1,253 @@
+"""TFEX Underlying Price Service - Fetch the underlying instrument price for a TFEX series."""
+
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.services.tfex.constants import (
+    TFEX_BASE_URL,
+    TFEX_UNDERLYING_PRICE_ENDPOINT,
+)
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import ResponseParseError, validate_or_raise
+
+
+class UnderlyingPrice(BaseModel):
+    """Model for the underlying instrument price of a TFEX series.
+
+    For SET50 index options/futures the underlying instrument is the SET50 index, so the
+    ``symbol`` here is the underlying (e.g. ``"SET50"``), not the series that was queried.
+    Financial fields are ``float | None`` and reject NaN/Infinity at decode time (the JSON
+    decoder used by ``AsyncDataFetcher`` rejects non-finite literals before validation).
+    """
+
+    symbol: str = Field(description="Underlying instrument symbol (e.g. 'SET50')")
+    sign: str = Field(description="Price movement sign indicator (e.g. '+', '-', or empty)")
+    prior: float | None = Field(description="Prior day's closing price of the underlying")
+    high: float | None = Field(description="Intraday high price of the underlying")
+    low: float | None = Field(description="Intraday low price of the underlying")
+    last: float | None = Field(description="Last traded price of the underlying")
+    change: float | None = Field(description="Absolute price change from prior close")
+    percent_change: float | None = Field(
+        alias="percentChange", description="Percentage price change from prior close"
+    )
+    total_volume: float | None = Field(
+        alias="totalVolume", description="Total traded volume of the underlying"
+    )
+    total_value: float | None = Field(
+        alias="totalValue", description="Total traded value of the underlying"
+    )
+    market_status: str = Field(
+        alias="marketStatus", description="Market status (e.g. 'Open', 'Closed')"
+    )
+    market_time: datetime = Field(
+        alias="marketTime", description="Market time when the underlying data was captured"
+    )
+    underlying_type: str = Field(
+        alias="underlyingType", description="Underlying instrument type (e.g. 'I' for index)"
+    )
+    statistics_as_of: datetime = Field(
+        alias="statisticsAsOf", description="Timestamp the statistics are reported as of"
+    )
+    pe: float | None = Field(description="Price-to-earnings ratio of the underlying")
+    pbv: float | None = Field(description="Price-to-book-value ratio of the underlying")
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+        str_strip_whitespace=True,  # Strip whitespace from strings
+    )
+
+
+class TFEXUnderlyingPriceService:
+    """
+    Service for fetching the underlying instrument price for a TFEX series.
+
+    This service provides async methods to fetch the price of the instrument underlying a
+    TFEX series (for SET50 index options/futures, that is the SET50 index), including the
+    last price, intraday high/low, change, traded volume/value, and valuation ratios.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """
+        Initialize the TFEX underlying price service.
+
+        Args:
+            config: Optional fetcher configuration (uses defaults if None)
+
+        Example:
+            >>> # Uses SessionManager for automatic cookie handling
+            >>> service = TFEXUnderlyingPriceService()
+        """
+        self.config = config or FetcherConfig()
+        self.base_url = TFEX_BASE_URL
+        logger.info(f"TFEXUnderlyingPriceService initialized with base_url={self.base_url}")
+
+    def _normalize_symbol(self, symbol: str) -> str:
+        """
+        Normalize symbol to uppercase.
+
+        Args:
+            symbol: Series symbol to normalize
+
+        Returns:
+            Normalized symbol in uppercase
+        """
+        return symbol.upper().strip()
+
+    async def get_underlying_price(self, symbol: str) -> UnderlyingPrice:
+        """
+        Fetch the underlying instrument price for a specific TFEX series.
+
+        Args:
+            symbol: Series symbol (e.g., 'S50M26C880')
+
+        Returns:
+            UnderlyingPrice with the underlying instrument's price data
+
+        Raises:
+            ResponseParseError: If the response is not valid JSON or contains a
+                NaN/Infinity literal (rejected to avoid silent financial-data corruption).
+            pydantic.ValidationError: If the response does not satisfy the model.
+            Exception: If the request itself fails.
+
+        Example:
+            >>> service = TFEXUnderlyingPriceService()
+            >>> price = await service.get_underlying_price("S50M26C880")
+            >>> print(f"Underlying: {price.symbol}")
+            >>> print(f"Last: {price.last}")
+            >>> print(f"Change: {price.change} ({price.percent_change}%)")
+        """
+        # Normalize symbol
+        normalized_symbol = self._normalize_symbol(symbol)
+
+        # Build URL with symbol
+        url = f"{self.base_url}{TFEX_UNDERLYING_PRICE_ENDPOINT.format(symbol=normalized_symbol)}"
+
+        logger.info(f"Fetching TFEX underlying price for {normalized_symbol} from {url}")
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            # Get optimized headers for TFEX API
+            headers = {
+                "Accept": "application/json, text/plain, */*",
+                "Accept-Encoding": "gzip, deflate, br, zstd",
+                "Accept-Language": "en-US,en;q=0.9,th-TH;q=0.8,th;q=0.7",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+                "Referer": f"https://www.tfex.co.th/en/products/futures/{normalized_symbol}",
+                "Sec-Ch-Ua": '"Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"',
+                "Sec-Ch-Ua-Mobile": "?0",
+                "Sec-Ch-Ua-Platform": '"macOS"',
+                "Sec-Fetch-Dest": "empty",
+                "Sec-Fetch-Mode": "cors",
+                "Sec-Fetch-Site": "same-origin",
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+                ),
+            }
+
+            # Fetch JSON data from API - SessionManager handles cookies automatically.
+            # fetch_json routes the body through decode_json, which rejects NaN/Infinity
+            # literals (the silent financial-data-corruption guard) with URL context.
+            data = await fetcher.fetch_json(url, headers=headers)
+
+            # Parse and validate response using Pydantic (context-rich on failure)
+            underlying_price = validate_or_raise(
+                UnderlyingPrice, data, context=f"{normalized_symbol} (tfex underlying-price)"
+            )
+
+            logger.info(
+                f"Successfully fetched underlying price for {normalized_symbol}: "
+                f"underlying={underlying_price.symbol}, "
+                f"last={underlying_price.last}, "
+                f"change={underlying_price.change}"
+            )
+
+            return underlying_price
+
+    async def get_underlying_price_raw(self, symbol: str) -> dict[str, Any]:
+        """
+        Fetch the underlying price as a raw dictionary without Pydantic validation.
+
+        Useful for debugging or when you need the raw API response.
+
+        Args:
+            symbol: Series symbol (e.g., 'S50M26C880')
+
+        Returns:
+            Raw dictionary from API
+
+        Raises:
+            ResponseParseError: If the request fails or the response is not a JSON object.
+
+        Example:
+            >>> service = TFEXUnderlyingPriceService()
+            >>> raw_data = await service.get_underlying_price_raw("S50M26C880")
+            >>> print(raw_data.keys())
+        """
+        # Normalize symbol
+        normalized_symbol = self._normalize_symbol(symbol)
+
+        # Build URL with symbol
+        url = f"{self.base_url}{TFEX_UNDERLYING_PRICE_ENDPOINT.format(symbol=normalized_symbol)}"
+
+        logger.info(f"Fetching raw TFEX underlying price for {normalized_symbol} from {url}")
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            # Get optimized headers for TFEX API
+            headers = {
+                "Accept": "application/json, text/plain, */*",
+                "Accept-Encoding": "gzip, deflate, br, zstd",
+                "Accept-Language": "en-US,en;q=0.9,th-TH;q=0.8,th;q=0.7",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+                "Referer": f"https://www.tfex.co.th/en/products/futures/{normalized_symbol}",
+                "Sec-Ch-Ua": '"Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"',
+                "Sec-Ch-Ua-Mobile": "?0",
+                "Sec-Ch-Ua-Platform": '"macOS"',
+                "Sec-Fetch-Dest": "empty",
+                "Sec-Fetch-Mode": "cors",
+                "Sec-Fetch-Site": "same-origin",
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+                ),
+            }
+
+            # Fetch JSON data
+            data: Any = await fetcher.fetch_json(url, headers=headers)
+            # Guard the documented dict return type explicitly (asserts are stripped under -O).
+            if not isinstance(data, dict):
+                raise ResponseParseError(
+                    f"Expected a JSON object for {normalized_symbol} "
+                    f"(tfex underlying-price), got {type(data).__name__}"
+                )
+            logger.debug(f"Raw response keys: {list(data.keys())}")
+            return data
+
+
+# Convenience function for quick access
+async def get_underlying_price(symbol: str, config: FetcherConfig | None = None) -> UnderlyingPrice:
+    """
+    Convenience function to fetch the underlying instrument price for a TFEX series.
+
+    Args:
+        symbol: Series symbol (e.g., 'S50M26C880')
+        config: Optional fetcher configuration
+
+    Returns:
+        UnderlyingPrice with the underlying instrument's price data
+
+    Example:
+        >>> from settfex.services.tfex import get_underlying_price
+        >>> # Uses SessionManager for automatic cookie handling
+        >>> price = await get_underlying_price("S50M26C880")
+        >>> print(f"Underlying: {price.symbol}")
+        >>> print(f"Last: {price.last:.2f}")
+        >>> print(f"Change: {price.change:.2f} ({price.percent_change:.2f}%)")
+        >>> print(f"P/E: {price.pe}, P/BV: {price.pbv}")
+    """
+    service = TFEXUnderlyingPriceService(config=config)
+    return await service.get_underlying_price(symbol)

--- a/tests/services/tfex/test_underlying_price.py
+++ b/tests/services/tfex/test_underlying_price.py
@@ -1,0 +1,143 @@
+"""Tests for TFEX underlying price service (validation + response-shape hardening)."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from settfex.services.tfex.underlying_price import (
+    TFEXUnderlyingPriceService,
+    UnderlyingPrice,
+    get_underlying_price,
+)
+from settfex.utils.data_fetcher import AsyncDataFetcher
+from settfex.utils.parsing import ResponseParseError
+
+# Real live response shape captured for series S50M26C880 (underlying = SET50 index).
+MOCK_UNDERLYING_PRICE = {
+    "symbol": "SET50",
+    "sign": "",
+    "prior": 1027.83,
+    "high": 1029.4,
+    "low": 1020.16,
+    "last": 1028.46,
+    "change": 0.63,
+    "percentChange": 0.06,
+    "totalVolume": 1874003100.0,
+    "totalValue": 45186543947.0,
+    "marketStatus": "Closed",
+    "marketTime": "2026-06-17T20:42:45.165793313+07:00",
+    "underlyingType": "I",
+    "statisticsAsOf": "2026-06-17T00:00:00+07:00",
+    "pe": 15.39,
+    "pbv": 1.53,
+}
+
+
+@pytest.fixture
+def mock_fetcher() -> Iterator[AsyncMock]:
+    """Mock AsyncDataFetcher with an async-context-manager returning fetch_json results."""
+    with patch("settfex.services.tfex.underlying_price.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        yield fetcher_instance
+
+
+class TestTFEXUnderlyingPriceService:
+    def test_init_uses_default_config(self) -> None:
+        service = TFEXUnderlyingPriceService()
+        assert service.base_url == "https://www.tfex.co.th"
+        assert service.config is not None
+
+    @pytest.mark.asyncio
+    async def test_fetch_success(self, mock_fetcher: AsyncMock) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_UNDERLYING_PRICE
+        result = await TFEXUnderlyingPriceService().get_underlying_price("s50m26c880")
+        assert isinstance(result, UnderlyingPrice)
+        assert result.symbol == "SET50"
+        assert result.last == 1028.46
+        assert result.change == 0.63
+        assert result.percent_change == 0.06
+        assert result.total_volume == 1874003100.0
+        assert result.market_status == "Closed"
+        assert result.underlying_type == "I"
+        assert result.pe == 15.39
+        assert result.pbv == 1.53
+        # tz-offset ISO strings parse into aware datetimes
+        assert result.market_time.year == 2026
+        assert result.market_time.utcoffset() is not None
+        assert result.statistics_as_of.tzinfo is not None
+
+    @pytest.mark.asyncio
+    async def test_fetch_normalizes_symbol_in_url(self, mock_fetcher: AsyncMock) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_UNDERLYING_PRICE
+        await TFEXUnderlyingPriceService().get_underlying_price("  s50m26c880  ")
+        called_url = mock_fetcher.fetch_json.call_args[0][0]
+        assert called_url.endswith("/api/set/tfex/series/S50M26C880/underlying-price")
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_required_field_raises(self, mock_fetcher: AsyncMock) -> None:
+        bad = {k: v for k, v in MOCK_UNDERLYING_PRICE.items() if k != "marketStatus"}
+        mock_fetcher.fetch_json.return_value = bad
+        with pytest.raises(ValidationError):
+            await TFEXUnderlyingPriceService().get_underlying_price("S50M26C880")
+
+    @pytest.mark.asyncio
+    async def test_fetch_nullable_financial_fields_accept_none(
+        self, mock_fetcher: AsyncMock
+    ) -> None:
+        payload = {**MOCK_UNDERLYING_PRICE, "pe": None, "pbv": None, "last": None}
+        mock_fetcher.fetch_json.return_value = payload
+        result = await TFEXUnderlyingPriceService().get_underlying_price("S50M26C880")
+        assert result.pe is None
+        assert result.pbv is None
+        assert result.last is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_rejects_non_finite_financial_field(self) -> None:
+        """The audit's headline guarantee: NaN/Infinity in a financial field is rejected.
+
+        decode_json (used by fetch_json) rejects the non-finite JSON literal, so a malformed
+        price can never reach the model. We drive the real decode path here instead of the
+        AsyncDataFetcher mock so the guard is genuinely exercised.
+        """
+        body = (
+            '{"symbol":"SET50","sign":"","prior":1027.83,"high":1029.4,"low":1020.16,'
+            '"last":NaN,"change":0.63,"percentChange":0.06,"totalVolume":1874003100.0,'
+            '"totalValue":45186543947.0,"marketStatus":"Closed",'
+            '"marketTime":"2026-06-17T20:42:45.165793313+07:00","underlyingType":"I",'
+            '"statisticsAsOf":"2026-06-17T00:00:00+07:00","pe":15.39,"pbv":1.53}'
+        )
+        fake_response = Mock()
+        fake_response.text = body
+        with (
+            patch.object(AsyncDataFetcher, "fetch", AsyncMock(return_value=fake_response)),
+            pytest.raises(ResponseParseError, match="non-finite"),
+        ):
+            await TFEXUnderlyingPriceService().get_underlying_price("S50M26C880")
+
+    @pytest.mark.asyncio
+    async def test_raw_rejects_non_dict_response(self, mock_fetcher: AsyncMock) -> None:
+        # Replaces the old `assert isinstance(data, dict)` (stripped under -O).
+        mock_fetcher.fetch_json.return_value = ["unexpected", "list"]
+        with pytest.raises(ResponseParseError, match="S50M26C880"):
+            await TFEXUnderlyingPriceService().get_underlying_price_raw("S50M26C880")
+
+    @pytest.mark.asyncio
+    async def test_raw_success_returns_dict(self, mock_fetcher: AsyncMock) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_UNDERLYING_PRICE
+        raw = await TFEXUnderlyingPriceService().get_underlying_price_raw("S50M26C880")
+        assert raw["symbol"] == "SET50"
+
+
+class TestConvenienceFunction:
+    @pytest.mark.asyncio
+    async def test_get_underlying_price(self, mock_fetcher: AsyncMock) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_UNDERLYING_PRICE
+        result = await get_underlying_price("S50M26C880")
+        assert isinstance(result, UnderlyingPrice)
+        assert result.symbol == "SET50"
+        assert result.last == 1028.46

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary
Adds the **TFEX underlying-price service** and cuts release **0.3.0**.

`get_underlying_price(symbol)` / `TFEXUnderlyingPriceService` / `UnderlyingPrice` wrap
`GET /api/set/tfex/series/{symbol}/underlying-price` — the **underlying instrument** of a TFEX series. For SET50 index options/futures the underlying is the **SET50 index spot**: last / prior / high / low, change, total volume & value, P/E, P/BV.

Mirrors the existing TFEX service pattern exactly: `SessionManager`/Incapsula bypass, hardened **NaN/Infinity-rejecting** parsing via `settfex/utils/parsing.py`, a `*_raw` variant, and a top-level `get_*` convenience function.

## Checklist (CLAUDE.md "Adding a New Service")
- ✅ Service module (`settfex/services/tfex/underlying_price.py`) + endpoint constant
- ✅ Tests (`tests/services/tfex/test_underlying_price.py`) — **100% module coverage**, incl. NaN-rejection
- ✅ `__init__.py` exports + `__all__`
- ✅ Verification script (`scripts/settfex/services/tfex/verify_underlying_price.py`, `scripts/` is gitignored like its siblings) — ran **10/10 live**
- ✅ Example notebook (`examples/tfex/03_underlying_price.ipynb`)

## Release 0.3.0
- Version bumped in `pyproject.toml` + `settfex/__init__.py` (+ `uv.lock`), in sync.
- `CHANGELOG.md` `## [0.3.0] - 2026-06-17` `### Added` section.
- Gate green: ruff · ruff-format · `mypy --strict settfex` · pytest **158 passed**, 62.46% cov.

After merge, the maintainer pushes `v0.3.0` to trigger the PyPI publish (`release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
