### PR TITLE
feat: SET Earnings Call (Opportunity Day) service + AsyncDataFetcher POST (release 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-19
+
 ### Added
 
 - **SET Earnings Call (Opportunity Day) service** (`get_earnings_calls`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **SET Earnings Call (Opportunity Day) service** (`get_earnings_calls`,
+  `get_earnings_calls_dataframe`, `EarningsCallService`, `EarningsCallItem`,
+  `EarningsCallResponse`, `EarningsCallDetail`, `FilterOption`): fetches the SET
+  "Earnings Call (OPPDAY)" calendar from the stateless opportunity-day backend
+  (`POST https://api.lcp.setgroup.or.th/api/v1/investor/search/archive`). Returns typed
+  Pydantic models with derived `company_name_clean` / `youtube_video_id` / `youtube_url`
+  fields, plus an optional pandas DataFrame (`to_dataframe()`) whose default columns are
+  `stock_name, company_name, earnings_call_date, video_clip_time, youtube_url`. Includes
+  bounded auto-pagination (`fetch_all_earnings_calls`), opt-in concurrent detail enrichment
+  (`enrich=True`), seven filter helpers, and a `*_raw` variant. This host needs no
+  cookies/Incapsula bypass, so it uses a plain sessionless fetcher. Not stock-scoped (not on
+  the `Stock` class). Adds the `docs/settfex/services/set/earnings_call.md` doc and the
+  `examples/set/12_earnings_call.ipynb` notebook.
+- **`AsyncDataFetcher` POST support**: `fetch()` / `fetch_json()` now accept keyword-only
+  `method="GET"` (default — fully backward compatible) and `json_body`. POST runs through the
+  standalone (sessionless) path and the same NaN-rejecting JSON decoder; POST via a persistent
+  session is intentionally unsupported (raises `NotImplementedError`).
+
+### Changed
+
+- pandas is now available as an optional `dataframe` extra
+  (`pip install "settfex[dataframe]"`); it is required only for the DataFrame convenience and
+  is imported lazily, so importing the library never requires pandas.
+
 ## [0.3.0] - 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Want to dig deeper? Check out our detailed guides:
 - **[Financial Service](docs/settfex/services/set/financial.md)** - Balance sheet, income statement, and cash flow data
 - **[Chart Quotation Service](docs/settfex/services/set/chart_quotation.md)** - Intraday and historical price chart data
 - **[Latest Historical Trading Service](docs/settfex/services/set/latest_historical_trading.md)** - Latest trading day summary with OHLCV and valuation metrics
+- **[Earnings Call (Opportunity Day) Service](docs/settfex/services/set/earnings_call.md)** - OPPDAY earnings-call calendar with YouTube links, as models or a DataFrame
 
 ### TFEX Services
 
@@ -376,6 +377,31 @@ print(f"Market Cap: {trading.market_cap:,.0f} THB")
 ```
 
 **👉 [Learn more about Latest Historical Trading](docs/settfex/services/set/latest_historical_trading.md)**
+
+---
+
+#### 🎤 Get Earnings Call (Opportunity Day) Calendar
+
+Fetch the SET Opportunity Day earnings-call calendar — symbol, company, date, clip duration,
+and a ready-to-use YouTube link — as typed models or a pandas DataFrame:
+
+```python
+from settfex.services.set import get_earnings_calls, get_earnings_calls_dataframe
+
+# Typed models
+response = await get_earnings_calls()
+for item in response.items[:5]:
+    print(item.symbol, item.company_name_clean, item.youtube_url)
+
+# …or straight to a DataFrame (requires: pip install "settfex[dataframe]")
+df = await get_earnings_calls_dataframe()
+# columns: stock_name, company_name, earnings_call_date, video_clip_time, youtube_url
+
+# Search one company, or filter by quarter/type
+hann = await get_earnings_calls(keyword="HANN")
+```
+
+**👉 [Learn more about the Earnings Call Service](docs/settfex/services/set/earnings_call.md)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -596,6 +596,12 @@ stock_list = await get_stock_list()
 
 Great for debugging or monitoring in production. Default is ERROR level for clean output.
 
+## 📋 Changelog
+
+See **[CHANGELOG.md](CHANGELOG.md)** for the full, versioned release history (this project
+follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
+[Semantic Versioning](https://semver.org/)).
+
 ## 🤝 Contributing
 
 We'd love your help making settfex better! Here's how:

--- a/docs/settfex/services/set/earnings_call.md
+++ b/docs/settfex/services/set/earnings_call.md
@@ -1,0 +1,187 @@
+# SET Earnings Call (Opportunity Day) Service
+
+## Overview
+
+The Earnings Call Service fetches the SET **"Earnings Call (OPPDAY)"** calendar — the
+Opportunity Day presentations listed at
+<https://opportunity-day.setgroup.or.th/en/earnings-call>. It returns typed Pydantic models
+and an optional pandas DataFrame whose columns are exactly what an earnings-call dashboard
+needs: `stock_name`, `company_name`, `earnings_call_date`, `video_clip_time`, `youtube_url`.
+
+Unlike the main SET API, the opportunity-day backend (`https://api.lcp.setgroup.or.th/api/v1`)
+is **stateless** — no Incapsula bot wall, no cookies, no auth. The service therefore uses a
+plain sessionless fetcher (no cookie warm-up).
+
+## Quick Start
+
+```python
+import asyncio
+from settfex.services.set import get_earnings_calls, get_earnings_calls_dataframe
+
+async def main():
+    # Typed models
+    response = await get_earnings_calls()
+    for item in response.items:
+        print(item.symbol, item.company_name_clean, item.youtube_url)
+
+    # …or straight to a DataFrame (requires: pip install settfex[dataframe])
+    df = await get_earnings_calls_dataframe()
+    print(df)
+
+asyncio.run(main())
+```
+
+## The 5 DataFrame columns
+
+| Column | Source |
+|---|---|
+| `stock_name` | `symbol` (e.g. `HANN`) |
+| `company_name` | `company_name` with the leading `"<SYMBOL>: "` prefix stripped |
+| `earnings_call_date` | `meeting_date` (tz-aware UTC) as a `date` |
+| `video_clip_time` | `period` — the clip **duration** shown on the card, e.g. `"45:00"` |
+| `youtube_url` | derived from the thumbnail `image_path`, e.g. `https://www.youtube.com/watch?v=…` |
+
+`youtube_url` (and `youtube_video_id`) are `None` for upcoming items with no recording.
+
+> ⚠️ **The `period` field has two meanings.** In the **list** response (used for
+> `video_clip_time`) it is the clip **duration** (`"45:00"`, MM:SS). In the **detail**
+> response (enrichment) it is the meeting **clock-time range** (`"16:15 - 17:00"`), surfaced
+> separately as `EarningsCallDetail.meeting_time`. The list duration is authoritative and is
+> never overwritten by enrichment.
+
+## Models
+
+### `EarningsCallItem`
+
+- `id: int`, `name: str` (Thai presentation title), `symbol: str`, `industry: str`
+- `company_name: str` — raw, e.g. `"HANN: MUKDAHAN INTERNATIONAL HOSPITAL …"`
+- `meeting_date: datetime` — tz-aware UTC
+- `image_path: str | None`, `view_mode: bool | None`, `period: str | None`
+- **Derived** (computed): `company_name_clean: str`, `youtube_video_id: str | None`,
+  `youtube_url: str | None`
+- `detail: EarningsCallDetail | None` — populated only when `enrich=True`
+
+### `EarningsCallResponse`
+
+- `no_records: int` — total records across all pages
+- `items: list[EarningsCallItem]`, `count` property
+- `to_dataframe(columns=None) -> pandas.DataFrame` — defaults to the 5 columns above;
+  additional selectable columns: `company_name_raw`, `earnings_call_datetime`,
+  `youtube_video_id`, `id`, `name`, `industry`, `view_mode`. Unknown column → `ValueError`;
+  pandas missing → `ImportError`.
+
+### `EarningsCallDetail` (enrichment)
+
+`video_link`, `company_name_th`, `meeting_time` (the clock-time range), `document_link`,
+`snapshot_link`, `round_name`, `type`, `type_id`, `year`, `round`, `has_qa`, …
+
+### `FilterOption`
+
+`id: int | str`, `name: str` (ids are ints for types/years/trusts/stages, string codes for
+industries/markets/themes).
+
+## Service Class
+
+### `EarningsCallService(config: FetcherConfig | None = None)`
+
+`use_session` is always coerced to `False` for this stateless host; all other `FetcherConfig`
+settings (timeout, retries, impersonation, rate limit) are honored.
+
+#### `fetch_earnings_calls(...) -> EarningsCallResponse`
+
+```python
+response = await EarningsCallService().fetch_earnings_calls(
+    type_id=1,        # 1=Earnings Call/OPPDAY, 2=Digital Roadshow, 3=C-Sign
+    quarter_id=0,     # 0=all quarters; see fetch_filter_years()
+    keyword=None,     # free-text symbol/company search (normalized)
+    industries_id=None,
+    start=1,          # 1-based page number
+    page_size=12,
+    language="en",    # "en" or "th"
+    enrich=False,     # opt-in per-item detail (bounded concurrency)
+)
+```
+
+#### `fetch_all_earnings_calls(..., max_records=None, max_pages=None, throttle=0.3)`
+
+Auto-paginates, **bounded and polite** — reuses one fetcher, sleeps `throttle` seconds between
+pages, and stops at the first short page, once `no_records` is reached, or when a cap is hit.
+
+> The API honors `page_size` up to ~100 but **rejects very large values** (e.g. 500), which
+> surfaces as a clear `ResponseParseError`/`ValidationError`. The defaults (12 for a single
+> page, 50 for `fetch_all`) stay safely under the cap — prefer iterating pages over an
+> oversized `page_size`.
+
+```python
+service = EarningsCallService()
+response = await service.fetch_all_earnings_calls(max_records=200)  # at most 200, polite
+df = response.to_dataframe()
+```
+
+#### `fetch_earnings_calls_raw(...) -> dict`
+
+Raw JSON dict (no validation), for debugging.
+
+#### Filter helpers
+
+`fetch_filter_types()`, `fetch_filter_years()`, `fetch_filter_industries()`,
+`fetch_filter_markets()`, `fetch_filter_themes()`, `fetch_filter_trusts()`,
+`fetch_filter_stages()` → `list[FilterOption]`.
+
+## Convenience Functions
+
+- `get_earnings_calls(...) -> EarningsCallResponse`
+- `get_earnings_calls_dataframe(..., columns=None) -> pandas.DataFrame`
+
+Both fetch a **single page** by default (mirroring `get_stock_list`). For the full calendar,
+use `fetch_all_earnings_calls()` then `to_dataframe()`.
+
+## Usage Examples
+
+### Filter by quarter and type
+
+```python
+service = EarningsCallService()
+years = await service.fetch_filter_years()          # find the quarter id you want
+q1_2026 = next(y for y in years if y.name == "Quater 1/2026").id
+response = await service.fetch_earnings_calls(type_id=1, quarter_id=q1_2026, page_size=50)
+```
+
+### Search a single company
+
+```python
+response = await get_earnings_calls(keyword="HANN")
+for item in response.items:
+    print(item.meeting_date.date(), item.youtube_url)
+```
+
+### Enrich with detail (video link, Thai name, meeting time)
+
+```python
+response = await get_earnings_calls(page_size=10, enrich=True)
+for item in response.items:
+    if item.detail:
+        print(item.symbol, item.detail.meeting_time, item.detail.video_link)
+```
+
+## Optional dependency: pandas
+
+`to_dataframe()` / `get_earnings_calls_dataframe()` need pandas, which is an **optional**
+extra (the rest of the service works without it):
+
+```bash
+pip install "settfex[dataframe]"   # or: uv add pandas
+```
+
+## API Endpoints
+
+```
+POST https://api.lcp.setgroup.or.th/api/v1/investor/search/archive      # list (primary)
+GET  https://api.lcp.setgroup.or.th/api/v1/investor/vdo/{id}            # detail (enrich)
+GET  https://api.lcp.setgroup.or.th/api/v1/investor/filter/{name}       # filter options
+```
+
+## Related Services
+
+- [Stock List Service](list.md) — discover all SET/mai stocks
+- [AsyncDataFetcher](../../utils/data_fetcher.md) — low-level HTTP client (now supports POST)

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,8 +21,9 @@ Complete tutorial series covering all 11 SET services:
 9. **Trading Statistics** - Historical performance (multi-period)
 10. **Price Performance** - Stock vs sector vs market comparison
 11. **Financial Statements** - Balance sheet, income, cash flow
+12. **Earnings Call (Opportunity Day)** - OPPDAY calendar with YouTube links → DataFrame → CSV
 
-**Total**: 11 notebooks + comprehensive guide
+**Total**: 12 notebooks + comprehensive guide
 
 ## Quick Start
 

--- a/examples/set/12_earnings_call.ipynb
+++ b/examples/set/12_earnings_call.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Earnings Call (Opportunity Day) Calendar\n",
+    "\n",
+    "Fetch the SET **Earnings Call (OPPDAY)** calendar with `settfex`: symbol, company, date,\n",
+    "video-clip duration, and a ready-to-use YouTube link — as typed models or a pandas DataFrame.\n",
+    "\n",
+    "> The opportunity-day backend is stateless (no cookies/bot wall), so these calls are fast and\n",
+    "> need no session warm-up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "The DataFrame helpers need pandas, an optional extra:\n",
+    "\n",
+    "```bash\n",
+    "pip install \"settfex[dataframe]\"   # or: uv add pandas\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from settfex.services.set import (\n",
+    "    EarningsCallService,\n",
+    "    get_earnings_calls,\n",
+    "    get_earnings_calls_dataframe,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Fetch the current OPPDAY list\n",
+    "\n",
+    "`get_earnings_calls()` returns one page of typed `EarningsCallItem`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await get_earnings_calls(page_size=12)\n",
+    "\n",
+    "print(f\"This page: {response.count} items | total available: {response.no_records}\")\n",
+    "\n",
+    "\n",
+    "for item in response.items[:5]:\n",
+    "    print(f\"{item.symbol:8} {item.meeting_date.date()}  {item.period}  {item.company_name_clean}\")\n",
+    "\n",
+    "    print(f\"         {item.youtube_url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. As a pandas DataFrame\n",
+    "\n",
+    "The default columns are exactly `stock_name, company_name, earnings_call_date, video_clip_time, youtube_url`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = await get_earnings_calls_dataframe(page_size=12)\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Search a single company (keyword)\n",
+    "\n",
+    "`keyword` is a free-text symbol/company search (normalized to uppercase)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hann = await get_earnings_calls(keyword=\"HANN\")\n",
+    "\n",
+    "hann.to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Filter by quarter and type\n",
+    "\n",
+    "Use the filter helpers to discover valid ids. `type_id` 1 = Earnings Call (OPPDAY),\n",
+    "2 = Digital Roadshow, 3 = C-Sign. `quarter_id` 0 = all quarters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service = EarningsCallService()\n",
+    "\n",
+    "\n",
+    "years = await service.fetch_filter_years()\n",
+    "\n",
+    "print(\"Available quarters (first 5):\")\n",
+    "\n",
+    "for y in years[:5]:\n",
+    "    print(f\"  {y.id}  {y.name}\")\n",
+    "\n",
+    "\n",
+    "# Pick the most recent quarter and fetch its OPPDAY presentations\n",
+    "\n",
+    "latest_quarter = years[0].id\n",
+    "\n",
+    "by_quarter = await service.fetch_earnings_calls(type_id=1, quarter_id=latest_quarter, page_size=20)\n",
+    "\n",
+    "print(f\"\\n{by_quarter.count} item(s) for quarter id {latest_quarter}\")\n",
+    "\n",
+    "by_quarter.to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Fetch more pages (bounded) and export to CSV\n",
+    "\n",
+    "`fetch_all_earnings_calls` auto-paginates politely. Always cap it with `max_records` /\n",
+    "`max_pages` — the full archive is thousands of rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full = await service.fetch_all_earnings_calls(max_records=100, throttle=0.3)\n",
+    "\n",
+    "df_full = full.to_dataframe()\n",
+    "\n",
+    "print(f\"Collected {len(df_full)} rows\")\n",
+    "\n",
+    "\n",
+    "df_full.to_csv(\"earnings_calls.csv\", index=False)\n",
+    "\n",
+    "print(\"Saved earnings_calls.csv\")\n",
+    "\n",
+    "df_full.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. (Optional) Enrich with detail\n",
+    "\n",
+    "`enrich=True` fetches each item's detail concurrently (bounded), adding the YouTube embed\n",
+    "link, the Thai company name, and the meeting **clock-time range** (`detail.meeting_time`,\n",
+    "e.g. `\"16:15 - 17:00\"`). Note this is *different* from `video_clip_time`, which is the clip\n",
+    "**duration** (`\"45:00\"`) from the list endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enriched = await get_earnings_calls(page_size=5, enrich=True)\n",
+    "\n",
+    "for item in enriched.items:\n",
+    "    if item.detail:\n",
+    "        print(f\"{item.symbol:8} duration={item.period}  meeting_time={item.detail.meeting_time}\")\n",
+    "\n",
+    "        print(f\"         {item.detail.video_link}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "settfex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,12 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
+# pandas is an optional, untyped runtime extra (used only in to_dataframe()); don't require
+# its stubs to keep the strict gate green.
+[[tool.mypy.overrides]]
+module = ["pandas", "pandas.*"]
+ignore_missing_imports = true
+
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", "scripts"]
 
@@ -117,6 +123,10 @@ exclude_dirs = ["tests", ".venv", "scripts"]
 default-groups = ["dev"]
 
 [project.optional-dependencies]
+# Lightweight extra for the DataFrame convenience (EarningsCallResponse.to_dataframe()).
+dataframe = [
+    "pandas>=2.0.0",
+]
 examples = [
     "pandas>=2.0.0",
     "matplotlib>=3.7.0",
@@ -129,6 +139,9 @@ dev = [
     "bandit>=1.7",
     "build>=1.0.0",
     "mypy>=1.18.2",
+    # pandas is an optional runtime extra (see [project.optional-dependencies].dataframe);
+    # it lives in the dev group too so the to_dataframe() tests run in CI.
+    "pandas>=2.0.0",
     "pip-audit>=2.7",
     "pre-commit>=3.7",
     "pytest>=8.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.3.0"
+version = "0.4.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -5,9 +5,13 @@ from settfex.services.set.constants import (
     SET_BOARD_OF_DIRECTOR_ENDPOINT,
     SET_COMPANY_PROFILE_ENDPOINT,
     SET_CORPORATE_ACTION_ENDPOINT,
+    SET_EARNINGS_CALL_DETAIL_ENDPOINT,
+    SET_EARNINGS_CALL_FILTER_ENDPOINT,
+    SET_EARNINGS_CALL_SEARCH_ENDPOINT,
     SET_FINANCIAL_BALANCE_SHEET_ENDPOINT,
     SET_FINANCIAL_CASH_FLOW_ENDPOINT,
     SET_FINANCIAL_INCOME_STATEMENT_ENDPOINT,
+    SET_LCP_BASE_URL,
     SET_NVDR_HOLDER_ENDPOINT,
     SET_PRICE_PERFORMANCE_ENDPOINT,
     SET_STOCK_HIGHLIGHT_DATA_ENDPOINT,
@@ -15,6 +19,15 @@ from settfex.services.set.constants import (
     SET_STOCK_PROFILE_ENDPOINT,
     SET_STOCK_SHAREHOLDER_ENDPOINT,
     SET_TRADING_STAT_ENDPOINT,
+)
+from settfex.services.set.earnings_call import (
+    EarningsCallDetail,
+    EarningsCallItem,
+    EarningsCallResponse,
+    EarningsCallService,
+    FilterOption,
+    get_earnings_calls,
+    get_earnings_calls_dataframe,
 )
 from settfex.services.set.list import (
     StockListResponse,
@@ -80,11 +93,23 @@ __all__ = [
     "SET_FINANCIAL_BALANCE_SHEET_ENDPOINT",
     "SET_FINANCIAL_INCOME_STATEMENT_ENDPOINT",
     "SET_FINANCIAL_CASH_FLOW_ENDPOINT",
+    "SET_LCP_BASE_URL",
+    "SET_EARNINGS_CALL_SEARCH_ENDPOINT",
+    "SET_EARNINGS_CALL_DETAIL_ENDPOINT",
+    "SET_EARNINGS_CALL_FILTER_ENDPOINT",
     # Stock List Service
     "StockListService",
     "StockListResponse",
     "StockSymbol",
     "get_stock_list",
+    # Earnings Call (Opportunity Day) Service
+    "EarningsCallService",
+    "EarningsCallItem",
+    "EarningsCallDetail",
+    "EarningsCallResponse",
+    "FilterOption",
+    "get_earnings_calls",
+    "get_earnings_calls_dataframe",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/constants.py
+++ b/settfex/services/set/constants.py
@@ -19,3 +19,13 @@ SET_FINANCIAL_INCOME_STATEMENT_ENDPOINT = "/api/set/factsheet/{symbol}/financial
 SET_FINANCIAL_CASH_FLOW_ENDPOINT = "/api/set/factsheet/{symbol}/financialstatement"
 SET_STOCK_CHART_QUOTATION_ENDPOINT = "/api/set/stock/{symbol}/chart-quotation"
 SET_STOCK_LATEST_HISTORICAL_TRADING_ENDPOINT = "/api/set/stock/{symbol}/latest-historical-trading"
+
+# Earnings Call (Opportunity Day) calendar API.
+# Hosted on a separate, stateless backend (no Incapsula/cookies, no auth) — the public page
+# is https://opportunity-day.setgroup.or.th/en/earnings-call.
+SET_LCP_BASE_URL = "https://api.lcp.setgroup.or.th/api/v1"
+SET_EARNINGS_CALL_SEARCH_ENDPOINT = "/investor/search/archive"
+SET_EARNINGS_CALL_DETAIL_ENDPOINT = "/investor/vdo/{id}"
+SET_EARNINGS_CALL_FILTER_ENDPOINT = "/investor/filter/{name}"
+SET_OPPDAY_ORIGIN = "https://opportunity-day.setgroup.or.th"
+SET_OPPDAY_REFERER = "https://opportunity-day.setgroup.or.th/"

--- a/settfex/services/set/earnings_call.py
+++ b/settfex/services/set/earnings_call.py
@@ -1,0 +1,706 @@
+"""SET Earnings Call (Opportunity Day) Calendar Service.
+
+Fetches the SET "Earnings Call (OPPDAY)" calendar from the opportunity-day backend
+(``https://api.lcp.setgroup.or.th/api/v1``) and returns typed Pydantic models plus an
+optional pandas DataFrame convenience.
+
+Unlike the main SET API, this host is **stateless**: it sits behind no Incapsula bot wall,
+needs no cookies and no auth header. The service therefore uses a plain (sessionless)
+``AsyncDataFetcher`` — there is no cookie warm-up.
+
+Note on the ``period`` field — it means two different things in the two endpoints:
+
+- in the **list** response (used here for :attr:`EarningsCallItem.period`) it is the video
+  **duration** as shown on the website card, e.g. ``"45:00"`` (MM:SS);
+- in the **detail** response it is the meeting **clock-time range**, e.g. ``"16:15 - 17:00"``
+  (exposed as :attr:`EarningsCallDetail.meeting_time`).
+
+The list duration is authoritative for ``video_clip_time`` and is never overwritten by
+enrichment.
+"""
+
+import asyncio
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+
+from settfex.services.set.constants import (
+    SET_EARNINGS_CALL_DETAIL_ENDPOINT,
+    SET_EARNINGS_CALL_FILTER_ENDPOINT,
+    SET_EARNINGS_CALL_SEARCH_ENDPOINT,
+    SET_LCP_BASE_URL,
+    SET_OPPDAY_ORIGIN,
+    SET_OPPDAY_REFERER,
+)
+from settfex.services.set.stock.utils import normalize_language, normalize_symbol
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import (
+    ResponseParseError,
+    validate_list_or_raise,
+    validate_or_raise,
+)
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# Extracts the YouTube video id from a thumbnail URL like
+# ``https://img.youtube.com/vi/<VIDEO_ID>/mqdefault.jpg``.
+_YOUTUBE_ID_RE = re.compile(r"/vi/([^/]+)/")
+
+
+def _extract_youtube_id(image_path: str | None) -> str | None:
+    """Extract the YouTube video id from a thumbnail URL.
+
+    Args:
+        image_path: Thumbnail URL from the API (e.g. ``.../vi/<id>/mqdefault.jpg``).
+
+    Returns:
+        The video id, or ``None`` if ``image_path`` is missing/empty or is not a
+        YouTube thumbnail (e.g. an upcoming item with no recording).
+    """
+    if not image_path or "youtube.com" not in image_path:
+        return None
+    match = _YOUTUBE_ID_RE.search(image_path)
+    return match.group(1) if match else None
+
+
+def _build_earnings_call_headers(language: str) -> dict[str, str]:
+    """Build browser-like headers for the opportunity-day API.
+
+    No cookie/authorization header is required (the host is stateless). ``Content-Type`` is
+    set automatically by curl_cffi when a JSON body is sent, so it is intentionally omitted.
+
+    Args:
+        language: Normalized language code (``"en"`` or ``"th"``) driving ``Accept-Language``.
+
+    Returns:
+        Header dictionary suitable for the search/detail/filter endpoints.
+    """
+    accept_language = "th,en-US;q=0.9,en;q=0.8" if language == "th" else "en-US,en;q=0.9,th;q=0.8"
+    return {
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": accept_language,
+        "Origin": SET_OPPDAY_ORIGIN,
+        "Referer": SET_OPPDAY_REFERER,
+        "Sec-Ch-Ua": '"Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"',
+        "Sec-Ch-Ua-Mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"macOS"',
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "cross-site",
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+        ),
+    }
+
+
+class FilterOption(BaseModel):
+    """A single filter option from ``/investor/filter/{name}``.
+
+    ``id`` is an ``int`` for the ``types``/``years``/``trusts``/``stages`` filters and a
+    ``str`` code for ``industries``/``markets``/``themes``.
+    """
+
+    id: int | str = Field(description="Option id (int or string code, depends on the filter)")
+    name: str = Field(description="Human-readable option name")
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
+class EarningsCallDetail(BaseModel):
+    """Enrichment fields from ``GET /investor/vdo/{id}`` (fetched only when ``enrich=True``)."""
+
+    id: int = Field(description="Presentation/event id")
+    symbol: str | None = Field(default=None, description="Stock symbol/ticker")
+    type_id: int | None = Field(default=None, description="Presentation type id (1 = OPPDAY)")
+    type: str | None = Field(default=None, description="Presentation type label")
+    year: int | None = Field(default=None, description="Fiscal year")
+    round: int | None = Field(default=None, description="Round number within the year")
+    round_name: str | None = Field(default=None, description='Round name, e.g. "Q1/2026"')
+    company_name: str | None = Field(default=None, description="Company name (English, raw)")
+    company_name_th: str | None = Field(default=None, description="Company name (Thai, raw)")
+    description: str | None = Field(default=None, description="Presentation description")
+    meeting_time: str | None = Field(
+        default=None,
+        alias="period",
+        description=(
+            'Meeting clock-time range, e.g. "16:15 - 17:00". Distinct from the list '
+            "endpoint's MM:SS video duration — see the module docstring."
+        ),
+    )
+    video_link: str | None = Field(default=None, description="YouTube embed URL")
+    document_link: str | None = Field(default=None, description="Presentation document path")
+    snapshot_link: str | None = Field(default=None, description="Listed-company snapshot URL")
+    company_link: str | None = Field(default=None, description="SET company profile URL")
+    logo_path: str | None = Field(default=None, description="Company logo URL")
+    has_qa: bool | None = Field(default=None, description="Whether a Q&A is available")
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore", str_strip_whitespace=True)
+
+
+class EarningsCallItem(BaseModel):
+    """A single Earnings Call (Opportunity Day) calendar entry from the list endpoint."""
+
+    id: int = Field(description="Unique presentation/event id")
+    name: str = Field(description="Presentation title (Thai, as shown on the card)")
+    company_name: str = Field(description='Raw company name, prefixed "<SYMBOL>: ..."')
+    industry: str = Field(default="", description="Industry classification")
+    symbol: str = Field(description="Stock symbol/ticker")
+    image_path: str | None = Field(
+        default=None, description="YouTube thumbnail URL (present only when recorded)"
+    )
+    view_mode: bool | None = Field(default=None, description="Whether the recording is viewable")
+    meeting_date: datetime = Field(
+        description="Meeting date (tz-aware UTC; the API reports midnight UTC)"
+    )
+    period: str | None = Field(
+        default=None,
+        description='Video clip duration as shown on the card, e.g. "45:00" (MM:SS)',
+    )
+    detail: EarningsCallDetail | None = Field(
+        default=None,
+        description="Enrichment from the detail endpoint, populated only when enrich=True",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    @field_validator("meeting_date")
+    @classmethod
+    def _ensure_tz_aware(cls, value: datetime) -> datetime:
+        """Guarantee a tz-aware datetime (assume UTC if the API ever omits the offset)."""
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def company_name_clean(self) -> str:
+        """Company name with the leading ``"<SYMBOL>: "`` prefix removed.
+
+        Uses a literal prefix check (not a regex) so symbols containing regex-special
+        characters (e.g. ``88TH``) are handled safely.
+        """
+        prefix = f"{self.symbol}:"
+        if self.company_name.startswith(prefix):
+            return self.company_name[len(prefix) :].strip()
+        return self.company_name.strip()
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def youtube_video_id(self) -> str | None:
+        """YouTube video id derived from ``image_path`` (``None`` if not a YouTube thumb)."""
+        return _extract_youtube_id(self.image_path)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def youtube_url(self) -> str | None:
+        """Canonical ``https://www.youtube.com/watch?v=<id>`` URL, or ``None``."""
+        video_id = self.youtube_video_id
+        return f"https://www.youtube.com/watch?v={video_id}" if video_id else None
+
+
+# DataFrame column name -> accessor. The first five are the user-facing default columns; the
+# rest are opt-in extras selectable via ``to_dataframe(columns=[...])``.
+_DATAFRAME_ACCESSORS: dict[str, Callable[[EarningsCallItem], Any]] = {
+    "stock_name": lambda item: item.symbol,
+    "company_name": lambda item: item.company_name_clean,
+    "earnings_call_date": lambda item: item.meeting_date.date(),
+    "video_clip_time": lambda item: item.period,
+    "youtube_url": lambda item: item.youtube_url,
+    "company_name_raw": lambda item: item.company_name,
+    "earnings_call_datetime": lambda item: item.meeting_date,
+    "youtube_video_id": lambda item: item.youtube_video_id,
+    "id": lambda item: item.id,
+    "name": lambda item: item.name,
+    "industry": lambda item: item.industry,
+    "view_mode": lambda item: item.view_mode,
+}
+_DEFAULT_DATAFRAME_COLUMNS: tuple[str, ...] = (
+    "stock_name",
+    "company_name",
+    "earnings_call_date",
+    "video_clip_time",
+    "youtube_url",
+)
+
+
+class EarningsCallResponse(BaseModel):
+    """Response from the earnings-call list endpoint (``no_records`` + ``items``)."""
+
+    no_records: int = Field(description="Total number of records across all pages")
+    items: list[EarningsCallItem] = Field(
+        default_factory=list, description="Calendar entries for this page (or accumulated)"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @property
+    def count(self) -> int:
+        """Number of items currently held (this page, or accumulated by ``fetch_all``)."""
+        return len(self.items)
+
+    def to_dataframe(self, columns: list[str] | None = None) -> "pd.DataFrame":
+        """Render the items as a pandas DataFrame.
+
+        pandas is an optional dependency; it is imported lazily here so that importing this
+        service never requires pandas.
+
+        Args:
+            columns: Column names to include, in order. Defaults to
+                ``["stock_name", "company_name", "earnings_call_date", "video_clip_time",
+                "youtube_url"]``. See ``_DATAFRAME_ACCESSORS`` for the full set of selectable
+                columns (e.g. ``"company_name_raw"``, ``"youtube_video_id"``,
+                ``"earnings_call_datetime"``, ``"industry"``, ``"id"``).
+
+        Returns:
+            A DataFrame with one row per item (empty — but with the requested columns — when
+            there are no items).
+
+        Raises:
+            ImportError: If pandas is not installed.
+            ValueError: If an unknown column name is requested.
+        """
+        try:
+            import pandas as pd
+        except ImportError as exc:  # pragma: no cover - exercised via monkeypatched sys.modules
+            raise ImportError(
+                "pandas is required for EarningsCallResponse.to_dataframe(). Install it with "
+                "'pip install settfex[dataframe]' (or 'uv add pandas')."
+            ) from exc
+
+        cols = list(columns) if columns is not None else list(_DEFAULT_DATAFRAME_COLUMNS)
+        unknown = [c for c in cols if c not in _DATAFRAME_ACCESSORS]
+        if unknown:
+            raise ValueError(
+                f"Unknown DataFrame column(s): {unknown}. "
+                f"Available columns: {sorted(_DATAFRAME_ACCESSORS)}"
+            )
+
+        rows = [{col: _DATAFRAME_ACCESSORS[col](item) for col in cols} for item in self.items]
+        return pd.DataFrame(rows, columns=cols)
+
+
+class EarningsCallService:
+    """Service for fetching the SET Earnings Call (Opportunity Day) calendar.
+
+    The opportunity-day host is stateless, so this service always uses a sessionless
+    ``AsyncDataFetcher`` (no cookie warm-up). Any injected :class:`FetcherConfig` is honored
+    for everything except ``use_session``, which is forced to ``False``.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """Initialize the service.
+
+        Args:
+            config: Optional fetcher configuration. ``use_session`` is always coerced to
+                ``False`` for this stateless host; all other settings (timeout, retries,
+                browser impersonation, rate limiting) are preserved.
+        """
+        base = config or FetcherConfig()
+        # This host needs no cookies; never warm up a SET session for it.
+        self.config = base.model_copy(update={"use_session": False})
+        self.base_url = SET_LCP_BASE_URL
+        logger.info(f"EarningsCallService initialized with base_url={self.base_url}")
+
+    @staticmethod
+    def _build_search_body(
+        *,
+        type_id: int,
+        quarter_id: int,
+        keyword: str | None,
+        industries_id: str | None,
+        composition_id: int | None,
+        start: int,
+        page_size: int,
+    ) -> dict[str, Any]:
+        """Build (and validate) the JSON body for the search endpoint.
+
+        Raises:
+            ValueError: If ``start`` or ``page_size`` is out of range.
+        """
+        if start < 1:
+            raise ValueError(f"start must be >= 1 (1-based page number), got {start}")
+        if page_size < 1:
+            raise ValueError(f"page_size must be >= 1, got {page_size}")
+
+        return {
+            "start": start,
+            "page_size": page_size,
+            "keyword": normalize_symbol(keyword) if keyword else None,
+            "quarter_id": quarter_id,
+            "industries_id": industries_id,
+            "composition_id": composition_id,
+            "type_id": type_id,
+        }
+
+    async def _search_page(
+        self, fetcher: AsyncDataFetcher, body: dict[str, Any], language: str
+    ) -> EarningsCallResponse:
+        """POST a single search page and validate the response."""
+        url = f"{self.base_url}{SET_EARNINGS_CALL_SEARCH_ENDPOINT}"
+        headers = _build_earnings_call_headers(language)
+        logger.debug(
+            f"POST earnings-call search: start={body['start']} page_size={body['page_size']} "
+            f"type_id={body['type_id']} quarter_id={body['quarter_id']} "
+            f"keyword={body['keyword']!r}"
+        )
+        data = await fetcher.fetch_json(url, headers=headers, method="POST", json_body=body)
+        response = validate_or_raise(EarningsCallResponse, data, context="set earnings-call search")
+        logger.info(
+            f"Fetched {response.count} earnings-call item(s) (no_records={response.no_records})"
+        )
+        return response
+
+    async def fetch_earnings_calls(
+        self,
+        *,
+        type_id: int = 1,
+        quarter_id: int = 0,
+        keyword: str | None = None,
+        industries_id: str | None = None,
+        composition_id: int | None = None,
+        start: int = 1,
+        page_size: int = 12,
+        language: str = "en",
+        enrich: bool = False,
+    ) -> EarningsCallResponse:
+        """Fetch one page of earnings-call entries.
+
+        Args:
+            type_id: Presentation type (1 = Earnings Call/OPPDAY, 2 = Digital Roadshow,
+                3 = C-Sign Public Presentation).
+            quarter_id: Quarter filter id (0 = all quarters); see ``fetch_filter_years()``.
+            keyword: Free-text symbol/company search (normalized via ``normalize_symbol``).
+            industries_id: Industry filter code (see ``fetch_filter_industries()``).
+            composition_id: Optional composition/theme filter id.
+            start: 1-based page number.
+            page_size: Items per page.
+            language: ``"en"`` or ``"th"`` (drives ``Accept-Language``).
+            enrich: If True, also fetch per-item detail concurrently (bounded). Off by
+                default — all five required columns come from the list endpoint.
+
+        Returns:
+            An :class:`EarningsCallResponse` for the requested page.
+
+        Raises:
+            ValueError: If ``start``/``page_size`` are out of range or ``language`` is invalid.
+            ResponseParseError: If the response cannot be decoded.
+
+        Example:
+            >>> service = EarningsCallService()
+            >>> response = await service.fetch_earnings_calls(keyword="HANN")
+            >>> response.items[0].youtube_url
+        """
+        language = normalize_language(language)
+        body = self._build_search_body(
+            type_id=type_id,
+            quarter_id=quarter_id,
+            keyword=keyword,
+            industries_id=industries_id,
+            composition_id=composition_id,
+            start=start,
+            page_size=page_size,
+        )
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            response = await self._search_page(fetcher, body, language)
+            if enrich:
+                await self._enrich_items(fetcher, response.items, language)
+            return response
+
+    async def fetch_earnings_calls_raw(
+        self,
+        *,
+        type_id: int = 1,
+        quarter_id: int = 0,
+        keyword: str | None = None,
+        industries_id: str | None = None,
+        composition_id: int | None = None,
+        start: int = 1,
+        page_size: int = 12,
+        language: str = "en",
+    ) -> dict[str, Any]:
+        """Fetch one page as a raw dict (no Pydantic validation).
+
+        Returns:
+            The raw JSON object from the API.
+
+        Raises:
+            ValueError: If ``start``/``page_size`` are out of range or ``language`` is invalid.
+            ResponseParseError: If the response is not a JSON object.
+        """
+        language = normalize_language(language)
+        body = self._build_search_body(
+            type_id=type_id,
+            quarter_id=quarter_id,
+            keyword=keyword,
+            industries_id=industries_id,
+            composition_id=composition_id,
+            start=start,
+            page_size=page_size,
+        )
+        url = f"{self.base_url}{SET_EARNINGS_CALL_SEARCH_ENDPOINT}"
+        headers = _build_earnings_call_headers(language)
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            data: Any = await fetcher.fetch_json(
+                url, headers=headers, method="POST", json_body=body
+            )
+            # Guard the documented dict return type explicitly (asserts are stripped under -O).
+            if not isinstance(data, dict):
+                raise ResponseParseError(
+                    f"Expected a JSON object for set earnings-call search, "
+                    f"got {type(data).__name__}"
+                )
+            logger.debug(f"Raw response keys: {list(data.keys())}")
+            return data
+
+    async def fetch_all_earnings_calls(
+        self,
+        *,
+        type_id: int = 1,
+        quarter_id: int = 0,
+        keyword: str | None = None,
+        industries_id: str | None = None,
+        composition_id: int | None = None,
+        start: int = 1,
+        page_size: int = 50,
+        language: str = "en",
+        enrich: bool = False,
+        max_records: int | None = None,
+        max_pages: int | None = None,
+        throttle: float = 0.3,
+    ) -> EarningsCallResponse:
+        """Auto-paginate across pages, bounded and polite.
+
+        Reuses a single fetcher across pages and sleeps ``throttle`` seconds between page
+        requests. Stops at the first short/empty page, once ``no_records`` is reached, or when
+        a cap is hit.
+
+        Args:
+            max_records: Stop once this many items have been accumulated (then truncate).
+            max_pages: Stop after this many pages.
+            throttle: Delay in seconds between page requests (0 disables).
+            (Other args mirror :meth:`fetch_earnings_calls`.)
+
+        Returns:
+            An :class:`EarningsCallResponse` with the accumulated items and the API's
+            ``no_records`` total.
+
+        Raises:
+            ValueError: If ``max_records``/``max_pages`` are set but < 1, or other inputs are
+                invalid.
+        """
+        language = normalize_language(language)
+        if max_records is not None and max_records < 1:
+            raise ValueError(f"max_records must be >= 1 when set, got {max_records}")
+        if max_pages is not None and max_pages < 1:
+            raise ValueError(f"max_pages must be >= 1 when set, got {max_pages}")
+
+        items: list[EarningsCallItem] = []
+        no_records = 0
+        page = start
+        pages_fetched = 0
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            while True:
+                body = self._build_search_body(
+                    type_id=type_id,
+                    quarter_id=quarter_id,
+                    keyword=keyword,
+                    industries_id=industries_id,
+                    composition_id=composition_id,
+                    start=page,
+                    page_size=page_size,
+                )
+                response = await self._search_page(fetcher, body, language)
+                no_records = response.no_records
+                items.extend(response.items)
+                pages_fetched += 1
+
+                if max_records is not None and len(items) >= max_records:
+                    break
+                if max_pages is not None and pages_fetched >= max_pages:
+                    break
+                if not response.items or len(response.items) < page_size:
+                    break
+                if len(items) >= no_records:
+                    break
+
+                page += 1
+                if throttle > 0:
+                    await asyncio.sleep(throttle)
+
+            if max_records is not None:
+                items = items[:max_records]
+            if enrich:
+                await self._enrich_items(fetcher, items, language)
+
+        logger.info(
+            f"Fetched {len(items)} earnings-call item(s) across {pages_fetched} page(s) "
+            f"(no_records={no_records})"
+        )
+        return EarningsCallResponse(no_records=no_records, items=items)
+
+    async def _fetch_detail(
+        self, fetcher: AsyncDataFetcher, item_id: int, language: str
+    ) -> EarningsCallDetail:
+        """Fetch and validate the detail record for a single item."""
+        endpoint = SET_EARNINGS_CALL_DETAIL_ENDPOINT.format(id=item_id)
+        url = f"{self.base_url}{endpoint}"
+        headers = _build_earnings_call_headers(language)
+        data = await fetcher.fetch_json(url, headers=headers)
+        return validate_or_raise(
+            EarningsCallDetail, data, context=f"set earnings-call detail id={item_id}"
+        )
+
+    async def _enrich_items(
+        self,
+        fetcher: AsyncDataFetcher,
+        items: list[EarningsCallItem],
+        language: str,
+        *,
+        concurrency: int = 5,
+    ) -> None:
+        """Populate ``item.detail`` for each item via bounded-concurrent detail fetches.
+
+        A failed detail fetch is logged and tolerated (that item keeps ``detail=None``); it
+        never fails the whole batch.
+        """
+        if not items:
+            return
+
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _attach(item: EarningsCallItem) -> None:
+            async with semaphore:
+                try:
+                    item.detail = await self._fetch_detail(fetcher, item.id, language)
+                except Exception as exc:  # noqa: BLE001 - tolerate one bad detail, keep the row
+                    logger.warning(
+                        f"Failed to enrich earnings-call item id={item.id} ({item.symbol}): {exc}"
+                    )
+
+        await asyncio.gather(*(_attach(item) for item in items))
+
+    async def _fetch_filter(self, name: str, language: str = "en") -> list[FilterOption]:
+        """Fetch a single filter endpoint and validate it into a list of options."""
+        language = normalize_language(language)
+        endpoint = SET_EARNINGS_CALL_FILTER_ENDPOINT.format(name=name)
+        url = f"{self.base_url}{endpoint}"
+        headers = _build_earnings_call_headers(language)
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            data = await fetcher.fetch_json(url, headers=headers)
+            return validate_list_or_raise(
+                FilterOption, data, context=f"set earnings-call filter/{name}"
+            )
+
+    async def fetch_filter_types(self, language: str = "en") -> list[FilterOption]:
+        """Fetch presentation types (e.g. 1 = Earnings Call/OPPDAY)."""
+        return await self._fetch_filter("types", language)
+
+    async def fetch_filter_years(self, language: str = "en") -> list[FilterOption]:
+        """Fetch quarter/year filter options (ids usable as ``quarter_id``)."""
+        return await self._fetch_filter("years", language)
+
+    async def fetch_filter_industries(self, language: str = "en") -> list[FilterOption]:
+        """Fetch industry filter options (string codes usable as ``industries_id``)."""
+        return await self._fetch_filter("industries", language)
+
+    async def fetch_filter_markets(self, language: str = "en") -> list[FilterOption]:
+        """Fetch market filter options (e.g. SET / mai / LiVEx)."""
+        return await self._fetch_filter("markets", language)
+
+    async def fetch_filter_themes(self, language: str = "en") -> list[FilterOption]:
+        """Fetch theme filter options (e.g. SET50, SET100, SETESG)."""
+        return await self._fetch_filter("themes", language)
+
+    async def fetch_filter_trusts(self, language: str = "en") -> list[FilterOption]:
+        """Fetch trust/security-kind filter options (e.g. Common Stock, REIT)."""
+        return await self._fetch_filter("trusts", language)
+
+    async def fetch_filter_stages(self, language: str = "en") -> list[FilterOption]:
+        """Fetch stage filter options (e.g. Upcoming, Live, Video)."""
+        return await self._fetch_filter("stages", language)
+
+
+async def get_earnings_calls(
+    *,
+    type_id: int = 1,
+    quarter_id: int = 0,
+    keyword: str | None = None,
+    industries_id: str | None = None,
+    composition_id: int | None = None,
+    start: int = 1,
+    page_size: int = 12,
+    language: str = "en",
+    enrich: bool = False,
+    config: FetcherConfig | None = None,
+) -> EarningsCallResponse:
+    """Convenience: fetch one page of earnings-call entries.
+
+    Example:
+        >>> from settfex.services.set import get_earnings_calls
+        >>> response = await get_earnings_calls(keyword="HANN")
+        >>> for item in response.items:
+        ...     print(item.symbol, item.company_name_clean, item.youtube_url)
+    """
+    service = EarningsCallService(config=config)
+    return await service.fetch_earnings_calls(
+        type_id=type_id,
+        quarter_id=quarter_id,
+        keyword=keyword,
+        industries_id=industries_id,
+        composition_id=composition_id,
+        start=start,
+        page_size=page_size,
+        language=language,
+        enrich=enrich,
+    )
+
+
+async def get_earnings_calls_dataframe(
+    *,
+    type_id: int = 1,
+    quarter_id: int = 0,
+    keyword: str | None = None,
+    industries_id: str | None = None,
+    composition_id: int | None = None,
+    start: int = 1,
+    page_size: int = 12,
+    language: str = "en",
+    columns: list[str] | None = None,
+    config: FetcherConfig | None = None,
+) -> "pd.DataFrame":
+    """Convenience: fetch one page and return it as a pandas DataFrame.
+
+    Defaults to the five columns ``stock_name, company_name, earnings_call_date,
+    video_clip_time, youtube_url``. For the full calendar, use
+    :meth:`EarningsCallService.fetch_all_earnings_calls` then :meth:`to_dataframe`.
+
+    Requires pandas (``pip install settfex[dataframe]``).
+
+    Example:
+        >>> from settfex.services.set import get_earnings_calls_dataframe
+        >>> df = await get_earnings_calls_dataframe()
+        >>> list(df.columns)
+        ['stock_name', 'company_name', 'earnings_call_date', 'video_clip_time', 'youtube_url']
+    """
+    response = await get_earnings_calls(
+        type_id=type_id,
+        quarter_id=quarter_id,
+        keyword=keyword,
+        industries_id=industries_id,
+        composition_id=composition_id,
+        start=start,
+        page_size=page_size,
+        language=language,
+        config=config,
+    )
+    return response.to_dataframe(columns=columns)

--- a/settfex/utils/data_fetcher.py
+++ b/settfex/utils/data_fetcher.py
@@ -172,25 +172,44 @@ class AsyncDataFetcher:
             ),
         }
 
-    async def _make_request(self, url: str, headers: dict[str, str]) -> Any:
+    async def _make_request(
+        self,
+        url: str,
+        headers: dict[str, str],
+        *,
+        method: str = "GET",
+        json_body: Any | None = None,
+    ) -> Any:
         """
-        Make HTTP GET request using either persistent session or standalone request.
+        Make an HTTP request using either a persistent session or a standalone request.
 
         Uses SessionManager for automatic cookie handling if use_session=True,
-        otherwise makes standalone request. Automatically detects SET vs TFEX URLs
+        otherwise makes a standalone request. Automatically detects SET vs TFEX URLs
         and uses the appropriate warmup strategy.
 
         Args:
             url: URL to fetch
             headers: HTTP headers to include
+            method: HTTP method, "GET" (default) or "POST"
+            json_body: JSON-serializable body for POST requests (ignored for GET)
 
         Returns:
             Response object from curl_cffi
 
         Raises:
+            NotImplementedError: If a non-GET method is requested with use_session=True
+                (persistent sessions are GET-only; use FetcherConfig(use_session=False)).
             Exception: If request fails
         """
         if self.config.use_session:
+            # Persistent (cookie-warmed) sessions support GET only. Non-GET targets — e.g.
+            # the cookieless opportunity-day API — must use a standalone fetcher
+            # (FetcherConfig(use_session=False)). Fail loudly rather than silently GET.
+            if method != "GET":
+                raise NotImplementedError(
+                    f"{method} via persistent session is not supported; "
+                    "use FetcherConfig(use_session=False) for non-GET requests"
+                )
             # Use persistent session with automatic cookie handling
             # Auto-detects SET vs TFEX based on URL
             from settfex.utils.session_manager import get_session_for_url
@@ -201,9 +220,17 @@ class AsyncDataFetcher:
             return response
         else:
             # Make standalone request (no cookie persistence)
-            logger.debug(f"Making standalone request to {url}")
+            logger.debug(f"Making standalone {method} request to {url}")
 
             def do_request() -> Any:
+                if method == "POST":
+                    return requests.post(
+                        url,
+                        json=json_body,
+                        headers=headers,
+                        timeout=self.config.timeout,
+                        impersonate=self.config.browser_impersonate,  # type: ignore
+                    )
                 return requests.get(
                     url,
                     headers=headers,
@@ -223,6 +250,9 @@ class AsyncDataFetcher:
         self,
         url: str,
         headers: dict[str, str] | None = None,
+        *,
+        method: str = "GET",
+        json_body: Any | None = None,
     ) -> FetchResponse:
         """
         Fetch data from a URL asynchronously with proper Unicode handling.
@@ -236,6 +266,9 @@ class AsyncDataFetcher:
         Args:
             url: URL to fetch
             headers: Optional custom headers (merged with defaults)
+            method: HTTP method, "GET" (default) or "POST". POST requires
+                FetcherConfig(use_session=False).
+            json_body: JSON-serializable body for POST requests (ignored for GET)
 
         Returns:
             FetchResponse with status, content, and metadata
@@ -277,7 +310,9 @@ class AsyncDataFetcher:
                 self._last_request_time = start_time
 
                 # Make request (either via persistent session or standalone)
-                response = await self._make_request(url, default_headers)
+                response = await self._make_request(
+                    url, default_headers, method=method, json_body=json_body
+                )
 
                 elapsed = time.time() - start_time
 
@@ -333,6 +368,9 @@ class AsyncDataFetcher:
         self,
         url: str,
         headers: dict[str, str] | None = None,
+        *,
+        method: str = "GET",
+        json_body: Any | None = None,
     ) -> Any:
         """
         Fetch JSON data from a URL.
@@ -343,6 +381,9 @@ class AsyncDataFetcher:
         Args:
             url: URL to fetch
             headers: Optional custom headers
+            method: HTTP method, "GET" (default) or "POST". POST requires
+                FetcherConfig(use_session=False).
+            json_body: JSON-serializable body for POST requests (ignored for GET)
 
         Returns:
             Parsed JSON data (dict, list, or primitive)
@@ -357,7 +398,7 @@ class AsyncDataFetcher:
         if headers:
             json_headers.update(headers)
 
-        response = await self.fetch(url, headers=json_headers)
+        response = await self.fetch(url, headers=json_headers, method=method, json_body=json_body)
 
         # Decode via the shared helper: rejects NaN/Infinity (silent-corruption guard)
         # and raises ResponseParseError (a ValueError) with URL context on bad JSON.

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -1,0 +1,519 @@
+"""Tests for the SET Earnings Call (Opportunity Day) calendar service.
+
+All HTTP is mocked (the suite runs offline). Fixtures are built from the real payloads
+captured in the opportunity-day HAR.
+"""
+
+import sys
+from datetime import date, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from settfex.services.set.earnings_call import (
+    EarningsCallDetail,
+    EarningsCallItem,
+    EarningsCallResponse,
+    EarningsCallService,
+    FilterOption,
+    get_earnings_calls,
+    get_earnings_calls_dataframe,
+)
+from settfex.utils.parsing import ResponseParseError
+
+# --- payloads from the real HAR ------------------------------------------------------------
+
+MOCK_ITEM = {
+    "id": 10647,
+    "name": "การนำเสนอข้อมูลงบการเงิน ผลการดำเนินงานประจำ Q1/2026",
+    "company_name": "HANN: MUKDAHAN INTERNATIONAL HOSPITAL PUBLIC COMPANY LIMITED",
+    "industry": "Services",
+    "symbol": "HANN",
+    "image_path": "https://img.youtube.com/vi/qCw7HH77f0U/mqdefault.jpg",
+    "view_mode": True,
+    "meeting_date": "2026-06-05T00:00:00Z",
+    "period": "45:00",
+}
+MOCK_ITEM_2 = {
+    "id": 10646,
+    "name": "OPPDAY ACE",
+    "company_name": "ACE: ABSOLUTE CLEAN ENERGY PUBLIC COMPANY LIMITED",
+    "industry": "Resources",
+    "symbol": "ACE",
+    "image_path": "https://img.youtube.com/vi/H-lEE0CWmXg/mqdefault.jpg",
+    "view_mode": True,
+    "meeting_date": "2026-06-04T00:00:00Z",
+    "period": "25:51",
+}
+# Upcoming item with no recording: null image_path/period (null youtube).
+MOCK_UPCOMING = {
+    "id": 99,
+    "name": "OPPDAY PTT",
+    "company_name": "PTT: PTT PUBLIC COMPANY LIMITED",
+    "industry": "Resources",
+    "symbol": "PTT",
+    "image_path": None,
+    "view_mode": False,
+    "meeting_date": "2026-07-01T00:00:00Z",
+    "period": None,
+}
+MOCK_PAGE = {"no_records": 9520, "items": [MOCK_ITEM, MOCK_ITEM_2]}
+
+MOCK_DETAIL = {
+    "id": 10647,
+    "year": 2026,
+    "round": 1,
+    "round_name": "Q1/2026",
+    "type_id": 1,
+    "type": "Earnings Call (OPPDAY)",
+    "company_name": "HANN: MUKDAHAN INTERNATIONAL HOSPITAL PUBLIC COMPANY LIMITED",
+    "company_name_th": "HANN: บริษัท โรงพยาบาลมุกดาหารอินเตอร์เนชั่นแนล จำกัด (มหาชน)",
+    "description": "การนำเสนอข้อมูลงบการเงิน",
+    "meeting_date": "2026-06-05T00:00:00Z",
+    "period": "16:15 - 17:00",
+    "symbol": "HANN",
+    "video_link": "https://www.youtube.com/embed/qCw7HH77f0U?",
+    "document_link": "/file/presentation/10647",
+    "snapshot_link": "https://example.com/snapshot.html",
+    "has_qa": True,
+}
+MOCK_TYPES = [
+    {"id": 1, "name": "Earnings Call (OPPDAY)"},
+    {"id": 3, "name": "C-Sign Public Presentation"},
+    {"id": 2, "name": "Digital Roadshow"},
+]
+MOCK_INDUSTRIES = [
+    {"id": "AGRO", "name": "Agro & Food Industry"},
+    {"id": "SERVICE", "name": "Services"},
+]
+
+
+@pytest.fixture
+def mock_fetcher() -> Any:
+    """Patch AsyncDataFetcher inside the service module and yield its async instance."""
+    with patch("settfex.services.set.earnings_call.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        yield fetcher_instance
+
+
+# --- models --------------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_item_parsing_and_derived_fields(self) -> None:
+        item = EarningsCallItem.model_validate(MOCK_ITEM)
+        assert item.symbol == "HANN"
+        assert item.company_name_clean == "MUKDAHAN INTERNATIONAL HOSPITAL PUBLIC COMPANY LIMITED"
+        assert item.youtube_video_id == "qCw7HH77f0U"
+        assert item.youtube_url == "https://www.youtube.com/watch?v=qCw7HH77f0U"
+
+    def test_meeting_date_is_tz_aware_utc(self) -> None:
+        item = EarningsCallItem.model_validate(MOCK_ITEM)
+        assert isinstance(item.meeting_date, datetime)
+        offset = item.meeting_date.utcoffset()
+        assert offset is not None and offset.total_seconds() == 0  # tz-aware UTC
+        assert item.meeting_date.date() == date(2026, 6, 5)
+
+    def test_company_name_clean_with_special_symbol(self) -> None:
+        # "88TH" contains digits; literal-prefix strip must still work.
+        item = EarningsCallItem.model_validate(
+            {
+                **MOCK_ITEM,
+                "symbol": "88TH",
+                "company_name": "88TH: 88(THAILAND) PUBLIC COMPANY LIMITED",
+            }
+        )
+        assert item.company_name_clean == "88(THAILAND) PUBLIC COMPANY LIMITED"
+
+    def test_company_name_clean_without_prefix(self) -> None:
+        item = EarningsCallItem.model_validate({**MOCK_ITEM, "company_name": "NO PREFIX COMPANY"})
+        assert item.company_name_clean == "NO PREFIX COMPANY"
+
+    def test_youtube_none_when_no_recording(self) -> None:
+        item = EarningsCallItem.model_validate(MOCK_UPCOMING)
+        assert item.youtube_video_id is None
+        assert item.youtube_url is None
+        assert item.period is None
+
+    def test_youtube_none_for_non_youtube_image(self) -> None:
+        item = EarningsCallItem.model_validate(
+            {**MOCK_ITEM, "image_path": "https://example.com/thumb.jpg"}
+        )
+        assert item.youtube_video_id is None
+        assert item.youtube_url is None
+
+    def test_youtube_none_for_empty_image(self) -> None:
+        item = EarningsCallItem.model_validate({**MOCK_ITEM, "image_path": ""})
+        assert item.youtube_url is None
+
+    def test_detail_period_is_aliased_to_meeting_time(self) -> None:
+        detail = EarningsCallDetail.model_validate(MOCK_DETAIL)
+        # The list's `period` is a duration; the detail's `period` is a clock-time range and
+        # must surface separately (never overwriting the list duration).
+        assert detail.meeting_time == "16:15 - 17:00"
+        assert detail.company_name_th.startswith("HANN:")
+        assert detail.video_link == "https://www.youtube.com/embed/qCw7HH77f0U?"
+
+    def test_filter_option_id_types(self) -> None:
+        assert FilterOption.model_validate({"id": 1, "name": "x"}).id == 1
+        assert FilterOption.model_validate({"id": "SERVICE", "name": "Services"}).id == "SERVICE"
+
+    def test_response_count(self) -> None:
+        resp = EarningsCallResponse.model_validate(MOCK_PAGE)
+        assert resp.count == 2
+        assert resp.no_records == 9520
+
+
+# --- to_dataframe --------------------------------------------------------------------------
+
+
+class TestToDataFrame:
+    def test_default_columns_order_and_values(self) -> None:
+        resp = EarningsCallResponse.model_validate(
+            {"no_records": 2, "items": [MOCK_ITEM, MOCK_UPCOMING]}
+        )
+        df = resp.to_dataframe()
+        assert list(df.columns) == [
+            "stock_name",
+            "company_name",
+            "earnings_call_date",
+            "video_clip_time",
+            "youtube_url",
+        ]
+        row0 = df.iloc[0].to_dict()
+        assert row0["stock_name"] == "HANN"
+        assert row0["company_name"] == "MUKDAHAN INTERNATIONAL HOSPITAL PUBLIC COMPANY LIMITED"
+        assert isinstance(row0["earnings_call_date"], date)
+        assert row0["video_clip_time"] == "45:00"
+        assert row0["youtube_url"] == "https://www.youtube.com/watch?v=qCw7HH77f0U"
+        # upcoming row: null youtube + null duration
+        row1 = df.iloc[1].to_dict()
+        assert row1["youtube_url"] is None
+        assert row1["video_clip_time"] is None
+
+    def test_custom_columns(self) -> None:
+        resp = EarningsCallResponse.model_validate(MOCK_PAGE)
+        df = resp.to_dataframe(columns=["id", "youtube_video_id", "company_name_raw"])
+        assert list(df.columns) == ["id", "youtube_video_id", "company_name_raw"]
+        assert df.iloc[0]["id"] == 10647
+        assert df.iloc[0]["company_name_raw"].startswith("HANN:")
+
+    def test_unknown_column_raises(self) -> None:
+        resp = EarningsCallResponse.model_validate(MOCK_PAGE)
+        with pytest.raises(ValueError, match="Unknown DataFrame column"):
+            resp.to_dataframe(columns=["stock_name", "does_not_exist"])
+
+    def test_empty_result_has_columns(self) -> None:
+        resp = EarningsCallResponse.model_validate({"no_records": 0, "items": []})
+        df = resp.to_dataframe()
+        assert len(df) == 0
+        assert list(df.columns) == [
+            "stock_name",
+            "company_name",
+            "earnings_call_date",
+            "video_clip_time",
+            "youtube_url",
+        ]
+
+    def test_pandas_missing_raises_importerror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        resp = EarningsCallResponse.model_validate(MOCK_PAGE)
+        monkeypatch.setitem(sys.modules, "pandas", None)
+        with pytest.raises(ImportError, match="settfex\\[dataframe\\]"):
+            resp.to_dataframe()
+
+
+# --- single-page fetch ---------------------------------------------------------------------
+
+
+class TestFetchEarningsCalls:
+    @pytest.mark.asyncio
+    async def test_fetch_success(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        resp = await EarningsCallService().fetch_earnings_calls()
+        assert isinstance(resp, EarningsCallResponse)
+        assert resp.count == 2
+        assert resp.items[0].symbol == "HANN"
+
+    @pytest.mark.asyncio
+    async def test_body_construction(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        await EarningsCallService().fetch_earnings_calls(
+            type_id=2, quarter_id=20262, keyword="hann", page_size=20, start=3
+        )
+        kwargs = mock_fetcher.fetch_json.call_args.kwargs
+        assert kwargs["method"] == "POST"
+        body = kwargs["json_body"]
+        assert body["type_id"] == 2
+        assert body["quarter_id"] == 20262
+        assert body["keyword"] == "HANN"  # normalized via normalize_symbol
+        assert body["page_size"] == 20
+        assert body["start"] == 3
+
+    @pytest.mark.asyncio
+    async def test_language_drives_accept_language(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        await EarningsCallService().fetch_earnings_calls(language="th")
+        headers = mock_fetcher.fetch_json.call_args.kwargs["headers"]
+        assert headers["Accept-Language"].startswith("th")
+
+    @pytest.mark.asyncio
+    async def test_invalid_page_size_raises(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="page_size"):
+            await EarningsCallService().fetch_earnings_calls(page_size=0)
+
+    @pytest.mark.asyncio
+    async def test_invalid_start_raises(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="start"):
+            await EarningsCallService().fetch_earnings_calls(start=0)
+
+    @pytest.mark.asyncio
+    async def test_invalid_language_raises(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="language"):
+            await EarningsCallService().fetch_earnings_calls(language="xx")
+
+
+class TestFetchRaw:
+    @pytest.mark.asyncio
+    async def test_raw_returns_dict(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        raw = await EarningsCallService().fetch_earnings_calls_raw()
+        assert isinstance(raw, dict)
+        assert raw["no_records"] == 9520
+
+    @pytest.mark.asyncio
+    async def test_raw_rejects_non_dict(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = ["unexpected", "list"]
+        with pytest.raises(ResponseParseError, match="earnings-call search"):
+            await EarningsCallService().fetch_earnings_calls_raw()
+
+
+# --- pagination ----------------------------------------------------------------------------
+
+
+class TestFetchAll:
+    @pytest.mark.asyncio
+    async def test_stops_on_short_page(self, mock_fetcher: Any) -> None:
+        pages = {
+            1: {"no_records": 3, "items": [MOCK_ITEM, MOCK_ITEM_2]},
+            2: {"no_records": 3, "items": [MOCK_UPCOMING]},
+        }
+
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            return pages[k["json_body"]["start"]]
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_all_earnings_calls(page_size=2, throttle=0)
+        assert resp.count == 3
+        assert resp.no_records == 3
+        assert mock_fetcher.fetch_json.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stops_at_no_records(self, mock_fetcher: Any) -> None:
+        # Every page is full (2 items) but no_records caps the crawl at 4.
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            return {"no_records": 4, "items": [MOCK_ITEM, MOCK_ITEM_2]}
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_all_earnings_calls(page_size=2, throttle=0)
+        assert resp.count == 4
+        assert mock_fetcher.fetch_json.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_records_cap(self, mock_fetcher: Any) -> None:
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            return {"no_records": 100, "items": [MOCK_ITEM, MOCK_ITEM_2]}
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_all_earnings_calls(
+            page_size=2, max_records=3, throttle=0
+        )
+        assert resp.count == 3  # truncated
+        assert mock_fetcher.fetch_json.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_pages_cap(self, mock_fetcher: Any) -> None:
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            return {"no_records": 100, "items": [MOCK_ITEM, MOCK_ITEM_2]}
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_all_earnings_calls(
+            page_size=2, max_pages=2, throttle=0
+        )
+        assert resp.count == 4
+        assert mock_fetcher.fetch_json.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_invalid_caps_raise(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="max_records"):
+            await EarningsCallService().fetch_all_earnings_calls(max_records=0, throttle=0)
+        with pytest.raises(ValueError, match="max_pages"):
+            await EarningsCallService().fetch_all_earnings_calls(max_pages=0, throttle=0)
+
+
+# --- enrichment ----------------------------------------------------------------------------
+
+
+class TestEnrich:
+    @pytest.mark.asyncio
+    async def test_enrich_attaches_detail(self, mock_fetcher: Any) -> None:
+        page = {"no_records": 2, "items": [MOCK_ITEM, MOCK_UPCOMING]}
+
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            if url.endswith("/search/archive"):
+                return page
+            if url.endswith("/vdo/10647"):
+                return MOCK_DETAIL
+            if url.endswith("/vdo/99"):
+                return {"id": 99, "period": "10:00 - 11:00", "symbol": "PTT"}
+            raise AssertionError(f"unexpected url {url}")
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_earnings_calls(enrich=True)
+        by_id = {item.id: item for item in resp.items}
+        assert by_id[10647].detail is not None
+        assert by_id[10647].detail.meeting_time == "16:15 - 17:00"
+        assert by_id[99].detail is not None
+        assert by_id[99].detail.meeting_time == "10:00 - 11:00"
+
+    @pytest.mark.asyncio
+    async def test_enrich_tolerates_detail_failure(self, mock_fetcher: Any) -> None:
+        page = {"no_records": 2, "items": [MOCK_ITEM, MOCK_UPCOMING]}
+
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            if url.endswith("/search/archive"):
+                return page
+            if url.endswith("/vdo/10647"):
+                return MOCK_DETAIL
+            raise ResponseParseError("detail boom")
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_earnings_calls(enrich=True)
+        by_id = {item.id: item for item in resp.items}
+        assert by_id[10647].detail is not None  # succeeded
+        assert by_id[99].detail is None  # failed but tolerated
+
+
+# --- filter helpers ------------------------------------------------------------------------
+
+
+class TestFilters:
+    @pytest.mark.asyncio
+    async def test_fetch_filter_types(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_TYPES
+        options = await EarningsCallService().fetch_filter_types()
+        assert [o.id for o in options] == [1, 3, 2]
+        assert options[0].name == "Earnings Call (OPPDAY)"
+
+    @pytest.mark.asyncio
+    async def test_fetch_filter_industries_string_ids(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_INDUSTRIES
+        options = await EarningsCallService().fetch_filter_industries()
+        assert options[0].id == "AGRO"
+        assert options[1].id == "SERVICE"
+
+    @pytest.mark.asyncio
+    async def test_filter_rejects_non_list(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = {"unexpected": "object"}
+        with pytest.raises(ResponseParseError, match="filter/markets"):
+            await EarningsCallService().fetch_filter_markets()
+
+
+# --- error paths ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_fetch_propagates_request_error(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = Exception("HTTP 500")
+        with pytest.raises(Exception, match="HTTP 500"):
+            await EarningsCallService().fetch_earnings_calls()
+
+    @pytest.mark.asyncio
+    async def test_fetch_propagates_parse_error(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = ResponseParseError("bad json")
+        with pytest.raises(ResponseParseError):
+            await EarningsCallService().fetch_earnings_calls()
+
+    @pytest.mark.asyncio
+    async def test_empty_items(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = {"no_records": 0, "items": []}
+        resp = await EarningsCallService().fetch_earnings_calls()
+        assert resp.count == 0
+        assert len(resp.to_dataframe()) == 0
+
+
+# --- convenience functions -----------------------------------------------------------------
+
+
+class TestCoverageExtras:
+    """Cheap tests for safety-net branches and the thin filter-helper passthroughs."""
+
+    def test_meeting_date_naive_assumed_utc(self) -> None:
+        # If the API ever omits the offset, the validator must attach UTC.
+        item = EarningsCallItem.model_validate({**MOCK_ITEM, "meeting_date": "2026-06-05T00:00:00"})
+        offset = item.meeting_date.utcoffset()
+        assert offset is not None and offset.total_seconds() == 0
+
+    @pytest.mark.asyncio
+    async def test_enrich_empty_items_is_noop(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = {"no_records": 0, "items": []}
+        resp = await EarningsCallService().fetch_earnings_calls(enrich=True)
+        assert resp.count == 0
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_with_enrich(self, mock_fetcher: Any) -> None:
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            if url.endswith("/search/archive"):
+                return {"no_records": 1, "items": [MOCK_ITEM]}
+            return MOCK_DETAIL
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        resp = await EarningsCallService().fetch_all_earnings_calls(
+            page_size=2, enrich=True, throttle=0
+        )
+        assert resp.items[0].detail is not None
+        assert resp.items[0].detail.meeting_time == "16:15 - 17:00"
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "fetch_filter_types",
+            "fetch_filter_years",
+            "fetch_filter_industries",
+            "fetch_filter_markets",
+            "fetch_filter_themes",
+            "fetch_filter_trusts",
+            "fetch_filter_stages",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_all_filter_helpers(self, mock_fetcher: Any, method_name: str) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_TYPES
+        options = await getattr(EarningsCallService(), method_name)()
+        assert len(options) == 3
+        assert isinstance(options[0], FilterOption)
+
+
+class TestConvenience:
+    @pytest.mark.asyncio
+    async def test_get_earnings_calls(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        resp = await get_earnings_calls(keyword="HANN")
+        assert isinstance(resp, EarningsCallResponse)
+        assert resp.count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_earnings_calls_dataframe(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_PAGE
+        df = await get_earnings_calls_dataframe()
+        assert list(df.columns) == [
+            "stock_name",
+            "company_name",
+            "earnings_call_date",
+            "video_clip_time",
+            "youtube_url",
+        ]
+        assert len(df) == 2

--- a/tests/utils/test_data_fetcher.py
+++ b/tests/utils/test_data_fetcher.py
@@ -424,3 +424,99 @@ class TestAsyncDataFetcher:
             response = await fetcher.fetch("https://example.com")
 
         assert response.elapsed >= 0.1
+
+
+class TestAsyncDataFetcherPost:
+    """Tests for the POST support added to AsyncDataFetcher (backward-compatible)."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_defaults_to_get(self) -> None:
+        """fetch() defaults to GET and forwards method/json_body to _make_request."""
+        fetcher = AsyncDataFetcher()
+        mock_response = Mock(status_code=200, content=b"ok", headers={}, url="https://example.com")
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response) as mock:
+            await fetcher.fetch("https://example.com")
+
+        assert mock.call_args.kwargs["method"] == "GET"
+        assert mock.call_args.kwargs["json_body"] is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_post_forwards_method_and_body(self) -> None:
+        """fetch(method='POST', json_body=...) forwards both onward."""
+        fetcher = AsyncDataFetcher()
+        body = {"start": 1, "page_size": 12, "type_id": 1}
+        mock_response = Mock(status_code=200, content=b"{}", headers={}, url="https://api.x/search")
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response) as mock:
+            await fetcher.fetch("https://api.x/search", method="POST", json_body=body)
+
+        assert mock.call_args.kwargs["method"] == "POST"
+        assert mock.call_args.kwargs["json_body"] == body
+
+    @pytest.mark.asyncio
+    async def test_fetch_json_post_returns_parsed_body(self) -> None:
+        """fetch_json supports POST and still routes through the hardened decoder."""
+        fetcher = AsyncDataFetcher()
+        payload = {"no_records": 2, "items": []}
+        mock_response = Mock(
+            status_code=200,
+            content=json.dumps(payload).encode("utf-8"),
+            headers={},
+            url="https://api.x/search",
+        )
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response) as mock:
+            data = await fetcher.fetch_json(
+                "https://api.x/search", method="POST", json_body={"start": 1}
+            )
+
+        assert data == payload
+        assert mock.call_args.kwargs["method"] == "POST"
+        assert mock.call_args.kwargs["json_body"] == {"start": 1}
+
+    @pytest.mark.asyncio
+    async def test_post_via_session_raises(self) -> None:
+        """POST via a persistent session is unsupported and must fail loudly."""
+        fetcher = AsyncDataFetcher()  # default use_session=True
+        with pytest.raises(NotImplementedError, match="POST"):
+            await fetcher._make_request(
+                "https://api.x/search", {}, method="POST", json_body={"a": 1}
+            )
+
+    @pytest.mark.asyncio
+    async def test_standalone_post_calls_requests_post(self) -> None:
+        """Standalone POST issues a curl_cffi POST carrying the JSON body."""
+        fetcher = AsyncDataFetcher(config=FetcherConfig(use_session=False))
+        body = {"start": 1, "type_id": 1}
+        mock_resp = Mock(status_code=200)
+
+        with patch("settfex.utils.data_fetcher.requests") as mock_requests:
+            mock_requests.post.return_value = mock_resp
+            result = await fetcher._make_request(
+                "https://api.x/search",
+                {"Origin": "https://opportunity-day.setgroup.or.th"},
+                method="POST",
+                json_body=body,
+            )
+
+        assert result is mock_resp
+        assert mock_requests.post.called
+        assert mock_requests.get.called is False
+        kwargs = mock_requests.post.call_args.kwargs
+        assert kwargs["json"] == body
+        assert kwargs["headers"]["Origin"] == "https://opportunity-day.setgroup.or.th"
+
+    @pytest.mark.asyncio
+    async def test_standalone_get_unchanged(self) -> None:
+        """Standalone GET still uses requests.get (no regression)."""
+        fetcher = AsyncDataFetcher(config=FetcherConfig(use_session=False))
+        mock_resp = Mock(status_code=200)
+
+        with patch("settfex.utils.data_fetcher.requests") as mock_requests:
+            mock_requests.get.return_value = mock_resp
+            result = await fetcher._make_request("https://example.com", {})
+
+        assert result is mock_resp
+        assert mock_requests.get.called
+        assert mock_requests.post.called is False

--- a/uv.lock
+++ b/uv.lock
@@ -2955,6 +2955,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dataframe = [
+    { name = "pandas" },
+]
 examples = [
     { name = "jupyter" },
     { name = "matplotlib" },
@@ -2967,6 +2970,7 @@ dev = [
     { name = "bandit" },
     { name = "build" },
     { name = "mypy" },
+    { name = "pandas" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -2984,16 +2988,18 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.7.0" },
     { name = "notebook", marker = "extra == 'examples'", specifier = ">=7.0.0" },
+    { name = "pandas", marker = "extra == 'dataframe'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'examples'", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
 ]
-provides-extras = ["examples"]
+provides-extras = ["dataframe", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.7" },
     { name = "build", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.18.2" },
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.4.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Adds a new SET **Earnings Call (Opportunity Day / OPPDAY)** calendar service and the small
HTTP capability it needs, then bumps the version for the **0.4.0** release. Purely additive —
no existing public API changes.

### New service — `settfex.services.set.earnings_call`
- Fetches the OPPDAY calendar from the stateless opportunity-day backend
  (`POST https://api.lcp.setgroup.or.th/api/v1/investor/search/archive`) as typed Pydantic
  models **plus** an optional pandas DataFrame.
- `EarningsCallService`: `fetch_earnings_calls` / `_raw`, bounded `fetch_all_earnings_calls`,
  opt-in concurrent `enrich=True`, and seven filter helpers.
- Models: `EarningsCallItem` (derived `company_name_clean` / `youtube_video_id` /
  `youtube_url`), `EarningsCallResponse.to_dataframe()`, `EarningsCallDetail`, `FilterOption`.
- Convenience: `get_earnings_calls`, `get_earnings_calls_dataframe`. Not stock-scoped.
- DataFrame default columns: `stock_name, company_name, earnings_call_date, video_clip_time,
  youtube_url`.

### `AsyncDataFetcher` POST support
- `fetch()` / `fetch_json()` gain keyword-only `method="GET"` (default → fully backward
  compatible) and `json_body`. POST uses the standalone (sessionless) path and the same
  NaN-rejecting decoder; POST via a persistent session raises `NotImplementedError`.

### Packaging
- pandas is an optional `dataframe` extra (lazy-imported); added to the dev group so CI runs
  the DataFrame tests. Importing the library never requires pandas.

### The `period` ambiguity (handled)
List `period` = clip **duration** (`"45:00"`) → `video_clip_time`, authoritative and never
overwritten. Detail `period` = meeting **clock-time range** (`"16:15 - 17:00"`) → surfaced
separately as `EarningsCallDetail.meeting_time`.

## Tests & quality
- 212 tests pass; **99%** coverage on the new module. All HTTP mocked (offline suite).
- ruff, ruff format, mypy --strict all clean; `uv lock --check` clean.
- Verified end-to-end against the **live** API (list, DataFrame, keyword filter, filters,
  enrichment).

## Release
Promotes `0.3.0 → 0.4.0` (`pyproject.toml`, `settfex/__init__.py`, `uv.lock`) and finalizes the
`## [0.4.0]` CHANGELOG section. After merge, pushing the `v0.4.0` tag triggers the OIDC PyPI
publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)