### PR TITLE
feat(exceptions): network-free "did you mean?" suggestion on SymbolNotFoundError (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-17
+
+### Added
+
+- **"Did you mean?" suggestions on `SymbolNotFoundError`**: a mistyped SET stock symbol now carries
+  a `.suggestion` attribute (the closest known symbol, via stdlib `difflib`) that agents can read
+  programmatically, and the hint is appended to the error message (e.g. `… HTTP 404 — did you mean
+  'CPALL'?`). Also exposes a `suggest_symbol()` helper. The suggestion is computed **network-free**:
+  it only consults the stock list already fetched earlier in the session (`get_stock_list()`), so a
+  404 never triggers an extra fetch, and `.suggestion` is `None` when no list has been fetched yet.
+  Index lookups are excluded from stock-symbol matching (`raise_for_status(..., suggest=False)`).
+
 ## [0.9.0] - 2026-07-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.9.0"
+version = "0.10.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/exceptions.py
+++ b/settfex/exceptions.py
@@ -8,14 +8,15 @@ Example:
     >>> from settfex import get_highlight_data
     >>> from settfex.exceptions import SymbolNotFoundError
     >>> try:
-    ...     await get_highlight_data("NOSUCH")
+    ...     await get_highlight_data("CPALLL")
     ... except SymbolNotFoundError as exc:
-    ...     print(exc.status_code, exc.symbol)
-    404 NOSUCH
+    ...     print(exc.status_code, exc.symbol, exc.suggestion)
+    404 CPALLL CPALL
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import NoReturn
 
 __all__ = [
@@ -25,6 +26,23 @@ __all__ = [
     "InvalidLanguageError",
     "raise_for_status",
 ]
+
+# A pluggable, network-free provider mapping a not-found symbol to a close match from an
+# already-available (cached) symbol list, or None. Registered by the SET stock-list service so
+# this module stays a dependency-free leaf. The provider MUST NOT perform network I/O.
+_symbol_suggester: Callable[[str], str | None] | None = None
+
+
+def register_symbol_suggester(suggester: Callable[[str], str | None] | None) -> None:
+    """Register (or clear, with ``None``) the callable used to compute a "did you mean?" suggestion.
+
+    The provider is consulted by :func:`raise_for_status` when raising a
+    :class:`SymbolNotFoundError`. It **must not** perform network I/O — it should only consult
+    already-available data (e.g. a previously-fetched, in-memory symbol list) and return ``None``
+    otherwise, so that a 404 never triggers an extra fetch.
+    """
+    global _symbol_suggester
+    _symbol_suggester = suggester
 
 
 class FetchError(Exception):
@@ -48,7 +66,25 @@ class FetchError(Exception):
 
 
 class SymbolNotFoundError(FetchError):
-    """A symbol or index was not found (HTTP 404)."""
+    """A symbol or index was not found (HTTP 404).
+
+    ``suggestion`` is a close match from the SET stock-symbol list when one is available — but only
+    if that list was already fetched earlier this session (it is never fetched on demand); ``None``
+    otherwise. When present, the suggestion is also appended to the error message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        symbol: str | None = None,
+        suggestion: str | None = None,
+    ) -> None:
+        self.suggestion = suggestion
+        if suggestion:
+            message = f"{message} — did you mean '{suggestion}'?"
+        super().__init__(message, status_code=status_code, symbol=symbol)
 
 
 class InvalidSymbolError(ValueError):
@@ -59,18 +95,34 @@ class InvalidLanguageError(ValueError):
     """A language string was not recognized (not ``en``/``th`` or an accepted alias)."""
 
 
-def raise_for_status(status_code: int, message: str, *, symbol: str | None = None) -> NoReturn:
+def raise_for_status(
+    status_code: int,
+    message: str,
+    *,
+    symbol: str | None = None,
+    suggest: bool = True,
+) -> NoReturn:
     """Raise :class:`SymbolNotFoundError` for HTTP 404, otherwise :class:`FetchError`.
 
     Args:
         status_code: The non-2xx HTTP status code from the response.
         message: The error message to attach.
         symbol: The stock/index symbol involved, when known.
+        suggest: Whether to attempt a network-free "did you mean?" suggestion for a 404 (default
+            True). Pass ``False`` for non-stock lookups (e.g. index symbols) that should not be
+            matched against the stock-symbol list.
 
     Raises:
         SymbolNotFoundError: If ``status_code`` is 404.
         FetchError: For any other non-2xx status.
     """
     if status_code == 404:
-        raise SymbolNotFoundError(message, status_code=status_code, symbol=symbol)
+        suggestion = (
+            _symbol_suggester(symbol)
+            if (suggest and symbol and _symbol_suggester is not None)
+            else None
+        )
+        raise SymbolNotFoundError(
+            message, status_code=status_code, symbol=symbol, suggestion=suggestion
+        )
     raise FetchError(message, status_code=status_code, symbol=symbol)

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -66,6 +66,7 @@ from settfex.services.set.list import (
     StockListService,
     StockSymbol,
     get_stock_list,
+    suggest_symbol,
 )
 from settfex.services.set.stock import (
     Account,
@@ -150,6 +151,7 @@ __all__ = [
     "StockListResponse",
     "StockSymbol",
     "get_stock_list",
+    "suggest_symbol",
     # Market Index Services
     "SetIndex",
     "IndexListService",

--- a/settfex/services/set/index/chart_quotation.py
+++ b/settfex/services/set/index/chart_quotation.py
@@ -93,7 +93,7 @@ class IndexChartQuotationService:
                     f"HTTP {response.status_code}"
                 )
                 logger.error(error_msg)
-                raise_for_status(response.status_code, error_msg, symbol=symbol)
+                raise_for_status(response.status_code, error_msg, symbol=symbol, suggest=False)
 
             data = decode_json(response.text, context=f"{symbol} (index-chart-quotation)")
 
@@ -152,7 +152,7 @@ class IndexChartQuotationService:
                     f"HTTP {response.status_code}"
                 )
                 logger.error(error_msg)
-                raise_for_status(response.status_code, error_msg, symbol=symbol)
+                raise_for_status(response.status_code, error_msg, symbol=symbol, suggest=False)
 
             data = decode_json(response.text, context=f"{symbol} (index-chart-quotation)")
 

--- a/settfex/services/set/index/info.py
+++ b/settfex/services/set/index/info.py
@@ -155,7 +155,7 @@ class IndexInfoService:
             if response.status_code != 200:
                 error_msg = f"Failed to fetch index info for {symbol}: HTTP {response.status_code}"
                 logger.error(error_msg)
-                raise_for_status(response.status_code, error_msg, symbol=symbol)
+                raise_for_status(response.status_code, error_msg, symbol=symbol, suggest=False)
 
             data = decode_json(response.text, context=f"{symbol} (index-info)")
 
@@ -200,7 +200,7 @@ class IndexInfoService:
             if response.status_code != 200:
                 error_msg = f"Failed to fetch index info for {symbol}: HTTP {response.status_code}"
                 logger.error(error_msg)
-                raise_for_status(response.status_code, error_msg, symbol=symbol)
+                raise_for_status(response.status_code, error_msg, symbol=symbol, suggest=False)
 
             data = decode_json(response.text, context=f"{symbol} (index-info)")
 

--- a/settfex/services/set/list.py
+++ b/settfex/services/set/list.py
@@ -1,14 +1,20 @@
 """SET Stock List Service - Fetch list of stock details from SET API."""
 
 import asyncio
+import difflib
 from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
+from settfex.exceptions import register_symbol_suggester
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_LIST_ENDPOINT
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
 from settfex.utils.parsing import validate_or_raise
+
+# In-memory cache of the last-fetched SET stock symbols, powering network-free "did you mean?"
+# suggestions on SymbolNotFoundError. Populated by fetch_stock_list; reading it never fetches.
+_KNOWN_SYMBOLS: list[str] | None = None
 
 
 class StockSymbol(BaseModel):
@@ -114,6 +120,31 @@ class StockListResponse(BaseModel):
         return None
 
 
+def _cache_known_symbols(response: StockListResponse) -> None:
+    """Cache fetched symbols for network-free symbol suggestions (see :func:`suggest_symbol`)."""
+    global _KNOWN_SYMBOLS
+    _KNOWN_SYMBOLS = [s.symbol for s in response.security_symbols]
+
+
+def suggest_symbol(symbol: str) -> str | None:
+    """Return the closest known SET stock symbol to ``symbol``, or ``None``.
+
+    Uses stdlib :func:`difflib.get_close_matches` against the symbols cached by the most recent
+    :func:`get_stock_list` / ``fetch_stock_list`` call **in this process**. Returns ``None`` — and
+    never performs a fetch — when no stock list has been fetched yet, or when no close match
+    exists. Powers :attr:`settfex.exceptions.SymbolNotFoundError.suggestion`.
+
+    Example:
+        >>> await get_stock_list()          # populates the cache (once per session)
+        >>> suggest_symbol("CPALLL")
+        'CPALL'
+    """
+    if not symbol or _KNOWN_SYMBOLS is None:
+        return None
+    matches = difflib.get_close_matches(symbol.strip().upper(), _KNOWN_SYMBOLS, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
 class StockListService:
     """
     Service for fetching stock list from SET API.
@@ -179,6 +210,7 @@ class StockListService:
 
             # Validate response using Pydantic (context-rich on failure)
             response = validate_or_raise(StockListResponse, data, context="set stock-list")
+            _cache_known_symbols(response)
 
             logger.info(f"Successfully fetched {response.count} stock symbols from SET API")
 
@@ -299,3 +331,8 @@ async def get_stock_list(
     """
     service = StockListService(config=config)
     return await service.fetch_stock_list(include_indices=include_indices)
+
+
+# Register the network-free symbol suggester so SymbolNotFoundError can offer "did you mean?"
+# hints without this module and settfex.exceptions importing each other cyclically.
+register_symbol_suggester(suggest_symbol)

--- a/tests/services/set/test_symbol_suggestion.py
+++ b/tests/services/set/test_symbol_suggestion.py
@@ -1,0 +1,133 @@
+"""Tests for the network-free 'did you mean?' symbol suggestion on SymbolNotFoundError."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+import settfex.services.set.list as list_module
+from settfex.exceptions import FetchError, SymbolNotFoundError, raise_for_status
+from settfex.services.set.list import StockListService, suggest_symbol
+
+
+def _stock(symbol: str) -> dict:
+    """Minimal securitySymbols row."""
+    return {
+        "symbol": symbol,
+        "nameTH": f"{symbol} TH",
+        "nameEN": f"{symbol} EN",
+        "market": "SET",
+        "securityType": "S",
+        "typeSequence": 1,
+        "industry": "SERVICE",
+        "sector": "COMM",
+        "querySector": "comm",
+        "isIFF": False,
+        "isForeignListing": False,
+        "remark": "",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_symbol_cache():
+    """Isolate the process-global symbol cache between tests."""
+    original = list_module._KNOWN_SYMBOLS
+    list_module._KNOWN_SYMBOLS = None
+    yield
+    list_module._KNOWN_SYMBOLS = original
+
+
+# --- suggest_symbol ---------------------------------------------------------------------------
+
+
+def test_suggest_symbol_returns_close_match() -> None:
+    list_module._KNOWN_SYMBOLS = ["CPALL", "PTT", "KBANK", "SCB"]
+    assert suggest_symbol("CPALLL") == "CPALL"
+    assert suggest_symbol("cpall") == "CPALL"  # query is case-insensitive
+
+
+def test_suggest_symbol_no_cache_returns_none_and_never_fetches() -> None:
+    assert list_module._KNOWN_SYMBOLS is None
+    # A fetch would construct AsyncDataFetcher — prove suggest_symbol does not.
+    with patch("settfex.services.set.list.AsyncDataFetcher") as fetcher:
+        assert suggest_symbol("CPALL") is None
+    fetcher.assert_not_called()
+
+
+def test_suggest_symbol_no_close_match_returns_none() -> None:
+    list_module._KNOWN_SYMBOLS = ["CPALL", "PTT"]
+    assert suggest_symbol("ZZZZ") is None
+
+
+def test_suggest_symbol_empty_input_returns_none() -> None:
+    list_module._KNOWN_SYMBOLS = ["CPALL"]
+    assert suggest_symbol("") is None
+
+
+# --- SymbolNotFoundError.suggestion + raise_for_status ----------------------------------------
+
+
+def test_symbol_not_found_error_carries_suggestion_and_message() -> None:
+    exc = SymbolNotFoundError("HTTP 404", status_code=404, symbol="CPALLL", suggestion="CPALL")
+    assert exc.suggestion == "CPALL"
+    assert exc.symbol == "CPALLL"
+    assert exc.status_code == 404
+    assert "did you mean 'CPALL'" in str(exc)
+    assert isinstance(exc, FetchError)  # still catchable as FetchError / Exception
+
+
+def test_symbol_not_found_error_without_suggestion_leaves_message_clean() -> None:
+    exc = SymbolNotFoundError("HTTP 404", status_code=404, symbol="X")
+    assert exc.suggestion is None
+    assert "did you mean" not in str(exc)
+
+
+def test_raise_for_status_404_warm_cache_suggests() -> None:
+    list_module._KNOWN_SYMBOLS = ["CPALL", "PTT", "KBANK"]
+    with pytest.raises(SymbolNotFoundError) as ei:
+        raise_for_status(
+            404, "Failed to fetch highlight data for CPALLL: HTTP 404", symbol="CPALLL"
+        )
+    assert ei.value.suggestion == "CPALL"
+    assert "did you mean 'CPALL'" in str(ei.value)
+
+
+def test_raise_for_status_404_cold_cache_no_suggestion() -> None:
+    assert list_module._KNOWN_SYMBOLS is None
+    with pytest.raises(SymbolNotFoundError) as ei:
+        raise_for_status(404, "Failed to fetch data for CPALLL: HTTP 404", symbol="CPALLL")
+    assert ei.value.suggestion is None
+
+
+def test_raise_for_status_404_suggest_false_skips_stock_list() -> None:
+    """Index lookups pass suggest=False, so an index typo is never matched against stock symbols."""
+    list_module._KNOWN_SYMBOLS = ["CPALL", "PTT", "SCB", "SCC"]
+    with pytest.raises(SymbolNotFoundError) as ei:
+        raise_for_status(
+            404, "Failed to fetch index info for SCG: HTTP 404", symbol="SCG", suggest=False
+        )
+    assert ei.value.suggestion is None
+
+
+def test_raise_for_status_non_404_is_plain_fetch_error() -> None:
+    list_module._KNOWN_SYMBOLS = ["CPALL"]
+    with pytest.raises(FetchError) as ei:
+        raise_for_status(500, "Failed: HTTP 500", symbol="CPALLL")
+    assert not isinstance(ei.value, SymbolNotFoundError)
+    assert ei.value.status_code == 500
+
+
+# --- integration: a real fetch populates the cache (no separate fetch for suggestions) ---------
+
+
+@pytest.mark.asyncio
+async def test_fetch_stock_list_populates_cache_for_suggestions() -> None:
+    payload = {"securitySymbols": [_stock("CPALL"), _stock("PTT"), _stock("KBANK")]}
+    with patch("settfex.services.set.list.AsyncDataFetcher") as mock:
+        inst = AsyncMock()
+        mock.return_value.__aenter__.return_value = inst
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={})
+        inst.fetch_json.return_value = payload
+        await StockListService().fetch_stock_list(include_indices=False)
+    assert list_module._KNOWN_SYMBOLS == ["CPALL", "PTT", "KBANK"]
+    assert suggest_symbol("CPALLL") == "CPALL"

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Adds a **network-free "did you mean?" suggestion** to `SymbolNotFoundError` (backlog item from the
#63 report). A mistyped SET stock symbol now carries a `.suggestion` attribute plus an enriched
message.

## Behavior
- `SymbolNotFoundError.suggestion: str | None` — the closest known SET stock symbol via stdlib
  `difflib.get_close_matches` (cutoff 0.6). Also appended to the message:
  `… HTTP 404 — did you mean 'CPALL'?`.
- **Network-free (key constraint):** computed only from the stock list already fetched earlier this
  session (`get_stock_list()` caches symbols in-process). A 404 **never** triggers an extra fetch;
  `.suggestion` is `None` when no list has been fetched yet.
- **Scoped to SET stocks:** index lookups pass `raise_for_status(..., suggest=False)`; TFEX doesn't
  raise `SymbolNotFoundError`, so it's excluded automatically.
- New public helper `suggest_symbol()`; `raise_for_status` gains a backward-compatible `suggest` param.

## Design (no import cycle)
`settfex/exceptions.py` stays a dependency-free leaf: it holds a *registerable* suggester slot, and
`settfex/services/set/list.py` registers a `difflib`-based `suggest_symbol` at import time
(`list.py → exceptions`, never the reverse).

## Verified end-to-end (live API)
Fetched **3928 real SET symbols**; `suggest_symbol("CPALLL") → "CPALL"`; exception message
`Failed to fetch highlight data for CPALLL: HTTP 404 — did you mean 'CPALL'?`; index `suggest=False`
→ `None`.

## Tests (11 new — `tests/services/set/test_symbol_suggestion.py`)
cached hit; **no-cache → None asserting the fetcher is never constructed**; no close match; empty
input; exception attr + message; warm/cold `raise_for_status`; `suggest=False` scoping; non-404 →
plain `FetchError`; integration (`fetch_stock_list` populates the cache).

## Verification
`uv run ruff check .` ✅ · `uv run pytest` ✅ **395 passed / 79%** · `uv run mypy .` ✅ clean

## Version
0.9.0 → **0.10.0** — MINOR per SemVer: new backward-compatible public API (`.suggestion` attribute,
`suggest_symbol()` helper, `raise_for_status(suggest=…)` param). Patch would be for fixes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
