### PR TITLE
feat: concurrent fetch_all earnings calls + progress bar (release 0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-19
+
+### Added
+
+- **Concurrent `fetch_all_earnings_calls` + an optional progress bar.** Fetching the whole OPPDAY
+  archive now fetches pages **concurrently** (bounded by `max_concurrency`, default 5) after
+  learning the total from page 1, so the full ~9520-record crawl drops from **~150 s to ~15 s
+  (~10× faster)** at the default concurrency. Opt into a `tqdm` progress bar with `progress=True`
+  (new optional `progress` extra:
+  `pip install "settfex[progress]"`), or pass a dependency-free `progress_callback(done, total)`;
+  both also cover the `enrich=True` phase.
+- **`get_all_earnings_calls(...)`** convenience — fetch the entire calendar in one concurrent call.
+
+### Changed
+
+- `fetch_all_earnings_calls` defaults: `page_size` 50 → 200 (fewer requests; the API does not cap
+  `page_size`) and `throttle` 0.3 → 0.0 (the concurrency bound now governs load). Results and item
+  ordering are unchanged.
+
 ## [0.4.1] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -399,6 +399,11 @@ df = await get_earnings_calls_dataframe()
 
 # Search one company, or filter by quarter/type
 hann = await get_earnings_calls(keyword="HANN")
+
+# Grab the WHOLE archive fast — pages are fetched concurrently, with an optional progress bar
+# (pip install "settfex[progress]"):
+from settfex.services.set import get_all_earnings_calls
+everything = await get_all_earnings_calls(progress=True)   # ~9520 records in ~15s (~10x faster)
 ```
 
 **👉 [Learn more about the Earnings Call Service](docs/settfex/services/set/earnings_call.md)**

--- a/docs/settfex/services/set/earnings_call.md
+++ b/docs/settfex/services/set/earnings_call.md
@@ -105,19 +105,29 @@ response = await EarningsCallService().fetch_earnings_calls(
 )
 ```
 
-#### `fetch_all_earnings_calls(..., max_records=None, max_pages=None, throttle=0.3)`
+#### `fetch_all_earnings_calls(..., page_size=200, max_concurrency=5, progress=False, progress_callback=None, max_records=None, max_pages=None)`
 
-Auto-paginates, **bounded and polite** — reuses one fetcher, sleeps `throttle` seconds between
-pages, and stops at the first short page, once `no_records` is reached, or when a cap is hit.
+Auto-paginates the **whole** archive **concurrently**: fetches page 1 to learn the total, then
+fetches the remaining pages in parallel (bounded by `max_concurrency`, default 5) and reassembles
+items in order. Far faster than one page at a time — fetching all ~9520 records drops from
+**~150 s to ~15 s (~10× faster)** at the default concurrency, and more with a higher
+`max_concurrency`.
 
-> `page_size` is **not** capped by the API — a single request can return the entire archive
-> (verified at `page_size=9520`). `fetch_all` still paginates politely by default; prefer it,
-> or a modest `page_size`, over one huge request to keep memory and server load reasonable.
+- **Speed**: `page_size` is **not** capped by the API (a larger page = fewer requests); the
+  default is 200. `max_concurrency` bounds simultaneous load (politeness).
+- **Progress**: pass `progress=True` for a `tqdm` bar (`pip install "settfex[progress]"`), or a
+  `progress_callback(done, total)` for a dependency-free hook. Both cover the page phase and,
+  when `enrich=True`, the enrichment phase.
 
 ```python
 service = EarningsCallService()
-response = await service.fetch_all_earnings_calls(max_records=200)  # at most 200, polite
+response = await service.fetch_all_earnings_calls(progress=True)   # whole archive, with a bar
 df = response.to_dataframe()
+
+# bounded + a custom progress hook:
+response = await service.fetch_all_earnings_calls(
+    max_records=2000, max_concurrency=8, progress_callback=lambda done, total: None
+)
 ```
 
 #### `fetch_earnings_calls_raw(...) -> dict`
@@ -146,9 +156,12 @@ print(detail.symbol, detail.round_name, detail.youtube_url)
 - `get_earnings_calls(...) -> EarningsCallResponse`
 - `get_earnings_calls_dataframe(..., columns=None) -> pandas.DataFrame`
 - `get_earnings_call_detail(id, language="en") -> EarningsCallDetail`
+- `get_all_earnings_calls(..., progress=False, max_concurrency=5) -> EarningsCallResponse` — the
+  whole calendar in one concurrent call
 
-The list functions fetch a **single page** by default (mirroring `get_stock_list`). For the
-full calendar, use `fetch_all_earnings_calls()` then `to_dataframe()`.
+`get_earnings_calls(...)` fetches a **single page** by default (mirroring `get_stock_list`); use
+`get_all_earnings_calls(progress=True)` (or `fetch_all_earnings_calls`) for the full calendar,
+then `to_dataframe()`.
 
 ## Usage Examples
 

--- a/examples/set/12_earnings_call.ipynb
+++ b/examples/set/12_earnings_call.ipynb
@@ -147,10 +147,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Fetch more pages (bounded) and export to CSV\n",
-    "\n",
-    "`fetch_all_earnings_calls` auto-paginates politely. Always cap it with `max_records` /\n",
-    "`max_pages` — the full archive is thousands of rows."
+    "## 5. Fetch the whole archive (concurrent) and export to CSV\n\n",
+    "\n\n",
+    "`get_all_earnings_calls` fetches pages **concurrently** (fast) and can show a `tqdm`\n\n",
+    "progress bar with `progress=True`. Bound large runs with `max_records` / `max_pages`."
    ]
   },
   {
@@ -159,17 +159,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "full = await service.fetch_all_earnings_calls(max_records=100, throttle=0.3)\n",
+    "# get_all_earnings_calls fetches pages concurrently (fast). progress=True shows a\n",
+    "# tqdm bar (pip install \"settfex[progress]\"). Bound large runs with max_records.\n",
+    "from settfex.services.set import get_all_earnings_calls\n",
     "\n",
+    "full = await get_all_earnings_calls(max_records=200, progress=True)\n",
     "df_full = full.to_dataframe()\n",
-    "\n",
     "print(f\"Collected {len(df_full)} rows\")\n",
     "\n",
-    "\n",
     "df_full.to_csv(\"earnings_calls.csv\", index=False)\n",
-    "\n",
     "print(\"Saved earnings_calls.csv\")\n",
-    "\n",
     "df_full.head()"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.4.1"
+version = "0.5.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -110,10 +110,10 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
-# pandas is an optional, untyped runtime extra (used only in to_dataframe()); don't require
-# its stubs to keep the strict gate green.
+# pandas/tqdm are optional, untyped runtime extras (DataFrame / progress bar); don't require
+# their stubs to keep the strict gate green.
 [[tool.mypy.overrides]]
-module = ["pandas", "pandas.*"]
+module = ["pandas", "pandas.*", "tqdm", "tqdm.*"]
 ignore_missing_imports = true
 
 [tool.bandit]
@@ -127,11 +127,16 @@ default-groups = ["dev"]
 dataframe = [
     "pandas>=2.0.0",
 ]
+# Progress bars for long fetches (e.g. fetch_all_earnings_calls(progress=True)).
+progress = [
+    "tqdm>=4.66.0",
+]
 examples = [
     "pandas>=2.0.0",
     "matplotlib>=3.7.0",
     "jupyter>=1.0.0",
     "notebook>=7.0.0",
+    "tqdm>=4.66.0",
 ]
 
 [dependency-groups]
@@ -148,5 +153,7 @@ dev = [
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.13.2",
+    # tqdm is the optional `progress` extra; in dev so the progress-bar tests run in CI.
+    "tqdm>=4.66.0",
     "twine>=5.0.0",
 ]

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -26,6 +26,7 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    get_all_earnings_calls,
     get_earnings_call_detail,
     get_earnings_calls,
     get_earnings_calls_dataframe,
@@ -112,6 +113,7 @@ __all__ = [
     "get_earnings_calls",
     "get_earnings_calls_dataframe",
     "get_earnings_call_detail",
+    "get_all_earnings_calls",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/earnings_call.py
+++ b/settfex/services/set/earnings_call.py
@@ -99,6 +99,64 @@ def _build_earnings_call_headers(language: str) -> dict[str, str]:
     }
 
 
+class _ProgressReporter:
+    """Optional progress reporting for long fetches: a tqdm bar and/or a callback.
+
+    ``show_bar`` renders a ``tqdm.auto`` bar (lazily imported from the optional ``progress``
+    extra; auto-detects Jupyter vs terminal). If tqdm is missing, it logs a one-time hint and
+    emits periodic loguru progress lines instead. ``callback`` (dependency-free) is invoked
+    with ``(done, total)`` after every update. Used only from the asyncio event loop (single
+    thread), so no locking is needed.
+    """
+
+    def __init__(
+        self,
+        total: int,
+        *,
+        show_bar: bool,
+        callback: Callable[[int, int], None] | None,
+        desc: str,
+    ) -> None:
+        self._total = total
+        self._done = 0
+        self._callback = callback
+        self._desc = desc
+        self._bar: Any = None
+        self._log_fallback = False
+        self._last_logged_pct = 0
+        if show_bar:
+            try:
+                from tqdm.auto import tqdm
+
+                self._bar = tqdm(total=total, desc=desc, unit="rec")
+            except ImportError:
+                logger.warning(
+                    "progress=True but tqdm is not installed; install it with "
+                    "'pip install settfex[progress]'. Falling back to log lines."
+                )
+                self._log_fallback = True
+
+    def update(self, n: int) -> None:
+        """Advance progress by ``n`` and fan out to the bar / callback / log fallback."""
+        if n <= 0:
+            return
+        self._done = min(self._done + n, self._total) if self._total else self._done + n
+        if self._bar is not None:
+            self._bar.update(n)
+        if self._callback is not None:
+            self._callback(self._done, self._total)
+        if self._log_fallback and self._total:
+            pct = self._done * 100 // self._total
+            if pct >= self._last_logged_pct + 10:
+                self._last_logged_pct = pct - (pct % 10)
+                logger.info(f"{self._desc}: {self._done}/{self._total} ({pct}%)")
+
+    def close(self) -> None:
+        """Close the underlying bar, if any."""
+        if self._bar is not None:
+            self._bar.close()
+
+
 class FilterOption(BaseModel):
     """A single filter option from ``/investor/filter/{name}``.
 
@@ -497,81 +555,119 @@ class EarningsCallService:
         industries_id: str | None = None,
         composition_id: int | None = None,
         start: int = 1,
-        page_size: int = 50,
+        page_size: int = 200,
         language: str = "en",
         enrich: bool = False,
         max_records: int | None = None,
         max_pages: int | None = None,
-        throttle: float = 0.3,
+        max_concurrency: int = 5,
+        progress: bool = False,
+        progress_callback: Callable[[int, int], None] | None = None,
+        throttle: float = 0.0,
     ) -> EarningsCallResponse:
-        """Auto-paginate across pages, bounded and polite.
+        """Auto-paginate across all pages **concurrently**, bounded and polite.
 
-        Reuses a single fetcher across pages and sleeps ``throttle`` seconds between page
-        requests. Stops at the first short/empty page, once ``no_records`` is reached, or when
-        a cap is hit.
+        Fetches the first page to learn ``no_records``, then fetches the remaining pages
+        concurrently under ``max_concurrency`` and reassembles them in page order. This is far
+        faster than fetching pages one at a time. ``page_size`` is uncapped by the API, so a
+        larger value also means fewer requests.
 
         Args:
-            max_records: Stop once this many items have been accumulated (then truncate).
-            max_pages: Stop after this many pages.
-            throttle: Delay in seconds between page requests (0 disables).
+            page_size: Records per request (default 200).
+            max_records: Stop once this many items are collected (then truncate).
+            max_pages: Fetch at most this many pages.
+            max_concurrency: Max simultaneous page requests (politeness bound, default 5).
+            progress: Show a ``tqdm`` progress bar (needs ``pip install settfex[progress]``).
+            progress_callback: Optional ``(done, total)`` callback, fired as pages complete.
+            throttle: Optional per-request delay in seconds (default 0; concurrency bounds load).
             (Other args mirror :meth:`fetch_earnings_calls`.)
 
         Returns:
-            An :class:`EarningsCallResponse` with the accumulated items and the API's
+            An :class:`EarningsCallResponse` with all collected items (in order) and the API's
             ``no_records`` total.
 
         Raises:
-            ValueError: If ``max_records``/``max_pages`` are set but < 1, or other inputs are
-                invalid.
+            ValueError: If ``max_records``/``max_pages`` are set but < 1, ``max_concurrency`` < 1,
+                or other inputs are invalid.
         """
         language = normalize_language(language)
         if max_records is not None and max_records < 1:
             raise ValueError(f"max_records must be >= 1 when set, got {max_records}")
         if max_pages is not None and max_pages < 1:
             raise ValueError(f"max_pages must be >= 1 when set, got {max_pages}")
+        if max_concurrency < 1:
+            raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
 
-        items: list[EarningsCallItem] = []
-        no_records = 0
-        page = start
-        pages_fetched = 0
+        def build(page: int) -> dict[str, Any]:
+            return self._build_search_body(
+                type_id=type_id,
+                quarter_id=quarter_id,
+                keyword=keyword,
+                industries_id=industries_id,
+                composition_id=composition_id,
+                start=page,
+                page_size=page_size,
+            )
 
         async with AsyncDataFetcher(config=self.config) as fetcher:
-            while True:
-                body = self._build_search_body(
-                    type_id=type_id,
-                    quarter_id=quarter_id,
-                    keyword=keyword,
-                    industries_id=industries_id,
-                    composition_id=composition_id,
-                    start=page,
-                    page_size=page_size,
-                )
-                response = await self._search_page(fetcher, body, language)
-                no_records = response.no_records
-                items.extend(response.items)
-                pages_fetched += 1
+            # 1. The first page reveals the total, so the rest can fan out concurrently.
+            first = await self._search_page(fetcher, build(start), language)
+            no_records = first.no_records
+            target = no_records if max_records is None else min(no_records, max_records)
+            total_pages = (target + page_size - 1) // page_size if target > 0 else 1
+            if max_pages is not None:
+                total_pages = min(total_pages, max_pages)
 
-                if max_records is not None and len(items) >= max_records:
-                    break
-                if max_pages is not None and pages_fetched >= max_pages:
-                    break
-                if not response.items or len(response.items) < page_size:
-                    break
-                if len(items) >= no_records:
-                    break
+            reporter = _ProgressReporter(
+                total=target,
+                show_bar=progress,
+                callback=progress_callback,
+                desc="Fetching OPPDAY",
+            )
+            items: list[EarningsCallItem] = list(first.items)
+            reporter.update(len(first.items))
 
-                page += 1
-                if throttle > 0:
-                    await asyncio.sleep(throttle)
+            # 2. Fetch the remaining pages concurrently, bounded by a semaphore.
+            if total_pages > 1:
+                semaphore = asyncio.Semaphore(max_concurrency)
 
+                async def fetch_page(page: int) -> tuple[int, list[EarningsCallItem]]:
+                    async with semaphore:
+                        if throttle > 0:
+                            await asyncio.sleep(throttle)
+                        resp = await self._search_page(fetcher, build(page), language)
+                        return page, resp.items
+
+                tasks = [
+                    asyncio.create_task(fetch_page(p))
+                    for p in range(start + 1, start + total_pages)
+                ]
+                pages: dict[int, list[EarningsCallItem]] = {}
+                for coro in asyncio.as_completed(tasks):
+                    page_no, page_items = await coro
+                    pages[page_no] = page_items
+                    reporter.update(len(page_items))
+                for page_no in sorted(pages):
+                    items.extend(pages[page_no])
+
+            reporter.close()
+
+            # 3. Truncate to the record cap, then optionally enrich.
             if max_records is not None:
                 items = items[:max_records]
             if enrich:
-                await self._enrich_items(fetcher, items, language)
+                await self._enrich_items(
+                    fetcher,
+                    items,
+                    language,
+                    max_concurrency=max_concurrency,
+                    progress=progress,
+                    progress_callback=progress_callback,
+                )
 
         logger.info(
-            f"Fetched {len(items)} earnings-call item(s) across {pages_fetched} page(s) "
-            f"(no_records={no_records})"
+            f"Fetched {len(items)} earnings-call item(s) across {total_pages} page(s) "
+            f"(no_records={no_records}, concurrency={max_concurrency})"
         )
         return EarningsCallResponse(no_records=no_records, items=items)
 
@@ -622,17 +718,25 @@ class EarningsCallService:
         items: list[EarningsCallItem],
         language: str,
         *,
-        concurrency: int = 5,
+        max_concurrency: int = 5,
+        progress: bool = False,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> None:
         """Populate ``item.detail`` for each item via bounded-concurrent detail fetches.
 
         A failed detail fetch is logged and tolerated (that item keeps ``detail=None``); it
-        never fails the whole batch.
+        never fails the whole batch. Progress (bar/callback) advances once per item.
         """
         if not items:
             return
 
-        semaphore = asyncio.Semaphore(concurrency)
+        semaphore = asyncio.Semaphore(max_concurrency)
+        reporter = _ProgressReporter(
+            total=len(items),
+            show_bar=progress,
+            callback=progress_callback,
+            desc="Enriching OPPDAY",
+        )
 
         async def _attach(item: EarningsCallItem) -> None:
             async with semaphore:
@@ -642,8 +746,11 @@ class EarningsCallService:
                     logger.warning(
                         f"Failed to enrich earnings-call item id={item.id} ({item.symbol}): {exc}"
                     )
+                finally:
+                    reporter.update(1)
 
         await asyncio.gather(*(_attach(item) for item in items))
+        reporter.close()
 
     async def _fetch_filter(self, name: str, language: str = "en") -> list[FilterOption]:
         """Fetch a single filter endpoint and validate it into a list of options."""
@@ -779,3 +886,52 @@ async def get_earnings_call_detail(
     """
     service = EarningsCallService(config=config)
     return await service.fetch_earnings_call_detail(item_id, language=language)
+
+
+async def get_all_earnings_calls(
+    *,
+    type_id: int = 1,
+    quarter_id: int = 0,
+    keyword: str | None = None,
+    industries_id: str | None = None,
+    composition_id: int | None = None,
+    start: int = 1,
+    page_size: int = 200,
+    language: str = "en",
+    enrich: bool = False,
+    max_records: int | None = None,
+    max_pages: int | None = None,
+    max_concurrency: int = 5,
+    progress: bool = False,
+    progress_callback: Callable[[int, int], None] | None = None,
+    config: FetcherConfig | None = None,
+) -> EarningsCallResponse:
+    """Convenience: fetch the **entire** OPPDAY calendar, concurrently.
+
+    Mirrors :meth:`EarningsCallService.fetch_all_earnings_calls` as a one-liner. Pass
+    ``progress=True`` for a tqdm bar (``pip install "settfex[progress]"``), or a
+    ``progress_callback(done, total)`` for a dependency-free hook. Bound the crawl with
+    ``max_records`` / ``max_pages`` / ``max_concurrency``.
+
+    Example:
+        >>> from settfex.services.set import get_all_earnings_calls
+        >>> response = await get_all_earnings_calls(progress=True)
+        >>> df = response.to_dataframe()
+    """
+    service = EarningsCallService(config=config)
+    return await service.fetch_all_earnings_calls(
+        type_id=type_id,
+        quarter_id=quarter_id,
+        keyword=keyword,
+        industries_id=industries_id,
+        composition_id=composition_id,
+        start=start,
+        page_size=page_size,
+        language=language,
+        enrich=enrich,
+        max_records=max_records,
+        max_pages=max_pages,
+        max_concurrency=max_concurrency,
+        progress=progress,
+        progress_callback=progress_callback,
+    )

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -7,7 +7,7 @@ captured in the opportunity-day HAR.
 import sys
 from datetime import date, datetime
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    get_all_earnings_calls,
     get_earnings_call_detail,
     get_earnings_calls,
     get_earnings_calls_dataframe,
@@ -556,6 +557,111 @@ class TestDetailById:
     async def test_fetch_detail_invalid_language(self, mock_fetcher: Any) -> None:
         with pytest.raises(ValueError, match="language"):
             await EarningsCallService().fetch_earnings_call_detail(10647, language="xx")
+
+
+def _paged(no_records: int, per_page: int) -> Any:
+    """side_effect: return `per_page` items per page, ids encoded as start*100+i (order check)."""
+
+    def dispatch(url: str, *a: Any, **k: Any) -> Any:
+        start = k["json_body"]["start"]
+        return {
+            "no_records": no_records,
+            "items": [{**MOCK_ITEM, "id": start * 100 + i} for i in range(per_page)],
+        }
+
+    return dispatch
+
+
+class TestFetchAllConcurrency:
+    @pytest.mark.asyncio
+    async def test_concurrent_pagination_in_order(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = _paged(no_records=6, per_page=2)
+        resp = await EarningsCallService().fetch_all_earnings_calls(page_size=2, max_concurrency=4)
+        assert resp.count == 6
+        # pages reassembled in order despite concurrent fetching
+        assert [it.id for it in resp.items] == [100, 101, 200, 201, 300, 301]
+        assert mock_fetcher.fetch_json.call_count == 3  # 1 first + 2 concurrent
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_respected(self, mock_fetcher: Any) -> None:
+        import asyncio
+
+        state = {"live": 0, "peak": 0}
+
+        async def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            start = k["json_body"]["start"]
+            state["live"] += 1
+            state["peak"] = max(state["peak"], state["live"])
+            await asyncio.sleep(0.02)
+            state["live"] -= 1
+            return {
+                "no_records": 20,
+                "items": [{**MOCK_ITEM, "id": start * 100 + i} for i in range(2)],
+            }
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        await EarningsCallService().fetch_all_earnings_calls(page_size=2, max_concurrency=3)
+        assert state["peak"] <= 3
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_concurrency(self, mock_fetcher: Any) -> None:
+        with pytest.raises(ValueError, match="max_concurrency"):
+            await EarningsCallService().fetch_all_earnings_calls(max_concurrency=0)
+
+    @pytest.mark.asyncio
+    async def test_progress_callback(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = _paged(no_records=6, per_page=2)
+        seen: list[tuple[int, int]] = []
+        await EarningsCallService().fetch_all_earnings_calls(
+            page_size=2, progress_callback=lambda d, t: seen.append((d, t))
+        )
+        assert seen[-1] == (6, 6)
+        assert all(seen[i][0] <= seen[i + 1][0] for i in range(len(seen) - 1))
+
+    @pytest.mark.asyncio
+    async def test_progress_bar_uses_tqdm(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = _paged(no_records=4, per_page=2)
+        bar = MagicMock()
+        with patch("tqdm.auto.tqdm", return_value=bar) as tqdm_ctor:
+            await EarningsCallService().fetch_all_earnings_calls(page_size=2, progress=True)
+        assert tqdm_ctor.called
+        assert bar.update.called
+        assert bar.close.called
+
+    @pytest.mark.asyncio
+    async def test_progress_without_tqdm_falls_back(
+        self, mock_fetcher: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_fetcher.fetch_json.side_effect = _paged(no_records=4, per_page=2)
+        # Make `from tqdm.auto import tqdm` fail.
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        resp = await EarningsCallService().fetch_all_earnings_calls(page_size=2, progress=True)
+        assert resp.count == 4  # still returns full data via the log fallback
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_enrich_progress(self, mock_fetcher: Any) -> None:
+        def dispatch(url: str, *a: Any, **k: Any) -> Any:
+            if url.endswith("/search/archive"):
+                return {"no_records": 1, "items": [MOCK_ITEM]}
+            return MOCK_DETAIL
+
+        mock_fetcher.fetch_json.side_effect = dispatch
+        seen: list[tuple[int, int]] = []
+        resp = await EarningsCallService().fetch_all_earnings_calls(
+            page_size=2, enrich=True, progress_callback=lambda d, t: seen.append((d, t))
+        )
+        assert resp.items[0].detail is not None
+        assert (1, 1) in seen  # both phases reported
+
+
+class TestGetAllConvenience:
+    @pytest.mark.asyncio
+    async def test_get_all_earnings_calls(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.side_effect = _paged(no_records=4, per_page=2)
+        resp = await get_all_earnings_calls(page_size=2)
+        assert isinstance(resp, EarningsCallResponse)
+        assert resp.count == 4
 
 
 class TestConvenience:

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },
@@ -2963,6 +2963,10 @@ examples = [
     { name = "matplotlib" },
     { name = "notebook" },
     { name = "pandas" },
+    { name = "tqdm" },
+]
+progress = [
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -2977,6 +2981,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tqdm" },
     { name = "twine" },
 ]
 
@@ -2991,8 +2996,10 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'dataframe'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'examples'", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "tqdm", marker = "extra == 'examples'", specifier = ">=4.66.0" },
+    { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.66.0" },
 ]
-provides-extras = ["dataframe", "examples"]
+provides-extras = ["dataframe", "progress", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3006,6 +3013,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.13.2" },
+    { name = "tqdm", specifier = ">=4.66.0" },
     { name = "twine", specifier = ">=5.0.0" },
 ]
 
@@ -3168,6 +3176,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/59/593bd0f40f7355806bf6573b47b8c22f8e1374c9b6fd03114bd6b7a3dcfd/tornado-6.5.2-cp39-abi3-win32.whl", hash = "sha256:c6f29e94d9b37a95013bb669616352ddb82e3bfe8326fccee50583caebc8a5f0", size = 445023, upload-time = "2025-08-08T18:26:56.677Z" },
     { url = "https://files.pythonhosted.org/packages/c7/2a/f609b420c2f564a748a2d80ebfb2ee02a73ca80223af712fca591386cafb/tornado-6.5.2-cp39-abi3-win_amd64.whl", hash = "sha256:e56a5af51cc30dd2cae649429af65ca2f6571da29504a07995175df14c18f35f", size = 445427, upload-time = "2025-08-08T18:26:57.91Z" },
     { url = "https://files.pythonhosted.org/packages/5e/4f/e1f65e8f8c76d73658b33d33b81eed4322fb5085350e4328d5c956f0c8f9/tornado-6.5.2-cp39-abi3-win_arm64.whl", hash = "sha256:d6c33dc3672e3a1f3618eb63b7ef4683a7688e7b9e6e8f0d9aa5726360a004af", size = 444456, upload-time = "2025-08-08T18:26:59.207Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fetching the **whole** OPPDAY archive was slow — `fetch_all_earnings_calls` paginated
**sequentially** with a 0.3 s throttle between every page (~191 serial requests, ~150 s for all
9520 records) and gave no feedback. This makes it **concurrent** and adds an **optional progress
bar**.

### Speed
- Learns `no_records` from page 1, then fetches the remaining pages **concurrently** under
  `max_concurrency` (default 5), reassembling items in order.
- Default `page_size` 50 → 200 (the API does not cap it), `throttle` 0.3 → 0.0 (the concurrency
  bound governs load). Results and ordering unchanged.

**Measured (full ~9520-record archive, live API):**

| | time | requests |
|---|---|---|
| before (0.4.1, sequential) | **151.6 s** | 191 |
| after (0.5.0, concurrent) | **14.2 s** | 48 |

→ **~10.7× faster**, identical 9520 items.

### Progress bar
- `progress=True` → a `tqdm.auto` bar (new optional `progress` extra:
  `pip install "settfex[progress]"`), lazily imported with a graceful log fallback if tqdm is absent.
- `progress_callback(done, total)` → dependency-free hook. Both cover the `enrich=True` phase.

### API
- New **`get_all_earnings_calls(...)`** convenience (exported).

## Tests & quality
- 226 tests pass (+8: concurrency ordering, `max_concurrency` bound, progress callback, tqdm bar,
  no-tqdm fallback, enrich progress, `get_all` convenience). 99% module coverage. All HTTP mocked.
- ruff / ruff format / mypy --strict clean; `uv lock --check` clean.

## Release
Bumps `0.4.1 → 0.5.0`. After merge, the `v0.5.0` tag triggers the OIDC PyPI publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)