### PR TITLE
fix(set): latest_historical_trading parity (fix broken README import + docs/tests/notebook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ All examples include beginner explanations, professional trading use cases, and 
 11. **[Financial Statements](examples/set/11_financial.ipynb)** - Balance sheet, income, cash flow analysis
 12. **[Earnings Call (Opportunity Day)](examples/set/12_earnings_call.ipynb)** - OPPDAY calendar, YouTube links, Thai transcripts for AI
 13. **[Chart Quotation & Latest Price](examples/set/13_chart_quotation.ipynb)** - Intraday series and the latest traded price relative to now
+14. **[Latest Historical Trading](examples/set/14_latest_historical_trading.ipynb)** - Latest trading-day summary: OHLCV, P/E, P/BV, market cap
 
 ### 📈 TFEX Examples (Thailand Futures Exchange)
 
@@ -395,7 +396,7 @@ trading = await get_latest_historical_trading("CPALL")
 
 print(f"Date: {trading.date}")
 print(f"Close: {trading.close:.2f} THB ({trading.percent_change:+.2f}%)")
-print(f"P/E: {trading.pe_ratio}, P/BV: {trading.pb_ratio}")
+print(f"P/E: {trading.pe}, P/BV: {trading.pbv}")
 print(f"Market Cap: {trading.market_cap:,.0f} THB")
 ```
 

--- a/docs/settfex/services/set/latest_historical_trading.md
+++ b/docs/settfex/services/set/latest_historical_trading.md
@@ -1,0 +1,139 @@
+# Stock Latest Historical Trading Service
+
+## Overview
+
+The Stock Latest Historical Trading Service fetches the **latest completed trading-day summary** for
+an individual SET stock symbol — OHLC prices, volume/value, and valuation metrics (P/E, P/BV,
+dividend yield, market cap, book value) for the most recent session.
+
+Endpoint: `GET /api/set/stock/{symbol}/latest-historical-trading`
+
+## Key Features
+
+- **One-shot daily summary** — open/high/low/close/average, change/%change, total volume & value.
+- **Valuation metrics** — P/E, P/BV, dividend yield, market cap, book value per share, listed shares.
+- **Type-safe** — full Pydantic model with camelCase→snake_case aliases.
+- **Symbol normalization** — lowercase input is upper-cased and trimmed.
+- **Bot-detection handled** — `SessionManager` warms cookies and builds the symbol-specific referer
+  automatically (Incapsula bypass); no manual cookie params.
+
+## Installation
+
+```bash
+pip install settfex
+```
+
+## Quick Start
+
+### Using the convenience function
+
+```python
+import asyncio
+from settfex.services.set import get_latest_historical_trading
+
+async def main():
+    trading = await get_latest_historical_trading("CPALL")
+    print(f"Date: {trading.date}")
+    print(f"Close: {trading.close:.2f} THB ({trading.percent_change:+.2f}%)")
+    print(f"P/E: {trading.pe}, P/BV: {trading.pbv}")
+    print(f"Market Cap: {trading.market_cap:,.0f} THB")
+
+asyncio.run(main())
+```
+
+### Using the Stock class
+
+```python
+from settfex.services.set import Stock
+
+stock = Stock("CPALL")
+trading = await stock.get_latest_historical_trading()
+```
+
+### Using the service class
+
+```python
+from settfex.services.set.stock import LatestHistoricalTradingService
+
+service = LatestHistoricalTradingService()
+trading = await service.fetch_latest_historical_trading("CPALL")
+raw = await service.fetch_latest_historical_trading_raw("CPALL")   # unvalidated dict
+```
+
+## API Reference
+
+### Model — `LatestHistoricalTrading`
+
+| Field | Type | JSON alias | Description |
+|-------|------|-----------|-------------|
+| `date` | `datetime` | `date` | Trading date (tz-aware, +07:00) |
+| `symbol` | `str` | `symbol` | Stock symbol |
+| `prior` | `float \| None` | `prior` | Prior closing price |
+| `open` | `float \| None` | `open` | Opening price |
+| `high` | `float \| None` | `high` | Day's high |
+| `low` | `float \| None` | `low` | Day's low |
+| `average` | `float \| None` | `average` | Average price |
+| `close` | `float \| None` | `close` | Closing price |
+| `change` | `float \| None` | `change` | Change from prior close |
+| `percent_change` | `float \| None` | `percentChange` | Percentage change from prior close |
+| `total_volume` | `float \| None` | `totalVolume` | Total volume (shares) |
+| `total_value` | `float \| None` | `totalValue` | Total value (THB) |
+| `pe` | `float \| None` | `pe` | Price-to-Earnings ratio |
+| `pbv` | `float \| None` | `pbv` | Price-to-Book Value ratio |
+| `book_value_per_share` | `float \| None` | `bookValuePerShare` | Book value per share (THB) |
+| `dividend_yield` | `float \| None` | `dividendYield` | Dividend yield (%) |
+| `market_cap` | `float \| None` | `marketCap` | Market capitalization (THB) |
+| `listed_share` | `float \| None` | `listedShare` | Number of listed shares |
+| `par` | `float \| None` | `par` | Par value per share (THB) |
+| `financial_date` | `datetime \| None` | `financialDate` | Financial data reference date |
+| `nav` | `float \| None` | `nav` | Net asset value (ETF/fund) |
+| `market_index` | `str \| None` | `marketIndex` | Market index name |
+| `market_percent_change` | `float \| None` | `marketPercentChange` | Market index percent change |
+
+> Note: the ratio fields are `pe` and `pbv` (not `pe_ratio` / `pb_ratio`).
+
+### Service Class — `LatestHistoricalTradingService`
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `fetch_latest_historical_trading(symbol)` | `LatestHistoricalTrading` | Validated model |
+| `fetch_latest_historical_trading_raw(symbol)` | `dict` | Unvalidated raw dict |
+
+### Convenience Function
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `get_latest_historical_trading(symbol, config=None)` | `LatestHistoricalTrading` | One-line fetch |
+
+## Usage Examples
+
+### Example 1 — Daily snapshot
+
+```python
+from settfex.services.set import get_latest_historical_trading
+
+d = await get_latest_historical_trading("PTT")
+print(f"{d.symbol}: close {d.close} ({d.percent_change:+.2f}%), vol {d.total_volume:,.0f}")
+```
+
+### Example 2 — Compare valuations across symbols
+
+```python
+from settfex.services.set import get_latest_historical_trading
+
+for sym in ["CPALL", "PTT", "KBANK"]:
+    d = await get_latest_historical_trading(sym)
+    print(f"{d.symbol:<8} P/E={d.pe}  P/BV={d.pbv}  Yield={d.dividend_yield}%")
+```
+
+## Error Handling & Troubleshooting
+
+- **Empty symbol** → `ValueError`.
+- **Non-200 HTTP response** → `Exception` with the status code (e.g. `HTTP 404`).
+- **Markets closed / weekend** → the most recent completed session's summary is returned.
+
+## Related Services
+
+- [Chart Quotation & Latest Price](chart_quotation.md) — intraday per-minute series + the latest
+  *traded* price relative to now.
+- [Highlight Data](highlight_data.md) — P/E, P/B, market cap, dividends, 52-week range, NVDR.

--- a/examples/set/14_latest_historical_trading.ipynb
+++ b/examples/set/14_latest_historical_trading.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Latest Historical Trading\n\nFetch the **latest completed trading-day summary** for any SET stock — OHLC prices,\nvolume/value, and valuation metrics (P/E, P/BV, dividend yield, market cap, book value).\n\nEndpoint: `GET /api/set/stock/{symbol}/latest-historical-trading`"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Setup"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install settfex\n",
+    "\n",
+    "from settfex.services.set import Stock, get_latest_historical_trading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Fetch the latest trading day\n\n`get_latest_historical_trading` returns a single `LatestHistoricalTrading` record for the\nmost recent completed session."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = await get_latest_historical_trading(\"CPALL\")\n",
+    "\n",
+    "print(f\"Date  : {d.date:%Y-%m-%d}\")\n",
+    "print(f\"OHLC  : O={d.open} H={d.high} L={d.low} C={d.close}\")\n",
+    "print(f\"Change: {d.change} ({d.percent_change:+.2f}%)\")\n",
+    "print(f\"Volume: {d.total_volume:,.0f} shares\")\n",
+    "print(f\"Value : {d.total_value:,.0f} THB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Valuation metrics\n\nThe same record carries valuation fields. Note the ratio fields are **`pe`** and **`pbv`**\n(not `pe_ratio` / `pb_ratio`)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"P/E              : {d.pe}\")\n",
+    "print(f\"P/BV             : {d.pbv}\")\n",
+    "print(f\"Dividend yield   : {d.dividend_yield}%\")\n",
+    "print(f\"Market cap       : {d.market_cap:,.0f} THB\")\n",
+    "print(f\"Book value/share : {d.book_value_per_share} THB\")\n",
+    "print(f\"Listed shares    : {d.listed_share:,.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Compare several symbols\n\nWith the optional `dataframe` extra (`pip install \"settfex[dataframe]\"`) you can build a\nquick comparison table."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "symbols = [\"CPALL\", \"PTT\", \"KBANK\", \"AOT\"]\n",
+    "\n",
+    "rows = []\n",
+    "for sym in symbols:\n",
+    "    d = await get_latest_historical_trading(sym)\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"symbol\": d.symbol,\n",
+    "            \"close\": d.close,\n",
+    "            \"pct_change\": d.percent_change,\n",
+    "            \"pe\": d.pe,\n",
+    "            \"pbv\": d.pbv,\n",
+    "            \"div_yield\": d.dividend_yield,\n",
+    "            \"market_cap\": d.market_cap,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "try:\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    display(pd.DataFrame(rows).set_index(\"symbol\"))\n",
+    "except ImportError:\n",
+    "    for r in rows:\n",
+    "        print(r)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Using the unified `Stock` class"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stock = Stock(\"PTT\")\n",
+    "\n",
+    "d = await stock.get_latest_historical_trading()\n",
+    "\n",
+    "print(f\"{d.symbol}: close {d.close} ({d.percent_change:+.2f}%), P/E {d.pe}, P/BV {d.pbv}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Summary\n\n- `get_latest_historical_trading(symbol)` → one `LatestHistoricalTrading` record.\n- OHLCV + change, plus valuation: `pe`, `pbv`, `dividend_yield`, `market_cap`,\n  `book_value_per_share`, `listed_share`.\n- Also on the unified `Stock` class via `stock.get_latest_historical_trading()`.\n\nSee `docs/settfex/services/set/latest_historical_trading.md` for the full reference."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "settfex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -55,6 +55,8 @@ from settfex.services.set.stock import (
     FinancialStatement,
     IncomeStatement,
     Intermission,
+    LatestHistoricalTrading,
+    LatestHistoricalTradingService,
     NVDRHolderData,
     NVDRHolderService,
     PricePerformanceData,
@@ -77,6 +79,7 @@ from settfex.services.set.stock import (
     get_corporate_actions,
     get_highlight_data,
     get_income_statement,
+    get_latest_historical_trading,
     get_latest_price,
     get_nvdr_holder_data,
     get_price_performance,
@@ -162,6 +165,10 @@ __all__ = [
     "Quotation",
     "get_chart_quotation",
     "get_latest_price",
+    # Latest Historical Trading Service
+    "LatestHistoricalTradingService",
+    "LatestHistoricalTrading",
+    "get_latest_historical_trading",
     # Financial Service
     "FinancialService",
     "FinancialStatement",

--- a/tests/services/set/stock/test_latest_historical_trading.py
+++ b/tests/services/set/stock/test_latest_historical_trading.py
@@ -1,0 +1,177 @@
+"""Tests for the SET stock latest-historical-trading service."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.services.set.stock.latest_historical_trading import (
+    LatestHistoricalTrading,
+    LatestHistoricalTradingService,
+    get_latest_historical_trading,
+)
+from settfex.services.set.stock.stock import Stock
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+
+BKK = timezone(timedelta(hours=7))
+
+# Real API response shape for CPALL (captured from the live endpoint). `nav` / `marketIndex` /
+# `marketPercentChange` come back null for ordinary stocks.
+SAMPLE: dict = {
+    "date": "2026-06-19T00:00:00+07:00",
+    "symbol": "CPALL",
+    "prior": 46.75,
+    "open": 46.75,
+    "high": 46.75,
+    "low": 46.0,
+    "average": 46.44,
+    "close": 46.5,
+    "change": -0.25,
+    "percentChange": -0.53,
+    "totalVolume": 54470359.0,
+    "totalValue": 2529470234.5,
+    "pe": 13.93,
+    "pbv": 2.8,
+    "bookValuePerShare": 16.63,
+    "dividendYield": 3.55,
+    "marketCap": 417714212682.0,
+    "listedShare": 8983101348.0,
+    "par": 1.0,
+    "financialDate": "2026-03-31T00:00:00+07:00",
+    "nav": None,
+    "marketIndex": None,
+    "marketPercentChange": None,
+}
+
+
+def _response(payload: dict) -> FetchResponse:
+    """Build a 200 FetchResponse whose body is ``payload`` serialized as JSON."""
+    body = json.dumps(payload)
+    return FetchResponse(
+        status_code=200,
+        content=body.encode("utf-8"),
+        text=body,
+        headers={},
+        url="https://www.set.or.th/api/set/stock/CPALL/latest-historical-trading",
+        elapsed=0.1,
+    )
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Patch AsyncDataFetcher in the service module; yield its async instance.
+
+    The patched class mock is attached as ``.cls`` for referer assertions.
+    """
+    with patch("settfex.services.set.stock.latest_historical_trading.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        fetcher_instance.cls = mock
+        yield fetcher_instance
+
+
+class TestModelParsing:
+    """Pydantic parsing: camelCase aliases, datetimes, nullable fields."""
+
+    def test_aliases_and_values(self):
+        data = LatestHistoricalTrading.model_validate(SAMPLE)
+        assert data.symbol == "CPALL"
+        assert data.close == 46.5
+        assert data.percent_change == -0.53  # percentChange
+        assert data.total_volume == 54470359.0  # totalVolume
+        assert data.total_value == 2529470234.5  # totalValue
+        assert data.pe == 13.93
+        assert data.pbv == 2.8
+        assert data.book_value_per_share == 16.63  # bookValuePerShare
+        assert data.dividend_yield == 3.55  # dividendYield
+        assert data.market_cap == 417714212682.0  # marketCap
+        assert data.listed_share == 8983101348.0  # listedShare
+
+    def test_datetime_fields(self):
+        data = LatestHistoricalTrading.model_validate(SAMPLE)
+        assert data.date == datetime(2026, 6, 19, 0, 0, tzinfo=BKK)
+        assert data.financial_date == datetime(2026, 3, 31, 0, 0, tzinfo=BKK)
+
+    def test_nullable_fields(self):
+        data = LatestHistoricalTrading.model_validate(SAMPLE)
+        assert data.nav is None
+        assert data.market_index is None  # marketIndex
+        assert data.market_percent_change is None  # marketPercentChange
+
+
+@pytest.mark.asyncio
+class TestLatestHistoricalTradingService:
+    """Service I/O: fetch, raw fetch, URL/referer construction, error handling."""
+
+    async def test_init_default_and_custom_config(self):
+        assert LatestHistoricalTradingService().base_url == "https://www.set.or.th"
+        service = LatestHistoricalTradingService(config=FetcherConfig(timeout=60, max_retries=5))
+        assert service.config.timeout == 60
+        assert service.config.max_retries == 5
+
+    async def test_fetch_success(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await LatestHistoricalTradingService().fetch_latest_historical_trading("CPALL")
+        assert isinstance(result, LatestHistoricalTrading)
+        assert result.symbol == "CPALL"
+        assert result.close == 46.5
+        assert result.pe == 13.93
+
+    async def test_fetch_url_and_referer_and_symbol_normalization(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        # lowercase input -> normalized to upper
+        await LatestHistoricalTradingService().fetch_latest_historical_trading("cpall")
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert url == "https://www.set.or.th/api/set/stock/CPALL/latest-historical-trading"
+        # this service builds a Thai (/th/) referer
+        referer = mock_fetcher.cls.get_set_api_headers.call_args.kwargs["referer"]
+        assert referer == "https://www.set.or.th/th/market/product/stock/quote/CPALL/price"
+
+    async def test_fetch_empty_symbol_raises(self):
+        with pytest.raises(ValueError, match="symbol cannot be empty"):
+            await LatestHistoricalTradingService().fetch_latest_historical_trading("   ")
+
+    async def test_fetch_http_error_raises(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = FetchResponse(
+            status_code=404, content=b"", text="", headers={}, url="x", elapsed=0.1
+        )
+        with pytest.raises(Exception, match="HTTP 404"):
+            await LatestHistoricalTradingService().fetch_latest_historical_trading("CPALL")
+
+    async def test_fetch_raw_success(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        raw = await LatestHistoricalTradingService().fetch_latest_historical_trading_raw("CPALL")
+        assert isinstance(raw, dict)
+        assert raw["symbol"] == "CPALL"
+        assert raw["pbv"] == 2.8
+
+    async def test_fetch_raw_http_error_raises(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = FetchResponse(
+            status_code=500, content=b"", text="", headers={}, url="x", elapsed=0.1
+        )
+        with pytest.raises(Exception, match="HTTP 500"):
+            await LatestHistoricalTradingService().fetch_latest_historical_trading_raw("CPALL")
+
+    async def test_fetch_raw_empty_symbol_raises(self):
+        with pytest.raises(ValueError, match="symbol cannot be empty"):
+            await LatestHistoricalTradingService().fetch_latest_historical_trading_raw("")
+
+
+@pytest.mark.asyncio
+class TestConvenienceAndStock:
+    """Top-level convenience function and the unified Stock accessor."""
+
+    async def test_get_latest_historical_trading(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await get_latest_historical_trading("CPALL")
+        assert isinstance(result, LatestHistoricalTrading)
+        assert result.market_cap == 417714212682.0
+
+    async def test_stock_get_latest_historical_trading(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await Stock("CPALL").get_latest_historical_trading()
+        assert isinstance(result, LatestHistoricalTrading)
+        assert result.close == 46.5


### PR DESCRIPTION
## Summary

Brings the `latest_historical_trading` service to parity with the other SET services and **fixes a broken README example**.

### Bugs fixed
The README "Get Latest Historical Trading" snippet was broken twice over:
- `from settfex.services.set import get_latest_historical_trading` → **ImportError** (the symbol was only exported from `settfex.services.set.stock`).
- The snippet used `trading.pe_ratio` / `trading.pb_ratio`, but the model fields are **`pe` / `pbv`** → **AttributeError**.

### Changes
- **Export** `LatestHistoricalTrading` / `LatestHistoricalTradingService` / `get_latest_historical_trading` from the top-level `settfex.services.set` (consistent with every other service) — fixes the import.
- **Fix README** example field names (`pe_ratio`→`pe`, `pb_ratio`→`pbv`).
- **Doc page** `docs/settfex/services/set/latest_historical_trading.md` — clears two previously-dangling README links.
- **Tests** `tests/services/set/stock/test_latest_historical_trading.py` — **100% coverage** on the module (fixture captured from a real CPALL response).
- **Notebook** `examples/set/14_latest_historical_trading.ipynb` (+ README index entry).

### Verification
- Full gate green: `ruff check` · `ruff format --check` · `mypy settfex/` · `pytest` (**287 passed**, 73%) · `uv lock --check`.
- Live-verified against the SET API (CPALL/PTT + normalization + empty-symbol); the exact README snippet now runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)