### PR TITLE
fix: tolerate null industry + add OPPDAY detail-by-id getter (release 0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Earnings Call: tolerate `industry: null`.** The OPPDAY list returns `industry: null` for a
+  handful of newly-listed companies (e.g. `ISTORE22`), so fetching deeper pages or a large
+  `page_size` raised a `ValidationError` (`EarningsCallItem.industry` was a required string). It
+  is now `str | None`. Note: `page_size` is **not** capped by the API — a single request can
+  return the entire archive; an earlier doc note claiming a ~100 cap was incorrect and has been
+  removed.
+
 ## [0.4.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-19
+
+### Added
+
+- **`get_earnings_call_detail(id)`** / `EarningsCallService.fetch_earnings_call_detail(id)` —
+  fetch a single OPPDAY presentation directly by its id (the number in an opportunity-day
+  `/vdo/{id}` URL), without going through a list + `enrich`.
+- `EarningsCallDetail` now exposes derived **`youtube_video_id` / `youtube_url`** (built from the
+  clean `image_path`) and strips stray whitespace from `video_link` — a few legacy records embed
+  a newline mid-URL (e.g. `vdo/6319`); `image_path` was added to the model.
+
 ### Fixed
 
 - **Earnings Call: tolerate `industry: null`.** The OPPDAY list returns `industry: null` for a

--- a/docs/settfex/services/set/earnings_call.md
+++ b/docs/settfex/services/set/earnings_call.md
@@ -107,10 +107,9 @@ response = await EarningsCallService().fetch_earnings_calls(
 Auto-paginates, **bounded and polite** — reuses one fetcher, sleeps `throttle` seconds between
 pages, and stops at the first short page, once `no_records` is reached, or when a cap is hit.
 
-> The API honors `page_size` up to ~100 but **rejects very large values** (e.g. 500), which
-> surfaces as a clear `ResponseParseError`/`ValidationError`. The defaults (12 for a single
-> page, 50 for `fetch_all`) stay safely under the cap — prefer iterating pages over an
-> oversized `page_size`.
+> `page_size` is **not** capped by the API — a single request can return the entire archive
+> (verified at `page_size=9520`). `fetch_all` still paginates politely by default; prefer it,
+> or a modest `page_size`, over one huge request to keep memory and server load reasonable.
 
 ```python
 service = EarningsCallService()

--- a/docs/settfex/services/set/earnings_call.md
+++ b/docs/settfex/services/set/earnings_call.md
@@ -70,10 +70,13 @@ asyncio.run(main())
   `youtube_video_id`, `id`, `name`, `industry`, `view_mode`. Unknown column → `ValueError`;
   pandas missing → `ImportError`.
 
-### `EarningsCallDetail` (enrichment)
+### `EarningsCallDetail` (enrichment / detail-by-id)
 
 `video_link`, `company_name_th`, `meeting_time` (the clock-time range), `document_link`,
-`snapshot_link`, `round_name`, `type`, `type_id`, `year`, `round`, `has_qa`, …
+`snapshot_link`, `round_name`, `type`, `type_id`, `year`, `round`, `has_qa`, `image_path`, …
+plus **derived** `youtube_video_id` / `youtube_url` (built from the clean `image_path`, so a
+malformed `video_link` can't break the link — `video_link` itself is also whitespace-cleaned,
+since a few legacy records embed a stray newline mid-URL).
 
 ### `FilterOption`
 
@@ -121,6 +124,17 @@ df = response.to_dataframe()
 
 Raw JSON dict (no validation), for debugging.
 
+#### `fetch_earnings_call_detail(id, language="en") -> EarningsCallDetail`
+
+Fetch one OPPDAY presentation directly by its id — the number in a
+`https://opportunity-day.setgroup.or.th/en/vdo/{id}` URL:
+
+```python
+detail = await EarningsCallService().fetch_earnings_call_detail(6319)
+print(detail.symbol, detail.round_name, detail.youtube_url)
+# SCB  YE/2021  https://www.youtube.com/watch?v=eOC0S8A4QEE
+```
+
 #### Filter helpers
 
 `fetch_filter_types()`, `fetch_filter_years()`, `fetch_filter_industries()`,
@@ -131,9 +145,10 @@ Raw JSON dict (no validation), for debugging.
 
 - `get_earnings_calls(...) -> EarningsCallResponse`
 - `get_earnings_calls_dataframe(..., columns=None) -> pandas.DataFrame`
+- `get_earnings_call_detail(id, language="en") -> EarningsCallDetail`
 
-Both fetch a **single page** by default (mirroring `get_stock_list`). For the full calendar,
-use `fetch_all_earnings_calls()` then `to_dataframe()`.
+The list functions fetch a **single page** by default (mirroring `get_stock_list`). For the
+full calendar, use `fetch_all_earnings_calls()` then `to_dataframe()`.
 
 ## Usage Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.4.0"
+version = "0.4.1"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -26,6 +26,7 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    get_earnings_call_detail,
     get_earnings_calls,
     get_earnings_calls_dataframe,
 )
@@ -110,6 +111,7 @@ __all__ = [
     "FilterOption",
     "get_earnings_calls",
     "get_earnings_calls_dataframe",
+    "get_earnings_call_detail",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/earnings_call.py
+++ b/settfex/services/set/earnings_call.py
@@ -138,9 +138,34 @@ class EarningsCallDetail(BaseModel):
     snapshot_link: str | None = Field(default=None, description="Listed-company snapshot URL")
     company_link: str | None = Field(default=None, description="SET company profile URL")
     logo_path: str | None = Field(default=None, description="Company logo URL")
+    image_path: str | None = Field(default=None, description="YouTube thumbnail URL")
     has_qa: bool | None = Field(default=None, description="Whether a Q&A is available")
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore", str_strip_whitespace=True)
+
+    @field_validator("video_link")
+    @classmethod
+    def _clean_video_link(cls, value: str | None) -> str | None:
+        """Remove stray internal whitespace (some old records embed a newline mid-URL)."""
+        if value is None:
+            return None
+        return "".join(value.split())
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def youtube_video_id(self) -> str | None:
+        """YouTube video id derived from the (clean) thumbnail ``image_path``.
+
+        Preferred over ``video_link``, which a few legacy records return malformed.
+        """
+        return _extract_youtube_id(self.image_path)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def youtube_url(self) -> str | None:
+        """Canonical ``https://www.youtube.com/watch?v=<id>`` URL, or ``None``."""
+        video_id = self.youtube_video_id
+        return f"https://www.youtube.com/watch?v={video_id}" if video_id else None
 
 
 class EarningsCallItem(BaseModel):
@@ -562,6 +587,35 @@ class EarningsCallService:
             EarningsCallDetail, data, context=f"set earnings-call detail id={item_id}"
         )
 
+    async def fetch_earnings_call_detail(
+        self, item_id: int, language: str = "en"
+    ) -> EarningsCallDetail:
+        """Fetch a single OPPDAY presentation's detail by its id.
+
+        This is the typed detail behind an
+        ``https://opportunity-day.setgroup.or.th/<lang>/vdo/{id}`` page
+        (``GET /investor/vdo/{id}``).
+
+        Args:
+            item_id: The presentation/event id (e.g. ``6319``).
+            language: ``"en"`` or ``"th"``.
+
+        Returns:
+            The :class:`EarningsCallDetail` for ``item_id``.
+
+        Raises:
+            ValueError: If ``language`` is invalid.
+            ResponseParseError: If the response cannot be decoded.
+
+        Example:
+            >>> service = EarningsCallService()
+            >>> detail = await service.fetch_earnings_call_detail(6319)
+            >>> detail.symbol, detail.round_name, detail.youtube_url
+        """
+        language = normalize_language(language)
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            return await self._fetch_detail(fetcher, item_id, language)
+
     async def _enrich_items(
         self,
         fetcher: AsyncDataFetcher,
@@ -707,3 +761,21 @@ async def get_earnings_calls_dataframe(
         config=config,
     )
     return response.to_dataframe(columns=columns)
+
+
+async def get_earnings_call_detail(
+    item_id: int,
+    language: str = "en",
+    config: FetcherConfig | None = None,
+) -> EarningsCallDetail:
+    """Convenience: fetch a single OPPDAY presentation's detail by id.
+
+    The ``id`` is the number in an opportunity-day ``/vdo/{id}`` URL.
+
+    Example:
+        >>> from settfex.services.set import get_earnings_call_detail
+        >>> detail = await get_earnings_call_detail(6319)
+        >>> print(detail.symbol, detail.round_name, detail.youtube_url)
+    """
+    service = EarningsCallService(config=config)
+    return await service.fetch_earnings_call_detail(item_id, language=language)

--- a/settfex/services/set/earnings_call.py
+++ b/settfex/services/set/earnings_call.py
@@ -149,7 +149,10 @@ class EarningsCallItem(BaseModel):
     id: int = Field(description="Unique presentation/event id")
     name: str = Field(description="Presentation title (Thai, as shown on the card)")
     company_name: str = Field(description='Raw company name, prefixed "<SYMBOL>: ..."')
-    industry: str = Field(default="", description="Industry classification")
+    industry: str | None = Field(
+        default=None,
+        description="Industry classification (None for newly-listed companies not yet classified)",
+    )
     symbol: str = Field(description="Stock symbol/ticker")
     image_path: str | None = Field(
         default=None, description="YouTube thumbnail URL (present only when recorded)"

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -17,6 +17,7 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    get_earnings_call_detail,
     get_earnings_calls,
     get_earnings_calls_dataframe,
 )
@@ -74,6 +75,7 @@ MOCK_DETAIL = {
     "period": "16:15 - 17:00",
     "symbol": "HANN",
     "video_link": "https://www.youtube.com/embed/qCw7HH77f0U?",
+    "image_path": "https://img.youtube.com/vi/qCw7HH77f0U/maxresdefault.jpg",
     "document_link": "/file/presentation/10647",
     "snapshot_link": "https://example.com/snapshot.html",
     "has_qa": True,
@@ -156,6 +158,26 @@ class TestModels:
         assert detail.meeting_time == "16:15 - 17:00"
         assert detail.company_name_th.startswith("HANN:")
         assert detail.video_link == "https://www.youtube.com/embed/qCw7HH77f0U?"
+
+    def test_detail_derives_youtube_from_image_path(self) -> None:
+        detail = EarningsCallDetail.model_validate(MOCK_DETAIL)
+        assert detail.youtube_video_id == "qCw7HH77f0U"
+        assert detail.youtube_url == "https://www.youtube.com/watch?v=qCw7HH77f0U"
+        # no image_path -> None
+        assert EarningsCallDetail.model_validate({"id": 1}).youtube_url is None
+
+    def test_detail_cleans_malformed_video_link(self) -> None:
+        # Some legacy records (e.g. vdo/6319) embed a stray newline mid-URL.
+        detail = EarningsCallDetail.model_validate(
+            {
+                "id": 6319,
+                "video_link": "https://www.youtube.com/embed/eOC0S8A4QEE\n?",
+                "image_path": "https://img.youtube.com/vi/eOC0S8A4QEE/maxresdefault.jpg",
+            }
+        )
+        assert detail.video_link == "https://www.youtube.com/embed/eOC0S8A4QEE?"
+        # youtube_url comes from the clean image_path, never the malformed video_link
+        assert detail.youtube_url == "https://www.youtube.com/watch?v=eOC0S8A4QEE"
 
     def test_filter_option_id_types(self) -> None:
         assert FilterOption.model_validate({"id": 1, "name": "x"}).id == 1
@@ -508,6 +530,32 @@ class TestCoverageExtras:
         options = await getattr(EarningsCallService(), method_name)()
         assert len(options) == 3
         assert isinstance(options[0], FilterOption)
+
+
+class TestDetailById:
+    @pytest.mark.asyncio
+    async def test_fetch_earnings_call_detail(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_DETAIL
+        detail = await EarningsCallService().fetch_earnings_call_detail(10647)
+        assert isinstance(detail, EarningsCallDetail)
+        assert detail.id == 10647
+        assert detail.symbol == "HANN"
+        assert detail.meeting_time == "16:15 - 17:00"
+        assert detail.youtube_url == "https://www.youtube.com/watch?v=qCw7HH77f0U"
+        # GET hits the /investor/vdo/{id} endpoint
+        assert mock_fetcher.fetch_json.call_args.args[0].endswith("/investor/vdo/10647")
+
+    @pytest.mark.asyncio
+    async def test_get_earnings_call_detail(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_DETAIL
+        detail = await get_earnings_call_detail(10647)
+        assert isinstance(detail, EarningsCallDetail)
+        assert detail.id == 10647
+
+    @pytest.mark.asyncio
+    async def test_fetch_detail_invalid_language(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="language"):
+            await EarningsCallService().fetch_earnings_call_detail(10647, language="xx")
 
 
 class TestConvenience:

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -166,6 +166,19 @@ class TestModels:
         assert resp.count == 2
         assert resp.no_records == 9520
 
+    def test_industry_can_be_null(self) -> None:
+        # Newly-listed companies (e.g. ISTORE22) come back with industry=null in the OPPDAY
+        # list; this must not fail validation (regression: large page_size / deep pages).
+        item = EarningsCallItem.model_validate({**MOCK_ITEM, "industry": None})
+        assert item.industry is None
+        # derived fields and the DataFrame still work with a null industry
+        assert item.youtube_url == "https://www.youtube.com/watch?v=qCw7HH77f0U"
+        resp = EarningsCallResponse.model_validate(
+            {"no_records": 1, "items": [{**MOCK_ITEM, "industry": None}]}
+        )
+        df = resp.to_dataframe(columns=["stock_name", "industry"])
+        assert df.iloc[0]["industry"] is None
+
 
 # --- to_dataframe --------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Patch release **0.4.1** addressing real-world OPPDAY data hit right after 0.4.0.

### Fixed
- **`industry: null` is now tolerated.** The OPPDAY list returns `industry: null` for a handful
  of newly-listed companies (e.g. `ISTORE22`), so fetching deeper pages or a large `page_size`
  raised a `ValidationError` (`EarningsCallItem.industry` was a required string). Now `str | None`.
- Corrected a wrong doc note: **`page_size` is not capped** by the API (verified to 9520 in one
  request); the earlier "rejected above ~100" claim was actually this null-industry error.

### Added
- **`get_earnings_call_detail(id)`** / `EarningsCallService.fetch_earnings_call_detail(id)` —
  fetch a single OPPDAY presentation by its id (the number in a `/vdo/{id}` URL), without a
  list + `enrich`.
- `EarningsCallDetail` now exposes derived **`youtube_video_id` / `youtube_url`** (from the clean
  `image_path`) and strips stray whitespace from `video_link` — a few legacy records (e.g.
  `vdo/6319`) embed a newline mid-URL. Added `image_path` to the detail model.

## Tests & quality
- 218 tests pass (+6); 99% coverage on the earnings-call module. All HTTP mocked.
- ruff, ruff format, mypy --strict clean; `uv lock --check` clean.

## Release
Bumps `0.4.0 → 0.4.1`. After merge, the `v0.4.1` tag triggers the OIDC PyPI publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)