### PR TITLE
docs: reference 0.10.0 typed exceptions + "did you mean?" suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,30 @@ stock_list = await get_stock_list()
 
 Great for debugging or monitoring in production. Default is ERROR level for clean output.
 
+## 🧯 Error Handling
+
+settfex raises typed exceptions from `settfex.exceptions` (all re-exported from the top level), so you can catch exactly what you need. They stay backward-compatible — fetch errors subclass `Exception`, validation errors subclass `ValueError`:
+
+```python
+from settfex import get_highlight_data
+from settfex.exceptions import (
+    FetchError,            # HTTP/transport failure — has .status_code and .symbol
+    SymbolNotFoundError,   # HTTP 404 for a symbol — subclass of FetchError
+    InvalidSymbolError,    # empty/invalid symbol  — subclass of ValueError
+    InvalidLanguageError,  # unrecognized language — subclass of ValueError
+)
+
+try:
+    data = await get_highlight_data("CPALLL")            # typo
+except SymbolNotFoundError as exc:
+    print(exc)              # "... HTTP 404 — did you mean 'CPALL'?"
+    print(exc.suggestion)   # "CPALL" — a network-free hint from a stock list you already fetched
+except FetchError as exc:
+    print(f"Fetch failed (HTTP {exc.status_code}) for {exc.symbol}")
+```
+
+`SymbolNotFoundError.suggestion` is computed only from the stock list already fetched this session (via `get_stock_list()`); a 404 never triggers an extra request, and it's `None` when no list has been fetched yet.
+
 ## 📋 Changelog
 
 See **[CHANGELOG.md](CHANGELOG.md)** for the full, versioned release history (this project

--- a/docs/settfex/services/set/list.md
+++ b/docs/settfex/services/set/list.md
@@ -254,7 +254,8 @@ they never fail the stock list call.
 - `StockListResponse` - Validated response with all stocks
 
 **Raises:**
-- `Exception` - If request fails or response cannot be parsed
+- `FetchError` - If the request fails (subclass of `Exception`)
+- `ResponseParseError` - If the response cannot be parsed (subclass of `ValueError`)
 
 **Example:**
 ```python
@@ -277,7 +278,7 @@ Useful for debugging or when you need the raw API response.
 - `dict[str, Any]` - Raw dictionary from API
 
 **Raises:**
-- `Exception` - If request fails
+- `FetchError` - If the request fails (subclass of `Exception`)
 
 **Example:**
 ```python
@@ -401,20 +402,28 @@ async def export_to_csv():
 
 ## Error Handling
 
+settfex raises typed exceptions from `settfex.exceptions` (all re-exported from the top-level
+`settfex` package). Fetch errors subclass `Exception` and validation errors subclass `ValueError`,
+so pre-0.9 `except Exception` / `except ValueError` handlers keep working.
+
 ### Basic Error Handling
 
 ```python
+from settfex.exceptions import FetchError
+
 async def safe_fetch():
     try:
         stock_list = await get_stock_list()
         print(f"Fetched {stock_list.count} stocks")
-    except Exception as e:
+    except FetchError as e:            # HTTP/transport failure; has .status_code and .symbol
         print(f"Failed to fetch stock list: {e}")
 ```
 
 ### Retry on Failure
 
 ```python
+from settfex.exceptions import FetchError
+
 async def fetch_with_retry():
     from settfex.utils.data_fetcher import FetcherConfig
 
@@ -427,9 +436,32 @@ async def fetch_with_retry():
     try:
         stock_list = await get_stock_list(config=config)
         return stock_list
-    except Exception as e:
+    except FetchError as e:
         print(f"All retries failed: {e}")
         return None
+```
+
+### Symbol suggestions ("did you mean?")
+
+Fetching the stock list also warms an in-process cache that powers a **network-free** "did you
+mean?" hint on `SymbolNotFoundError` — so a later typo on any stock service suggests the closest
+real symbol, with no extra request (the suggestion is `None`, and no fetch happens, when no list
+has been fetched this session):
+
+```python
+from settfex import get_highlight_data, get_stock_list
+from settfex.exceptions import SymbolNotFoundError
+from settfex.services.set import suggest_symbol
+
+await get_stock_list()                      # once per session — warms the suggestion cache
+
+try:
+    await get_highlight_data("CPALLL")      # typo
+except SymbolNotFoundError as exc:
+    print(exc)                              # "... HTTP 404 — did you mean 'CPALL'?"
+    print(exc.suggestion)                   # "CPALL"
+
+print(suggest_symbol("CPALLL"))             # "CPALL"  (or None if no list fetched yet)
 ```
 
 ## Performance


### PR DESCRIPTION
The docs pin no settfex version (unpinned `pip install settfex`, dynamic PyPI badge, CHANGELOG pointer already at 0.10.0) — so nothing to version-bump. The real gap: service docs still described the pre-0.9 **generic `Exception`** model. This updates the user-facing error-handling docs to the **0.10.0 typed exceptions** + the new "did you mean?" suggestion.

## Changes
- **README** — new `## 🧯 Error Handling` section: catch `SymbolNotFoundError` / `FetchError` / `InvalidSymbolError` / `InvalidLanguageError` from `settfex.exceptions`; `SymbolNotFoundError.suggestion`; backward-compat note.
- **docs/settfex/services/set/list.md** — `Raises:` now list `FetchError` / `ResponseParseError` (not `Exception`); Error Handling examples use `FetchError`; new **"Symbol suggestions (did you mean?)"** subsection documenting the network-free 0.10.0 suggestion + `suggest_symbol()`.

## Verification
Docs-only. All referenced symbols/attributes verified to resolve against 0.10.0 (`SymbolNotFoundError.suggestion`, `FetchError.status_code/.symbol`, `suggest_symbol`, `ResponseParseError`, the `ValueError`/`Exception` subclassing). No stray `Exception` Raises remain in list.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)