### PR TITLE
fix(set): export latest_historical_trading top-level (release 0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-21
+
+### Fixed
+
+- `get_latest_historical_trading`, `LatestHistoricalTrading`, and `LatestHistoricalTradingService`
+  are now importable from the top-level `settfex.services.set` (previously only from
+  `settfex.services.set.stock`) — the documented top-level import raised `ImportError` on 0.7.0.
+- The README "Latest Historical Trading" example used the non-existent fields `pe_ratio` / `pb_ratio`;
+  the model fields are `pe` / `pbv`.
+
+### Added
+
+- Documentation page and example notebook for the Latest Historical Trading service.
+
 ## [0.7.0] - 2026-06-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ settfex/
 │                             #   session_cache.py, logging.py
 ├── tests/                     # Mirror of settfex/ with test_ prefix
 ├── docs/                      # Service docs, guides, solutions
-├── examples/                  # 13 Jupyter notebooks (11 SET + 2 TFEX)
+├── examples/                  # 15 Jupyter notebooks (13 SET + 2 TFEX)
 ├── scripts/                   # Verification scripts per service
 ├── .github/                   # CI and agent instructions
 ├── pyproject.toml             # uv-based config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.7.0"
+version = "0.7.1"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -19,7 +19,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Patch release **0.7.1**. Ships the `latest_historical_trading` top-level export fix (merged to `main` in #53, after `v0.7.0` was already tagged).

On the published **0.7.0**, `from settfex.services.set import get_latest_historical_trading` raises `ImportError` (the symbol was only exported from `settfex.services.set.stock`). This release makes the documented import work for installed users.

### Changes
- Bump `0.7.0 → 0.7.1` in `pyproject.toml` + `settfex/__init__.py`, re-locked `uv.lock`.
- `CHANGELOG.md` `## [0.7.1]` (Fixed: top-level import + README field names; Added: doc page + notebook).
- Tidy a stale notebook count in `CLAUDE.md` (13 → 15).

After merge, tag `v0.7.1` triggers the OIDC publish pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)