### PR TITLE
chore(mypy): type-check tests/ for real errors instead of ignoring them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,15 +104,17 @@ ignore = []
 "tests/**" = ["E501", "B017"]
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
-# scripts/ are untyped standalone verification helpers (not a package, not shipped); keep them out
-# of `uv run mypy .` discovery so the gate reflects the packaged library. tests/ are handled by the
-# ignore_errors override below.
-exclude = ['^scripts/']
+# Derive module names from the repo root so non-package dirs get dotted names (e.g.
+# scripts.settfex....) and can be targeted by the per-module override below. No-op in CI, which
+# has no scripts/ (it is gitignored — see below).
+explicit_package_bases = true
+mypy_path = "."
 
 # pandas/tqdm/youtube-transcript-api are optional, untyped runtime extras; don't require their
 # stubs to keep the strict gate green.
@@ -127,12 +129,16 @@ module = [
 ]
 ignore_missing_imports = true
 
-# tests/ are intentionally not strictly typed (untyped test functions). Exclude them from the
-# strict gate so `uv run mypy .` type-checks the shipped package. The pre-existing test-annotation
-# errors are tracked as separate backlog, not masked by scoping the command to settfex/.
+# tests/ ARE type-checked for real errors (arg-type, union-attr, call-arg, ...), but are not
+# required to carry full annotations — no `-> None`/param boilerplate on every test. The shipped
+# package itself stays fully strict (disallow_untyped_defs above).
+# scripts/ is gitignored (local-only verification helpers); it is listed here purely so that
+# `uv run mypy .` stays usable for developers who keep those local scripts.
 [[tool.mypy.overrides]]
-module = ["tests", "tests.*"]
-ignore_errors = true
+module = ["tests", "tests.*", "scripts", "scripts.*"]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", "scripts"]

--- a/tests/services/set/index/test_chart_quotation.py
+++ b/tests/services/set/index/test_chart_quotation.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -18,7 +19,7 @@ from settfex.utils.data_fetcher import FetchResponse
 BKK = timezone(timedelta(hours=7))
 
 # Trimmed 1D index series: pre-open null bucket, two traded minutes, trailing null bucket.
