### PR TITLE
feat: Thai YouTube transcripts for earnings calls (release 0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-19
+
+### Added
+
+- **Thai YouTube transcripts for earnings calls** (raw text for AI/LLM use), behind a new optional
+  `transcript` extra (`pip install "settfex[transcript]"`, backed by `youtube-transcript-api`):
+  - `fetch_youtube_transcript(video_id, *, languages=("th",), proxies=None) -> str | None` — a
+    generic async wrapper that returns the caption text as one string, or `None` when the video has
+    no matching captions / they're disabled / the request is blocked (never raises for those).
+  - `fetch_transcripts(items, ...) -> list[EarningsCallItem]` — fills `EarningsCallItem.transcript`
+    for every item that has a YouTube video (bounded concurrency, default 3; optional progress bar;
+    per-item tolerant; items without a video are skipped).
+  - `get_earnings_call_transcript(id, ...) -> str | None` — one presentation's transcript by id.
+  - New `EarningsCallItem.transcript: str | None` field (populated only by the above).
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -404,6 +404,11 @@ hann = await get_earnings_calls(keyword="HANN")
 # (pip install "settfex[progress]"):
 from settfex.services.set import get_all_earnings_calls
 everything = await get_all_earnings_calls(progress=True)   # ~9520 records in ~15s (~10x faster)
+
+# Thai subtitles as raw text for AI/LLM use (pip install "settfex[transcript]"):
+from settfex.services.set import fetch_transcripts, get_earnings_call_transcript
+await fetch_transcripts(hann.items)               # fills item.transcript (Thai) per video
+text = await get_earnings_call_transcript(6319)   # …or one presentation's transcript by id
 ```
 
 **👉 [Learn more about the Earnings Call Service](docs/settfex/services/set/earnings_call.md)**

--- a/docs/settfex/services/set/earnings_call.md
+++ b/docs/settfex/services/set/earnings_call.md
@@ -60,6 +60,8 @@ asyncio.run(main())
 - **Derived** (computed): `company_name_clean: str`, `youtube_video_id: str | None`,
   `youtube_url: str | None`
 - `detail: EarningsCallDetail | None` — populated only when `enrich=True`
+- `transcript: str | None` — YouTube transcript text (Thai by default), as raw text for AI/LLM
+  use; populated only by `fetch_transcripts()` / `get_earnings_call_transcript()`
 
 ### `EarningsCallResponse`
 
@@ -158,6 +160,11 @@ print(detail.symbol, detail.round_name, detail.youtube_url)
 - `get_earnings_call_detail(id, language="en") -> EarningsCallDetail`
 - `get_all_earnings_calls(..., progress=False, max_concurrency=5) -> EarningsCallResponse` — the
   whole calendar in one concurrent call
+- `fetch_transcripts(items, ..., languages=("th",)) -> list[EarningsCallItem]` — fill
+  `item.transcript` for every item that has a YouTube video
+- `get_earnings_call_transcript(id, languages=("th",)) -> str | None` — one presentation's
+  transcript by id
+- `fetch_youtube_transcript(video_id, languages=("th",)) -> str | None` — the generic core
 
 `get_earnings_calls(...)` fetches a **single page** by default (mirroring `get_stock_list`); use
 `get_all_earnings_calls(progress=True)` (or `fetch_all_earnings_calls`) for the full calendar,
@@ -191,13 +198,40 @@ for item in response.items:
         print(item.symbol, item.detail.meeting_time, item.detail.video_link)
 ```
 
-## Optional dependency: pandas
+### Get Thai transcripts (for AI)
 
-`to_dataframe()` / `get_earnings_calls_dataframe()` need pandas, which is an **optional**
-extra (the rest of the service works without it):
+For any earnings call with a YouTube video, fetch its **Thai subtitle text as a plain string** —
+ready to feed to an LLM. Needs the `transcript` extra (`pip install "settfex[transcript]"`).
+
+```python
+from settfex.services.set import (
+    get_earnings_calls, fetch_transcripts, get_earnings_call_transcript,
+)
+
+# Batch: fill `item.transcript` for a filtered set (items without a video are skipped)
+resp = await get_earnings_calls(keyword="SCB")
+await fetch_transcripts(resp.items, progress=True)
+for item in resp.items:
+    if item.transcript:
+        feed_to_llm(item.transcript)              # raw Thai text
+
+# …or one presentation by id:
+text = await get_earnings_call_transcript(6319)   # SCB, YE/2021
+```
+
+> **YouTube rate-limits / IP-blocks** aggressively (especially from cloud servers), so this is
+> meant for a **filtered** set — never the full 9520-archive — and uses low concurrency (3) by
+> default. A missing/blocked/disabled transcript simply yields `None`; pass
+> `proxies={"http": ..., "https": ...}` if your host IP is blocked.
+
+## Optional dependencies
+
+The core service needs none of these; install the extra for the feature you use:
 
 ```bash
-pip install "settfex[dataframe]"   # or: uv add pandas
+pip install "settfex[dataframe]"    # to_dataframe() / get_earnings_calls_dataframe()  (pandas)
+pip install "settfex[progress]"     # progress=True bars                               (tqdm)
+pip install "settfex[transcript]"   # transcripts                       (youtube-transcript-api)
 ```
 
 ## API Endpoints

--- a/examples/set/12_earnings_call.ipynb
+++ b/examples/set/12_earnings_call.ipynb
@@ -198,6 +198,39 @@
     "\n",
     "        print(f\"         {item.detail.video_link}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Thai transcripts (text for AI)\n\n",
+    "\n\n",
+    "For each earnings call that has a YouTube video, fetch its **Thai subtitle text** as a plain\n\n",
+    "string — the raw text you'd feed to an LLM. Needs `pip install \"settfex[transcript]\"`.\n\n",
+    "\n\n",
+    "> YouTube rate-limits/IP-blocks aggressively — use this on a **filtered** set (here: one\n\n",
+    "> company), not the whole archive. A blocked/missing transcript just comes back as `None`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from settfex.services.set import fetch_transcripts, get_earnings_calls\n",
+    "\n",
+    "scb = await get_earnings_calls(keyword=\"SCB\", page_size=5)\n",
+    "\n",
+    "await fetch_transcripts(scb.items, progress=True)\n",
+    "\n",
+    "\n",
+    "for item in scb.items:\n",
+    "    if item.transcript:\n",
+    "        print(f\"{item.symbol} {item.meeting_date.date()} ({len(item.transcript)} chars)\")\n",
+    "\n",
+    "        print(item.transcript[:300], \"...\\n\")"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.5.0"
+version = "0.6.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -110,10 +110,17 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
-# pandas/tqdm are optional, untyped runtime extras (DataFrame / progress bar); don't require
-# their stubs to keep the strict gate green.
+# pandas/tqdm/youtube-transcript-api are optional, untyped runtime extras; don't require their
+# stubs to keep the strict gate green.
 [[tool.mypy.overrides]]
-module = ["pandas", "pandas.*", "tqdm", "tqdm.*"]
+module = [
+    "pandas",
+    "pandas.*",
+    "tqdm",
+    "tqdm.*",
+    "youtube_transcript_api",
+    "youtube_transcript_api.*",
+]
 ignore_missing_imports = true
 
 [tool.bandit]
@@ -131,12 +138,17 @@ dataframe = [
 progress = [
     "tqdm>=4.66.0",
 ]
+# YouTube transcript fetching for earnings calls (fetch_transcripts / get_earnings_call_transcript).
+transcript = [
+    "youtube-transcript-api>=1.0.0",
+]
 examples = [
     "pandas>=2.0.0",
     "matplotlib>=3.7.0",
     "jupyter>=1.0.0",
     "notebook>=7.0.0",
     "tqdm>=4.66.0",
+    "youtube-transcript-api>=1.0.0",
 ]
 
 [dependency-groups]
@@ -156,4 +168,6 @@ dev = [
     # tqdm is the optional `progress` extra; in dev so the progress-bar tests run in CI.
     "tqdm>=4.66.0",
     "twine>=5.0.0",
+    # youtube-transcript-api is the optional `transcript` extra; in dev so its tests run in CI.
+    "youtube-transcript-api>=1.0.0",
 ]

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -26,8 +26,10 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    fetch_transcripts,
     get_all_earnings_calls,
     get_earnings_call_detail,
+    get_earnings_call_transcript,
     get_earnings_calls,
     get_earnings_calls_dataframe,
 )
@@ -78,6 +80,7 @@ from settfex.services.set.stock import (
     normalize_language,
     normalize_symbol,
 )
+from settfex.utils.youtube_transcript import fetch_youtube_transcript
 
 __all__ = [
     # Constants
@@ -114,6 +117,9 @@ __all__ = [
     "get_earnings_calls_dataframe",
     "get_earnings_call_detail",
     "get_all_earnings_calls",
+    "fetch_transcripts",
+    "get_earnings_call_transcript",
+    "fetch_youtube_transcript",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/earnings_call.py
+++ b/settfex/services/set/earnings_call.py
@@ -21,7 +21,7 @@ enrichment.
 
 import asyncio
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +43,7 @@ from settfex.utils.parsing import (
     validate_list_or_raise,
     validate_or_raise,
 )
+from settfex.utils.youtube_transcript import fetch_youtube_transcript
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -251,6 +252,13 @@ class EarningsCallItem(BaseModel):
     detail: EarningsCallDetail | None = Field(
         default=None,
         description="Enrichment from the detail endpoint, populated only when enrich=True",
+    )
+    transcript: str | None = Field(
+        default=None,
+        description=(
+            "YouTube transcript text (Thai by default), populated only by fetch_transcripts() "
+            "or get_earnings_call_transcript() — handy as raw text for AI/LLM use"
+        ),
     )
 
     model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
@@ -934,4 +942,97 @@ async def get_all_earnings_calls(
         max_concurrency=max_concurrency,
         progress=progress,
         progress_callback=progress_callback,
+    )
+
+
+async def fetch_transcripts(
+    items: list[EarningsCallItem],
+    *,
+    languages: Sequence[str] = ("th",),
+    max_concurrency: int = 3,
+    progress: bool = False,
+    progress_callback: Callable[[int, int], None] | None = None,
+    proxies: dict[str, str] | None = None,
+) -> list[EarningsCallItem]:
+    """Fetch the YouTube transcript for each item that has a video, in place.
+
+    For every item with a ``youtube_video_id``, fetches the transcript (Thai by default) and
+    stores it on ``item.transcript`` as a plain string (raw text, ready for AI/LLM use); items
+    without a video are left ``transcript=None``. Fetches run with bounded concurrency and are
+    individually tolerant — a blocked/missing transcript logs a warning and leaves that item
+    ``None`` rather than failing the batch.
+
+    YouTube rate-limits / IP-blocks aggressively, so the default concurrency is low (3) and this
+    is meant for a **filtered** set of items, not the full archive. Pass ``proxies`` if the host
+    IP is blocked. Requires the ``transcript`` extra (``pip install "settfex[transcript]"``).
+
+    Args:
+        items: The items to annotate (e.g. ``response.items``).
+        languages: Transcript language priority (default Thai).
+        max_concurrency: Max simultaneous YouTube requests.
+        progress: Show a tqdm bar (needs ``settfex[progress]``).
+        progress_callback: Optional ``(done, total)`` hook.
+        proxies: Optional ``{"http": url, "https": url}`` proxy mapping.
+
+    Returns:
+        The same ``items`` list (for chaining), with ``transcript`` populated where available.
+
+    Example:
+        >>> from settfex.services.set import get_earnings_calls, fetch_transcripts
+        >>> resp = await get_earnings_calls(keyword="SCB")
+        >>> await fetch_transcripts(resp.items)
+        >>> [it.transcript[:40] for it in resp.items if it.transcript]
+    """
+    targets = [item for item in items if item.youtube_video_id]
+    if not targets:
+        return items
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    reporter = _ProgressReporter(
+        total=len(targets), show_bar=progress, callback=progress_callback, desc="Transcripts"
+    )
+
+    async def _attach(item: EarningsCallItem) -> None:
+        async with semaphore:
+            try:
+                video_id = item.youtube_video_id
+                if video_id is not None:
+                    item.transcript = await fetch_youtube_transcript(
+                        video_id, languages=languages, proxies=proxies
+                    )
+            except Exception as exc:  # noqa: BLE001 - tolerate one bad transcript, keep the batch
+                logger.warning(
+                    f"Failed to fetch transcript for item id={item.id} ({item.symbol}): {exc}"
+                )
+            finally:
+                reporter.update(1)
+
+    await asyncio.gather(*(_attach(item) for item in targets))
+    reporter.close()
+    return items
+
+
+async def get_earnings_call_transcript(
+    item_id: int,
+    *,
+    languages: Sequence[str] = ("th",),
+    proxies: dict[str, str] | None = None,
+    config: FetcherConfig | None = None,
+) -> str | None:
+    """Convenience: fetch one OPPDAY presentation's YouTube transcript by id.
+
+    Resolves the presentation's video via the detail endpoint, then fetches its transcript (Thai
+    by default). Returns ``None`` if the presentation has no YouTube video or no matching
+    captions. Requires the ``transcript`` extra (``pip install "settfex[transcript]"``).
+
+    Example:
+        >>> from settfex.services.set import get_earnings_call_transcript
+        >>> text = await get_earnings_call_transcript(6319)   # SCB, YE/2021
+        >>> print((text or "")[:200])
+    """
+    detail = await get_earnings_call_detail(item_id, config=config)
+    if not detail.youtube_video_id:
+        return None
+    return await fetch_youtube_transcript(
+        detail.youtube_video_id, languages=languages, proxies=proxies
     )

--- a/settfex/utils/__init__.py
+++ b/settfex/utils/__init__.py
@@ -4,6 +4,7 @@ from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig, FetchRes
 from settfex.utils.logging import get_logger, setup_logger
 from settfex.utils.session_cache import SessionCache, get_global_cache
 from settfex.utils.session_manager import SessionManager, get_shared_session
+from settfex.utils.youtube_transcript import fetch_youtube_transcript
 
 __all__ = [
     "AsyncDataFetcher",
@@ -15,4 +16,5 @@ __all__ = [
     "get_global_cache",
     "SessionManager",
     "get_shared_session",
+    "fetch_youtube_transcript",
 ]

--- a/settfex/utils/youtube_transcript.py
+++ b/settfex/utils/youtube_transcript.py
@@ -1,0 +1,83 @@
+"""Fetch YouTube transcripts (e.g. Thai OPPDAY captions) as plain strings.
+
+A thin async wrapper around the optional ``youtube-transcript-api`` library (the ``transcript``
+extra). Returns a single concatenated string suitable for feeding to an LLM, or ``None`` when the
+video has no matching captions, they are disabled, or the request is blocked/rate-limited.
+
+The underlying library is synchronous (``requests``-based) and talks to YouTube directly — no SET
+cookies / curl_cffi are involved — so the blocking call is wrapped in ``asyncio.to_thread``.
+"""
+
+import asyncio
+from collections.abc import Sequence
+
+from loguru import logger
+
+__all__ = ["fetch_youtube_transcript"]
+
+
+async def fetch_youtube_transcript(
+    video_id: str,
+    *,
+    languages: Sequence[str] = ("th",),
+    join_with: str = " ",
+    preserve_formatting: bool = False,
+    proxies: dict[str, str] | None = None,
+) -> str | None:
+    """Fetch a YouTube transcript as a single string, or ``None`` if unavailable.
+
+    Args:
+        video_id: YouTube video id (the ``v=`` value), e.g. ``"eOC0S8A4QEE"``.
+        languages: Language codes in **descending priority** (default Thai). For each code a
+            manually-created transcript is preferred, then an auto-generated one.
+        join_with: Separator used to join caption snippets into one string.
+        preserve_formatting: Keep basic inline formatting (``<i>``/``<b>``) if present.
+        proxies: Optional ``{"http": url, "https": url}`` to route through a proxy — helps when
+            YouTube blocks the host IP (common from cloud servers).
+
+    Returns:
+        The concatenated transcript text, or ``None`` when no matching transcript exists, the
+        captions are disabled, the video is unavailable, or YouTube blocks/limits the request.
+
+    Raises:
+        ImportError: If the optional ``youtube-transcript-api`` dependency is not installed.
+
+    Example:
+        >>> text = await fetch_youtube_transcript("eOC0S8A4QEE", languages=("th",))
+        >>> text[:50] if text else None
+    """
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+    except ImportError as exc:
+        raise ImportError(
+            "youtube-transcript-api is required for transcript fetching. Install it with "
+            "'pip install \"settfex[transcript]\"'."
+        ) from exc
+
+    proxy_config = None
+    if proxies:
+        from youtube_transcript_api.proxies import GenericProxyConfig
+
+        proxy_config = GenericProxyConfig(
+            http_url=proxies.get("http"), https_url=proxies.get("https")
+        )
+
+    def _fetch() -> str | None:
+        try:
+            api = YouTubeTranscriptApi(proxy_config=proxy_config)
+            fetched = api.fetch(
+                video_id,
+                languages=list(languages),
+                preserve_formatting=preserve_formatting,
+            )
+            snippets = fetched.to_raw_data()
+            text = join_with.join(s["text"] for s in snippets if s.get("text"))
+            return text or None
+        except Exception as exc:  # noqa: BLE001 - any retrieval failure -> "no transcript"
+            logger.warning(
+                f"No transcript for video {video_id} (languages={list(languages)}): "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return None
+
+    return await asyncio.to_thread(_fetch)

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -17,8 +17,10 @@ from settfex.services.set.earnings_call import (
     EarningsCallResponse,
     EarningsCallService,
     FilterOption,
+    fetch_transcripts,
     get_all_earnings_calls,
     get_earnings_call_detail,
+    get_earnings_call_transcript,
     get_earnings_calls,
     get_earnings_calls_dataframe,
 )
@@ -653,6 +655,74 @@ class TestFetchAllConcurrency:
         )
         assert resp.items[0].detail is not None
         assert (1, 1) in seen  # both phases reported
+
+
+class TestTranscripts:
+    _PATCH = "settfex.services.set.earnings_call.fetch_youtube_transcript"
+
+    @pytest.mark.asyncio
+    async def test_fetch_transcripts_attaches_and_skips(self) -> None:
+        with_video = EarningsCallItem.model_validate(MOCK_ITEM)  # has youtube_video_id
+        no_video = EarningsCallItem.model_validate(MOCK_UPCOMING)  # image_path None
+
+        async def fake(video_id: str, **k: Any) -> str:
+            return f"TXT[{video_id}]"
+
+        with patch(self._PATCH, side_effect=fake):
+            out = await fetch_transcripts([with_video, no_video])
+        assert out[0].transcript == "TXT[qCw7HH77f0U]"
+        assert out[1].transcript is None  # no video -> skipped
+
+    @pytest.mark.asyncio
+    async def test_fetch_transcripts_tolerates_failure(self) -> None:
+        a = EarningsCallItem.model_validate(MOCK_ITEM)
+        b = EarningsCallItem.model_validate(MOCK_ITEM_2)
+
+        async def fake(video_id: str, **k: Any) -> str:
+            if video_id == a.youtube_video_id:
+                raise RuntimeError("blocked")
+            return "OK"
+
+        with patch(self._PATCH, side_effect=fake):
+            out = await fetch_transcripts([a, b])
+        assert out[0].transcript is None  # failed but tolerated
+        assert out[1].transcript == "OK"
+
+    @pytest.mark.asyncio
+    async def test_fetch_transcripts_progress(self) -> None:
+        items = [
+            EarningsCallItem.model_validate(MOCK_ITEM),
+            EarningsCallItem.model_validate(MOCK_ITEM_2),
+        ]
+        seen: list[tuple[int, int]] = []
+
+        async def fake(video_id: str, **k: Any) -> str:
+            return "x"
+
+        with patch(self._PATCH, side_effect=fake):
+            await fetch_transcripts(items, progress_callback=lambda d, t: seen.append((d, t)))
+        assert seen[-1] == (2, 2)
+
+    @pytest.mark.asyncio
+    async def test_fetch_transcripts_no_videos_is_noop(self) -> None:
+        out = await fetch_transcripts([EarningsCallItem.model_validate(MOCK_UPCOMING)])
+        assert out[0].transcript is None
+
+    @pytest.mark.asyncio
+    async def test_get_earnings_call_transcript(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = MOCK_DETAIL  # has image_path -> youtube_video_id
+
+        async def fake(video_id: str, **k: Any) -> str:
+            return "THAI TEXT"
+
+        with patch(self._PATCH, side_effect=fake):
+            text = await get_earnings_call_transcript(10647)
+        assert text == "THAI TEXT"
+
+    @pytest.mark.asyncio
+    async def test_get_earnings_call_transcript_no_video(self, mock_fetcher: Any) -> None:
+        mock_fetcher.fetch_json.return_value = {"id": 1}  # no image_path -> no youtube video
+        assert await get_earnings_call_transcript(1) is None
 
 
 class TestGetAllConvenience:

--- a/tests/utils/test_youtube_transcript.py
+++ b/tests/utils/test_youtube_transcript.py
@@ -1,0 +1,66 @@
+"""Tests for the YouTube transcript utility (youtube-transcript-api fully mocked)."""
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from settfex.utils.youtube_transcript import fetch_youtube_transcript
+
+
+def _api_returning(snippets: list[dict[str, Any]]) -> MagicMock:
+    """Mock YouTubeTranscriptApi whose fetch().to_raw_data() returns `snippets`."""
+    api = MagicMock()
+    api.fetch.return_value.to_raw_data.return_value = snippets
+    return api
+
+
+class TestFetchYoutubeTranscript:
+    @pytest.mark.asyncio
+    async def test_joins_snippets_into_string(self) -> None:
+        api = _api_returning([{"text": "สวัสดี"}, {"text": "ครับ"}])
+        with patch("youtube_transcript_api.YouTubeTranscriptApi", return_value=api):
+            text = await fetch_youtube_transcript("vid", languages=("th",))
+        assert text == "สวัสดี ครับ"
+        assert api.fetch.call_args.kwargs["languages"] == ["th"]
+
+    @pytest.mark.asyncio
+    async def test_custom_join_separator(self) -> None:
+        api = _api_returning([{"text": "a"}, {"text": "b"}])
+        with patch("youtube_transcript_api.YouTubeTranscriptApi", return_value=api):
+            text = await fetch_youtube_transcript("vid", join_with="\n")
+        assert text == "a\nb"
+
+    @pytest.mark.asyncio
+    async def test_empty_snippets_returns_none(self) -> None:
+        api = _api_returning([])
+        with patch("youtube_transcript_api.YouTubeTranscriptApi", return_value=api):
+            assert await fetch_youtube_transcript("vid") is None
+
+    @pytest.mark.asyncio
+    async def test_retrieval_failure_returns_none(self) -> None:
+        # Any retrieval failure (disabled / blocked / unavailable) -> None, never raises.
+        api = MagicMock()
+        api.fetch.side_effect = RuntimeError("IpBlocked")
+        with patch("youtube_transcript_api.YouTubeTranscriptApi", return_value=api):
+            assert await fetch_youtube_transcript("vid") is None
+
+    @pytest.mark.asyncio
+    async def test_missing_library_raises_importerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "youtube_transcript_api", None)
+        with pytest.raises(ImportError, match=r"settfex\[transcript\]"):
+            await fetch_youtube_transcript("vid")
+
+    @pytest.mark.asyncio
+    async def test_proxies_build_generic_config(self) -> None:
+        api = _api_returning([{"text": "x"}])
+        with (
+            patch("youtube_transcript_api.YouTubeTranscriptApi", return_value=api) as ctor,
+            patch("youtube_transcript_api.proxies.GenericProxyConfig") as proxy_cls,
+        ):
+            await fetch_youtube_transcript("vid", proxies={"http": "http://p", "https": "http://p"})
+        assert proxy_cls.called
+        assert ctor.call_args.kwargs["proxy_config"] is proxy_cls.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },
@@ -2964,9 +2964,13 @@ examples = [
     { name = "notebook" },
     { name = "pandas" },
     { name = "tqdm" },
+    { name = "youtube-transcript-api" },
 ]
 progress = [
     { name = "tqdm" },
+]
+transcript = [
+    { name = "youtube-transcript-api" },
 ]
 
 [package.dev-dependencies]
@@ -2983,6 +2987,7 @@ dev = [
     { name = "ruff" },
     { name = "tqdm" },
     { name = "twine" },
+    { name = "youtube-transcript-api" },
 ]
 
 [package.metadata]
@@ -2998,8 +3003,10 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "tqdm", marker = "extra == 'examples'", specifier = ">=4.66.0" },
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.66.0" },
+    { name = "youtube-transcript-api", marker = "extra == 'examples'", specifier = ">=1.0.0" },
+    { name = "youtube-transcript-api", marker = "extra == 'transcript'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dataframe", "progress", "examples"]
+provides-extras = ["dataframe", "progress", "transcript", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3015,6 +3022,7 @@ dev = [
     { name = "ruff", specifier = ">=0.13.2" },
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "twine", specifier = ">=5.0.0" },
+    { name = "youtube-transcript-api", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -3343,6 +3351,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Each recorded OPPDAY earnings call is a Thai-language YouTube video. This adds fetching its
**transcript as a plain string** — the raw Thai text you'd feed to an AI/LLM — behind a new
optional `transcript` extra (`pip install "settfex[transcript]"`, backed by
`youtube-transcript-api`, lazily imported).

### API
- **`fetch_youtube_transcript(video_id, *, languages=("th",), join_with=" ", proxies=None) -> str | None`**
  — generic async wrapper (sync lib via `asyncio.to_thread`). Returns the caption text as one
  string, or `None` when captions are missing / disabled / the IP is blocked (**never raises** for
  those). Optional proxy support for blocked hosts.
- **`fetch_transcripts(items, ...) -> list[EarningsCallItem]`** — fills
  `EarningsCallItem.transcript` for every item that has a YouTube video (bounded concurrency,
  default 3; optional progress bar; per-item tolerant; items without a video are skipped).
- **`get_earnings_call_transcript(id, ...) -> str | None`** — one presentation's transcript by id.
- New **`EarningsCallItem.transcript: str | None`** field.

Composable by design (not bolted onto the bulk fetch) — you attach transcripts to a **filtered**
set, never the 9520-archive, since YouTube rate-limits/IP-blocks aggressively.

## Tests & quality
- 238 tests pass (+12); the new utility is **100%** covered. youtube-transcript-api fully mocked
  (offline). ruff / ruff format / mypy --strict clean; `uv lock --check` clean.

## Verified live
A real OPPDAY video (`qCw7HH77f0U`, HANN) returns **~6,300 chars of Thai transcript**; videos
without Thai captions return `None` gracefully.

## Release
Bumps `0.5.0 → 0.6.0`. After merge, the `v0.6.0` tag triggers the OIDC PyPI publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)