-SAMPLE_CHART: dict = {
+SAMPLE_CHART: dict[str, Any] = {
     "prior": 1071.84,
     "intermissions": [
         {"begin": "2026-07-16T12:30:00", "end": "2026-07-16T13:45:00"},
@@ -69,7 +70,7 @@ def _at(hour: int, minute: int = 0) -> datetime:
     return datetime(2026, 7, 16, hour, minute, tzinfo=BKK)
 
 
-def _response(payload: dict, status_code: int = 200) -> FetchResponse:
+def _response(payload: dict[str, Any], status_code: int = 200) -> FetchResponse:
     """Build a FetchResponse whose body is ``payload`` serialized as JSON."""
     body = json.dumps(payload)
     return FetchResponse(

--- a/tests/services/set/index/test_composition.py
+++ b/tests/services/set/index/test_composition.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -19,7 +20,7 @@ from settfex.utils.data_fetcher import FetchResponse
 
 # Live /api/set/index/SET50/composition payload shape: one full constituent row (CPALL-like,
 # with the string bid/offer prices the API really sends), one minimal row with null ladders.
-SAMPLE_COMPOSITION: dict = {
+SAMPLE_COMPOSITION: dict[str, Any] = {
     "composition": {
         "symbol": "SET50",
         "nameEN": "SET50",
@@ -104,7 +105,7 @@ SAMPLE_COMPOSITION: dict = {
 }
 
 # SET industry indices (e.g. 'AGRO') return no stocks — just their sector quotes.
-SAMPLE_INDUSTRY_DRILLDOWN: dict = {
+SAMPLE_INDUSTRY_DRILLDOWN: dict[str, Any] = {
     "composition": {
         "symbol": "AGRO",
         "nameEN": "Agro & Food Industry",
@@ -119,7 +120,7 @@ SAMPLE_INDUSTRY_DRILLDOWN: dict = {
 }
 
 
-def _response(payload: dict, status_code: int = 200) -> FetchResponse:
+def _response(payload: dict[str, Any], status_code: int = 200) -> FetchResponse:
     """Build a FetchResponse whose body is ``payload`` serialized as JSON."""
     body = json.dumps(payload)
     return FetchResponse(

--- a/tests/services/set/index/test_index.py
+++ b/tests/services/set/index/test_index.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 
 BKK = timezone(timedelta(hours=7))
 
-SAMPLE_INFO: dict = {
+SAMPLE_INFO: dict[str, Any] = {
     "symbol": "SET50",
     "last": 1078.25,
     "change": 6.41,
@@ -23,7 +24,7 @@ SAMPLE_INFO: dict = {
     "level": "INDEX",
 }
 
-SAMPLE_COMPOSITION: dict = {
+SAMPLE_COMPOSITION: dict[str, Any] = {
     "composition": {
         "symbol": "SET50",
         "stockInfos": [
@@ -35,7 +36,7 @@ SAMPLE_COMPOSITION: dict = {
     "indexInfos": [SAMPLE_INFO],
 }
 
-SAMPLE_CHART: dict = {
+SAMPLE_CHART: dict[str, Any] = {
     "prior": 1071.84,
     "intermissions": [],
     "quotations": [
@@ -52,14 +53,14 @@ SAMPLE_CHART: dict = {
 }
 
 
-def _response(payload: dict) -> FetchResponse:
+def _response(payload: dict[str, Any]) -> FetchResponse:
     body = json.dumps(payload)
     return FetchResponse(
         status_code=200, content=body.encode("utf-8"), text=body, headers={}, url="x", elapsed=0.1
     )
 
 
-def _patch_fetcher(module: str, payload: dict):
+def _patch_fetcher(module: str, payload: dict[str, Any]):
     """Context manager patching AsyncDataFetcher in ``module`` to return ``payload``."""
     patcher = patch(f"settfex.services.set.index.{module}.AsyncDataFetcher")
     mock = patcher.start()

--- a/tests/services/set/index/test_info.py
+++ b/tests/services/set/index/test_info.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -19,7 +20,7 @@ from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 BKK = timezone(timedelta(hours=7))
 
 # Live /api/set/index/SET50/info payload shape (values trimmed).
-SAMPLE_INFO: dict = {
+SAMPLE_INFO: dict[str, Any] = {
     "symbol": "SET50",
     "nameEN": "SET50",
     "nameTH": "SET50",
@@ -41,7 +42,7 @@ SAMPLE_INFO: dict = {
     "level": "INDEX",
 }
 
-SAMPLE_INFO_LIST: dict = {
+SAMPLE_INFO_LIST: dict[str, Any] = {
     "indexIndustrySectors": [
         SAMPLE_INFO,
         {
@@ -69,7 +70,7 @@ SAMPLE_INFO_LIST: dict = {
 }
 
 
-def _response(payload: dict, status_code: int = 200) -> FetchResponse:
+def _response(payload: dict[str, Any], status_code: int = 200) -> FetchResponse:
     """Build a FetchResponse whose body is ``payload`` serialized as JSON."""
     body = json.dumps(payload)
     return FetchResponse(
@@ -165,7 +166,7 @@ class TestIndexInfoService:
 
     async def test_fetch_invalid_language_raises(self):
         with pytest.raises(ValueError, match="Invalid language"):
-            await IndexInfoService().fetch_index_info("SET50", lang="jp")
+            await IndexInfoService().fetch_index_info("SET50", lang="jp")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
     async def test_fetch_http_error_raises(self, mock_fetcher):
         mock_fetcher.fetch.return_value = _response({}, status_code=404)

--- a/tests/services/set/index/test_list.py
+++ b/tests/services/set/index/test_list.py
@@ -1,5 +1,6 @@
 """Tests for the SET market index list service (index directory)."""
 
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from settfex.utils.data_fetcher import FetcherConfig
 
 # Representative slice of the live /api/set/index/list payload: headline indices for both
 # markets, the SET/mai 'AGRO' industry pair (same symbol, different querySymbol), one sector.
-SAMPLE_INDEX_LIST: list[dict] = [
+SAMPLE_INDEX_LIST: list[dict[str, Any]] = [
     {
         "symbol": "SET",
         "market": "SET",
@@ -215,7 +216,7 @@ class TestIndexListService:
 
     async def test_fetch_invalid_language_raises(self):
         with pytest.raises(ValueError, match="Invalid language"):
-            await IndexListService().fetch_index_list(lang="fr")
+            await IndexListService().fetch_index_list(lang="fr")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
     async def test_fetch_uses_default_referer(self, mock_fetcher):
         mock_fetcher.fetch_json.return_value = SAMPLE_INDEX_LIST
@@ -243,5 +244,5 @@ class TestConvenienceFunctions:
 
     async def test_get_index_list_thai(self, mock_fetcher):
         mock_fetcher.fetch_json.return_value = SAMPLE_INDEX_LIST
-        await get_index_list(lang="thai")
+        await get_index_list(lang="thai")  # type: ignore[arg-type]  # intentional: runtime-permissive language
         assert "language=th" in mock_fetcher.fetch_json.call_args.args[0]

--- a/tests/services/set/stock/financial/test_financial.py
+++ b/tests/services/set/stock/financial/test_financial.py
@@ -145,7 +145,7 @@ class TestAccount:
 
     def test_account_model_creation(self):
         """Test Account model can be created with valid data."""
-        account = Account(
+        account = Account(  # type: ignore[call-arg]  # intentional: constructs via camelCase alias
             accountCode="601",
             accountName="Cash And Cash Equivalents",
             amount=37680002.0,
@@ -181,7 +181,7 @@ class TestAccount:
 
     def test_account_model_null_amount(self):
         """Test Account model handles null amounts."""
-        account = Account(
+        account = Account(  # type: ignore[call-arg]  # intentional: constructs via camelCase alias
             accountCode="618",
             accountName="Treasury Stock",
             amount=None,

--- a/tests/services/set/stock/test_chart_quotation.py
+++ b/tests/services/set/stock/test_chart_quotation.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -26,7 +27,7 @@ BKK = timezone(timedelta(hours=7))
 #   - a null bucket inside the lunch intermission (13:00)
 #   - an afternoon trade (14:00)
 #   - a trailing future / no-trade null bucket (16:00)
-SAMPLE: dict = {
+SAMPLE: dict[str, Any] = {
     "prior": 0.21,
     "intermissions": [
         {"begin": "2026-06-19T12:30:00", "end": "2026-06-19T13:45:00"},
@@ -95,7 +96,7 @@ def _at(hour: int, minute: int = 0) -> datetime:
     return datetime(2026, 6, 19, hour, minute, tzinfo=BKK)
 
 
-def _response(payload: dict) -> FetchResponse:
+def _response(payload: dict[str, Any]) -> FetchResponse:
     """Build a 200 FetchResponse whose body is ``payload`` serialized as JSON."""
     body = json.dumps(payload)
     return FetchResponse(
@@ -349,7 +350,7 @@ class TestGetLatestQuotation:
 
         class _FixedDatetime(datetime):
             @classmethod
-            def now(cls, tz=None):  # type: ignore[override]
+            def now(cls, tz=None):
                 return datetime(2026, 6, 19, 11, 0, tzinfo=tz)
 
         monkeypatch.setattr(module, "datetime", _FixedDatetime)

--- a/tests/services/set/stock/test_latest_historical_trading.py
+++ b/tests/services/set/stock/test_latest_historical_trading.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -18,7 +19,7 @@ BKK = timezone(timedelta(hours=7))
 
 # Real API response shape for CPALL (captured from the live endpoint). `nav` / `marketIndex` /
 # `marketPercentChange` come back null for ordinary stocks.
-SAMPLE: dict = {
+SAMPLE: dict[str, Any] = {
     "date": "2026-06-19T00:00:00+07:00",
     "symbol": "CPALL",
     "prior": 46.75,
@@ -45,7 +46,7 @@ SAMPLE: dict = {
 }
 
 
-def _response(payload: dict) -> FetchResponse:
+def _response(payload: dict[str, Any]) -> FetchResponse:
     """Build a 200 FetchResponse whose body is ``payload`` serialized as JSON."""
     body = json.dumps(payload)
     return FetchResponse(

--- a/tests/services/set/test_board_of_director.py
+++ b/tests/services/set/test_board_of_director.py
@@ -1,6 +1,7 @@
 """Tests for SET board of director service."""
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
-MOCK_BOARD_DATA = [
+MOCK_BOARD_DATA: list[dict[str, Any]] = [
     {
         "name": "Mr. WILLIAM ELLWOOD HEINECKE",
         "positions": ["CHAIRMAN"],
@@ -34,7 +35,7 @@ MOCK_BOARD_DATA = [
 ]
 
 # Sample Thai language data
-MOCK_BOARD_DATA_THAI = [
+MOCK_BOARD_DATA_THAI: list[dict[str, Any]] = [
     {
         "name": "นาย วิลเลี่ยม เอลล์วูด ไฮเนเก้",
         "positions": ["ประธานกรรมการ"],
@@ -164,7 +165,7 @@ class TestBoardOfDirectorService:
 
         # Test various language inputs
         for lang_input in ["th", "TH", "thai", "THAI"]:
-            result = await service.fetch_board_of_directors("MINT", lang=lang_input)
+            result = await service.fetch_board_of_directors("MINT", lang=lang_input)  # type: ignore[arg-type]  # intentional: runtime-permissive language
             assert len(result) == 4
 
     async def test_fetch_board_of_directors_empty_symbol(self):
@@ -179,7 +180,7 @@ class TestBoardOfDirectorService:
         service = BoardOfDirectorService()
 
         with pytest.raises(ValueError, match="Invalid language"):
-            await service.fetch_board_of_directors("MINT", lang="invalid")
+            await service.fetch_board_of_directors("MINT", lang="invalid")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
     async def test_fetch_board_of_directors_http_error(self, mock_fetcher):
         """Test handling of HTTP error response."""

--- a/tests/services/set/test_corporate_action.py
+++ b/tests/services/set/test_corporate_action.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -15,7 +16,7 @@ from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
-MOCK_CORPORATE_ACTION_DATA = [
+MOCK_CORPORATE_ACTION_DATA: list[dict[str, Any]] = [
     {
         "symbol": "AOT",
         "name": "",
@@ -123,6 +124,7 @@ class TestCorporateActionService:
         xm_action = result[1]
         assert xm_action.ca_type == "XM"
         assert xm_action.meeting_type == "AGM"
+        assert xm_action.agenda is not None
         assert "Cash dividend payment" in xm_action.agenda
 
     async def test_fetch_corporate_actions_symbol_normalization(self, mock_fetcher):
@@ -159,7 +161,7 @@ class TestCorporateActionService:
 
         # Test various language inputs
         for lang_input in ["th", "TH", "thai", "THAI"]:
-            result = await service.fetch_corporate_actions("AOT", lang=lang_input)
+            result = await service.fetch_corporate_actions("AOT", lang=lang_input)  # type: ignore[arg-type]  # intentional: runtime-permissive language
             assert len(result) == 2
 
     async def test_fetch_corporate_actions_empty_symbol(self):
@@ -174,7 +176,7 @@ class TestCorporateActionService:
         service = CorporateActionService()
 
         with pytest.raises(ValueError, match="Invalid language"):
-            await service.fetch_corporate_actions("AOT", lang="invalid")
+            await service.fetch_corporate_actions("AOT", lang="invalid")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
     async def test_fetch_corporate_actions_http_error(self, mock_fetcher):
         """Test handling of HTTP error response."""
@@ -291,13 +293,14 @@ class TestCorporateActionModel:
         assert action.symbol == "AOT"
         assert action.ca_type == "XM"
         assert action.meeting_type == "AGM"
+        assert action.agenda is not None
         assert "Cash dividend payment" in action.agenda
         assert isinstance(action.meeting_date, datetime)
 
     def test_model_alias_support(self):
         """Test that model supports both field names and aliases."""
         # Test with alias (camelCase)
-        action1 = CorporateAction(
+        action1 = CorporateAction(  # type: ignore[call-arg]  # intentional: constructs via camelCase alias
             symbol="TEST",
             name="Test Company",
             caType="XD",
@@ -324,7 +327,7 @@ class TestCorporateActionModel:
 
     def test_model_optional_fields(self):
         """Test that optional fields can be None."""
-        action = CorporateAction(
+        action = CorporateAction(  # type: ignore[call-arg]  # intentional: constructs via camelCase alias
             symbol="TEST",
             name="",
             caType="XD",

--- a/tests/services/set/test_earnings_call.py
+++ b/tests/services/set/test_earnings_call.py
@@ -159,6 +159,7 @@ class TestModels:
         # The list's `period` is a duration; the detail's `period` is a clock-time range and
         # must surface separately (never overwriting the list duration).
         assert detail.meeting_time == "16:15 - 17:00"
+        assert detail.company_name_th is not None
         assert detail.company_name_th.startswith("HANN:")
         assert detail.video_link == "https://www.youtube.com/embed/qCw7HH77f0U?"
 
@@ -310,7 +311,7 @@ class TestFetchEarningsCalls:
     @pytest.mark.asyncio
     async def test_invalid_language_raises(self, mock_fetcher: Any) -> None:
         with pytest.raises(ValueError, match="language"):
-            await EarningsCallService().fetch_earnings_calls(language="xx")
+            await EarningsCallService().fetch_earnings_calls(language="xx")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
 
 class TestFetchRaw:
@@ -558,7 +559,7 @@ class TestDetailById:
     @pytest.mark.asyncio
     async def test_fetch_detail_invalid_language(self, mock_fetcher: Any) -> None:
         with pytest.raises(ValueError, match="language"):
-            await EarningsCallService().fetch_earnings_call_detail(10647, language="xx")
+            await EarningsCallService().fetch_earnings_call_detail(10647, language="xx")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
 
 def _paged(no_records: int, per_page: int) -> Any:

--- a/tests/services/set/test_list.py
+++ b/tests/services/set/test_list.py
@@ -1,5 +1,6 @@
 """Tests for the SET stock list service, incl. the index-membership enrichment."""
 
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -15,7 +16,7 @@ from settfex.services.set.list import (
 from settfex.utils.data_fetcher import FetcherConfig
 
 
-def _stock(symbol: str, market: str = "SET", industry: str = "SERVICE") -> dict:
+def _stock(symbol: str, market: str = "SET", industry: str = "SERVICE") -> dict[str, Any]:
     """Build one realistic securitySymbols row."""
     return {
         "symbol": symbol,
@@ -33,7 +34,7 @@ def _stock(symbol: str, market: str = "SET", industry: str = "SERVICE") -> dict:
     }
 
 
-SAMPLE_STOCK_LIST: dict = {
+SAMPLE_STOCK_LIST: dict[str, Any] = {
     "securitySymbols": [
         _stock("CPALL"),
         _stock("AAA", industry="INDUS"),

--- a/tests/services/set/test_shareholder.py
+++ b/tests/services/set/test_shareholder.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -17,7 +18,7 @@ from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 from settfex.utils.parsing import ResponseParseError
 
 # Sample test data based on actual API response
-MOCK_SHAREHOLDER_DATA = {
+MOCK_SHAREHOLDER_DATA: dict[str, Any] = {
     "symbol": "MINT",
     "bookCloseDate": "2025-09-02T00:00:00+07:00",
     "caType": "XD",
@@ -168,7 +169,7 @@ class TestShareholderService:
 
         # Test various language inputs
         for lang_input in ["th", "TH", "thai", "THAI"]:
-            result = await service.fetch_shareholder_data("MINT", lang=lang_input)
+            result = await service.fetch_shareholder_data("MINT", lang=lang_input)  # type: ignore[arg-type]  # intentional: runtime-permissive language
             assert result.symbol == "MINT"
 
     async def test_fetch_shareholder_data_empty_symbol(self):
@@ -183,7 +184,7 @@ class TestShareholderService:
         service = ShareholderService()
 
         with pytest.raises(ValueError, match="Invalid language"):
-            await service.fetch_shareholder_data("MINT", lang="invalid")
+            await service.fetch_shareholder_data("MINT", lang="invalid")  # type: ignore[arg-type]  # intentional: runtime-permissive language
 
     async def test_fetch_shareholder_data_http_error(self, mock_fetcher):
         """Test handling of HTTP error response."""
@@ -299,7 +300,7 @@ class TestShareholderModels:
     def test_model_alias_support(self):
         """Test that models support both field names and aliases."""
         # Test MajorShareholder with alias (camelCase)
-        sh1 = MajorShareholder(
+        sh1 = MajorShareholder(  # type: ignore[call-arg]  # intentional: constructs via camelCase alias
             sequence=1,
             name="Test Company",
             nationality=None,

--- a/tests/services/set/test_symbol_suggestion.py
+++ b/tests/services/set/test_symbol_suggestion.py
@@ -1,5 +1,6 @@
 """Tests for the network-free 'did you mean?' symbol suggestion on SymbolNotFoundError."""
 
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -9,7 +10,7 @@ from settfex.exceptions import FetchError, SymbolNotFoundError, raise_for_status
 from settfex.services.set.list import StockListService, suggest_symbol
 
 
-def _stock(symbol: str) -> dict:
+def _stock(symbol: str) -> dict[str, Any]:
     """Minimal securitySymbols row."""
     return {
         "symbol": symbol,


### PR DESCRIPTION
## Summary

`tests/` were `ignore_errors = true` — mypy checked **nothing** in them, including real type bugs. This turns real checking ON while relaxing only the annotation boilerplate, driving tests/ from **357 errors → 0**. The shipped package is untouched.

## Approach (pragmatic scope)
Of the 599 errors originally measured, **~449 (75%) were pure annotation boilerplate** (`no-untyped-def`/`no-untyped-call`) and ~157 were real type issues. Rather than bolt `-> None` onto ~390 test functions, this:
- relaxes `disallow_untyped_defs` / `disallow_incomplete_defs` / `disallow_untyped_calls` for tests (no boilerplate burden on future tests), and
- keeps the rest of `strict` **ON**, then **fixes the real errors**.

## Changes
- **Enable the pydantic mypy plugin** — it understands model construction, cutting false positives (arg-type 63→31, call-arg 13→9). `settfex/` stays clean.
- **tests/ 357 → 0**: annotate sample constants as `dict[str, Any]` (so `Model(**SAMPLE)`/indexing check); narrow Optionals (`agenda`, `company_name_th`); `# type: ignore[arg-type]` where tests deliberately pass runtime-permissive languages (`"english"`/`"invalid"`/`"fr"`) now that `lang` is `Literal["en","th"]`; `# type: ignore[call-arg]` for deliberate camelCase-alias construction; drop a stale `type: ignore[override]`.
- `explicit_package_bases`/`mypy_path` + a `scripts.*` override keep `uv run mypy .` usable for devs who keep local scripts — **both no-ops in CI**.

## Finding: the "scripts/ debt" was never real repo debt
`scripts/` is **gitignored** (`.gitignore:202` — *"scripts/ stay local"*) with **0 tracked files**. Its 242 errors only ever existed on a local machine; CI never saw them. So the committable win is tests/. (The local copies did contain genuine stale-API bugs — a deleted `_generate_random_cookies()` still wired into the run registry, a `SessionManager._instance` that no longer exists, and incomplete `isinstance(result, Exception)` narrowing for `gather(return_exceptions=True)` — I fixed those locally, but they cannot be committed.)

## Verification
- `uv run ruff check .` ✅ · `uv run mypy .` ✅ **0 errors** · `uv run pytest` ✅ **395 passed / 79%**
- Simulated a fresh CI checkout (scripts/ absent): `mypy .` clean on **83 source files**.
- **No version bump / CHANGELOG entry**: `settfex/` is untouched — no shipped-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)