### PR TITLE
fix(set): tolerate null management startDate in company profile (0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-18
+
+### Fixed
+
+- **Company Profile: tolerate `startDate: null` on management entries.** SET reports a vacant or
+  undisclosed executive seat with `"startDate": null` (and an empty `name`) — e.g. `VIBE` lists
+  its top finance-responsibility position that way — so `fetch_company_profile()` raised a
+  `ValidationError` (`Management.start_date` was a required `datetime`). It is now
+  `datetime | None`. Every prior release (0.1.0–0.10.0) is affected; upgrading is the fix.
+
 ## [0.10.0] - 2026-07-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full, versioned release history — t
 - **Index API query param:** the SET *index* endpoints (`/api/set/index/...`) use `?language=`, whereas the SET *stock* endpoints use `?lang=`. Passing the wrong one silently returns the wrong-language payload instead of erroring.
 - **No composition for whole-market indices:** `SET` and `mai` have no `/composition` endpoint (the API returns HTTP 404) — query a sub-index (e.g. `SET50`), a sector, or an industry instead. The service raises with a helpful message.
 - **Two distinct `chart_quotation.py` modules:** `services/set/stock/chart_quotation.py` (per-stock) and `services/set/index/chart_quotation.py` (per-index) are different files — don't conflate them.
+- **Company-profile management `startDate` can be null:** SET reports a vacant/undisclosed executive seat with `"startDate": null` and an empty `name` (e.g. `VIBE`) — `Management.start_date` is `datetime | None`; guard before calling `.strftime()` on it.
 
 ---
 

--- a/docs/settfex/services/set/profile_company.md
+++ b/docs/settfex/services/set/profile_company.md
@@ -130,7 +130,7 @@ Complete company profile data model.
 - `position_code: int` - Position code
 - `position: str` - Position title
 - `name: str` - Executive's name
-- `start_date: datetime` - Start date in position
+- `start_date: datetime | None` - Start date in position (`None` when the seat is vacant or undisclosed, e.g. VIBE's top finance position)
 
 #### Capital
 
@@ -291,7 +291,8 @@ async def show_management():
     print(f"Management Team ({len(profile.managements)} executives):")
     for mgmt in profile.managements[:5]:  # Show top 5
         print(f"  {mgmt.position}: {mgmt.name}")
-        print(f"    Since: {mgmt.start_date.strftime('%Y-%m-%d')}")
+        since = mgmt.start_date.strftime("%Y-%m-%d") if mgmt.start_date else "N/A"
+        print(f"    Since: {since}")
 
 asyncio.run(show_management())
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.10.0"
+version = "0.10.1"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/set/stock/profile_company.py
+++ b/settfex/services/set/stock/profile_company.py
@@ -29,7 +29,10 @@ class Management(BaseModel):
     position_code: int = Field(alias="positionCode", description="Position code")
     position: str = Field(description="Position title")
     name: str = Field(description="Executive's name")
-    start_date: datetime = Field(alias="startDate", description="Start date in position")
+    start_date: datetime | None = Field(
+        alias="startDate",
+        description="Start date in position (null when the seat is vacant or undisclosed)",
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/tests/services/set/test_profile_company.py
+++ b/tests/services/set/test_profile_company.py
@@ -1,0 +1,303 @@
+"""Tests for SET company profile service."""
+
+import json
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.services.set.stock.profile_company import (
+    Auditor,
+    CompanyProfile,
+    CompanyProfileService,
+    Management,
+    get_company_profile,
+)
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
+
+# Sample test data based on the actual API response for VIBE (mai-listed), captured 2026-07-18.
+# Kept deliberately close to the real payload: it exercises the null-heavy corners of this
+# endpoint — a vacant management seat (`startDate: null`, empty name), plus null cgScore,
+# treasuryShares, and preferred capital/share.
+MOCK_COMPANY_PROFILE_DATA: dict[str, Any] = {
+    "symbol": "VIBE",
+    "name": "VIBE SYNERGY GROUP PUBLIC COMPANY LIMITED",
+    "nameRemark": "",
+    "market": "mai",
+    "industry": "SERVICE",
+    "industryName": "Services",
+    "sector": "",
+    "sectorName": "",
+    "logoUrl": "https://media.set.or.th/common/logo/company/VIBE.png",
+    "businessType": "Retail Business",
+    "url": "https://www.vibesynergygroup.com",
+    "address": "24, Soi Ramkhamhaeng 22 (Chittranukhro), Ramkhamhaeng Road, Bangkok 10240",
+    "telephone": "0-2514-5000",
+    "fax": "",
+    "email": "",
+    "dividendPolicy": "The Company has a policy to pay dividends to the shareholders "
+    "when the Company does not have accumulated losses.",
+    "cgScore": None,
+    "cgRemark": "",
+    "cacFlag": False,
+    "setesgRating": "",
+    "setesgRatingRemark": "",
+    "establishedDate": "03/01/1990",
+    "auditEnd": "2026-12-31T00:00:00+07:00",
+    "auditChoice": "Unqualified opinion with an emphasis of matters",
+    "auditors": [
+        {
+            "name": "MISS KANNIKA WIPANURAT",
+            "company": "KARIN AUDIT COMPANY LIMITED",
+            "auditEndDate": "2026-12-31T00:00:00+07:00",
+        },
+        {
+            "name": "MR. JADESADA HUNGSAPRUEK",
+            "company": "KARIN AUDIT COMPANY LIMITED",
+            "auditEndDate": "2026-12-31T00:00:00+07:00",
+        },
+    ],
+    "managements": [
+        {
+            # Vacant seat: SET reports the position with no holder and no start date.
+            "positionCode": 1,
+            "position": "The person taking the highest responsibility in finance and accounting",
+            "name": "",
+            "startDate": None,
+        },
+        {
+            "positionCode": 2,
+            "position": "The person supervising accounting",
+            "name": "Miss Kan-Itsariya Charoenpakdee",
+            "startDate": "2024-09-01T00:00:00+07:00",
+        },
+    ],
+    "commonCapital": {
+        "authorizedCapital": 737435718.0,
+        "paidupCapital": 547680522.0,
+        "par": 1.0,
+        "currency": "Baht",
+    },
+    "commonsShare": {
+        "listedShare": 547680522,
+        "votingRights": [
+            {"symbol": "VIBE", "paidupShare": 547680522, "ratio": "1 : 1"},
+        ],
+        "treasuryShares": None,
+        "votingShares": [
+            {"asOfDate": "2026-07-20T00:00:00+07:00", "share": 547680522},
+            {"asOfDate": "2026-06-30T00:00:00+07:00", "share": 547680522},
+        ],
+    },
+    "preferredCapital": None,
+    "preferredShare": None,
+}
+
+
+def make_response(text: str, status_code: int = 200) -> FetchResponse:
+    """Build a FetchResponse around the given body."""
+    return FetchResponse(
+        status_code=status_code,
+        content=text.encode("utf-8"),
+        text=text,
+        headers={},
+        url="https://www.set.or.th/api/set/company/VIBE/profile?lang=en",
+        elapsed=0.5,
+    )
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Create a mock AsyncDataFetcher."""
+    with patch("settfex.services.set.stock.profile_company.AsyncDataFetcher") as mock:
+        # Create async context manager mock
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+
+        # Mock the get_set_api_headers static method
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+
+        yield fetcher_instance
+
+
+@pytest.mark.asyncio
+class TestCompanyProfileService:
+    """Tests for CompanyProfileService class."""
+
+    async def test_init_default_config(self):
+        """Test service initialization with default config."""
+        service = CompanyProfileService()
+        assert service.config is not None
+        assert service.base_url == "https://www.set.or.th"
+
+    async def test_init_custom_config(self):
+        """Test service initialization with custom config."""
+        config = FetcherConfig(timeout=60, max_retries=5)
+        service = CompanyProfileService(config=config)
+        assert service.config.timeout == 60
+        assert service.config.max_retries == 5
+
+    async def test_fetch_company_profile_success(self, mock_fetcher):
+        """Test successful fetch of company profile data."""
+        mock_fetcher.fetch.return_value = make_response(json.dumps(MOCK_COMPANY_PROFILE_DATA))
+
+        service = CompanyProfileService()
+        result = await service.fetch_company_profile("VIBE", lang="en")
+
+        assert isinstance(result, CompanyProfile)
+        assert result.symbol == "VIBE"
+        assert result.name == "VIBE SYNERGY GROUP PUBLIC COMPANY LIMITED"
+        assert result.market == "mai"
+        assert result.business_type == "Retail Business"
+        assert result.cg_score is None
+        assert isinstance(result.audit_end, datetime)
+        assert len(result.auditors) == 2
+        assert isinstance(result.auditors[0], Auditor)
+        assert len(result.managements) == 2
+        assert result.common_capital.paidup_capital == 547680522.0
+        assert result.commons_share.listed_share == 547680522
+        assert result.commons_share.treasury_shares is None
+        assert result.preferred_capital is None
+        assert result.preferred_share is None
+
+    async def test_fetch_tolerates_null_management_start_date(self, mock_fetcher):
+        """Regression: a vacant management seat has `startDate: null` and must not raise.
+
+        The real VIBE payload includes an executive position with no holder
+        (`name: ""`, `startDate: null`). Prior to 0.10.1 every settfex release
+        (0.1.0-0.10.0) raised a pydantic ValidationError on such symbols because
+        `Management.start_date` was a required, non-nullable datetime.
+        """
+        mock_fetcher.fetch.return_value = make_response(json.dumps(MOCK_COMPANY_PROFILE_DATA))
+
+        service = CompanyProfileService()
+        result = await service.fetch_company_profile("VIBE", lang="en")
+
+        vacant, held = result.managements
+        assert vacant.position_code == 1
+        assert vacant.name == ""
+        assert vacant.start_date is None
+
+        assert held.start_date is not None
+        assert held.start_date.year == 2024
+        assert held.start_date.month == 9
+
+    async def test_fetch_company_profile_symbol_normalization(self, mock_fetcher):
+        """Test symbol normalization (lowercase to uppercase)."""
+        mock_fetcher.fetch.return_value = make_response(json.dumps(MOCK_COMPANY_PROFILE_DATA))
+
+        service = CompanyProfileService()
+        result = await service.fetch_company_profile("vibe", lang="en")
+
+        assert result.symbol == "VIBE"
+
+    async def test_fetch_company_profile_empty_symbol(self):
+        """Test fetch with empty symbol raises ValueError."""
+        service = CompanyProfileService()
+
+        with pytest.raises(ValueError, match="Stock symbol cannot be empty"):
+            await service.fetch_company_profile("", lang="en")
+
+    async def test_fetch_company_profile_invalid_language(self):
+        """Test fetch with invalid language raises ValueError."""
+        service = CompanyProfileService()
+
+        with pytest.raises(ValueError, match="Invalid language"):
+            await service.fetch_company_profile("VIBE", lang="invalid")  # type: ignore[arg-type]  # intentional: runtime-permissive language
+
+    async def test_fetch_company_profile_http_error(self, mock_fetcher):
+        """Test handling of HTTP error response."""
+        mock_fetcher.fetch.return_value = make_response("Not Found", status_code=404)
+
+        service = CompanyProfileService()
+
+        with pytest.raises(Exception, match="Failed to fetch company profile"):
+            await service.fetch_company_profile("INVALID", lang="en")
+
+    async def test_fetch_company_profile_json_decode_error(self, mock_fetcher):
+        """Test handling of invalid JSON response."""
+        mock_fetcher.fetch.return_value = make_response("Invalid JSON")
+
+        service = CompanyProfileService()
+
+        with pytest.raises(ResponseParseError, match="VIBE"):
+            await service.fetch_company_profile("VIBE", lang="en")
+
+    async def test_fetch_company_profile_raw_success(self, mock_fetcher):
+        """Test successful fetch of raw company profile data."""
+        mock_fetcher.fetch_json.return_value = MOCK_COMPANY_PROFILE_DATA
+
+        service = CompanyProfileService()
+        result = await service.fetch_company_profile_raw("VIBE", lang="en")
+
+        assert isinstance(result, dict)
+        assert result["symbol"] == "VIBE"
+        assert result["managements"][0]["startDate"] is None
+
+
+@pytest.mark.asyncio
+class TestCompanyProfileModels:
+    """Tests for Company Profile Pydantic models."""
+
+    def test_management_null_start_date(self):
+        """Regression: Management must accept `startDate: null` (vacant/undisclosed seat)."""
+        management = Management.model_validate(MOCK_COMPANY_PROFILE_DATA["managements"][0])
+
+        assert management.position_code == 1
+        assert management.name == ""
+        assert management.start_date is None
+
+    def test_management_with_start_date(self):
+        """A populated startDate still parses to a datetime."""
+        management = Management.model_validate(MOCK_COMPANY_PROFILE_DATA["managements"][1])
+
+        assert isinstance(management.start_date, datetime)
+        assert management.start_date.year == 2024
+
+    def test_management_field_name_support(self):
+        """Test that Management supports snake_case field names (populate_by_name)."""
+        management = Management(
+            position_code=1,
+            position="Chief Executive Officer",
+            name="Test Person",
+            start_date=None,
+        )
+        assert management.start_date is None
+
+    def test_create_company_profile(self):
+        """Test creating a CompanyProfile model from the full payload."""
+        profile = CompanyProfile.model_validate(MOCK_COMPANY_PROFILE_DATA)
+
+        assert profile.symbol == "VIBE"
+        assert profile.market == "mai"
+        assert isinstance(profile.managements[0], Management)
+        assert profile.managements[0].start_date is None
+        assert isinstance(profile.auditors[0].audit_end_date, datetime)
+        assert profile.common_capital.currency == "Baht"
+
+
+@pytest.mark.asyncio
+class TestConvenienceFunction:
+    """Tests for get_company_profile convenience function."""
+
+    async def test_get_company_profile_success(self, mock_fetcher):
+        """Test convenience function with successful fetch."""
+        mock_fetcher.fetch.return_value = make_response(json.dumps(MOCK_COMPANY_PROFILE_DATA))
+
+        result = await get_company_profile("VIBE", lang="en")
+
+        assert isinstance(result, CompanyProfile)
+        assert result.symbol == "VIBE"
+        assert result.managements[0].start_date is None
+
+    async def test_get_company_profile_custom_config(self, mock_fetcher):
+        """Test convenience function with custom config."""
+        mock_fetcher.fetch.return_value = make_response(json.dumps(MOCK_COMPANY_PROFILE_DATA))
+
+        config = FetcherConfig(timeout=60, max_retries=5)
+        result = await get_company_profile("VIBE", lang="en", config=config)
+
+        assert result.symbol == "VIBE"

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Problem

A user reported that `fetch_company_profile("VIBE")` crashes with a pydantic `ValidationError`. Reproduced live: SET reports a vacant/undisclosed executive seat with `"startDate": null` and an empty `name` (VIBE's "person taking the highest responsibility in finance and accounting"), while `Management.start_date` was a required, non-nullable `datetime`.

```
ValidationError: 1 error — loc=('managements', 0, 'startDate') type=datetime_type
```

**Affected versions: all of them (0.1.0 → 0.10.0).** The field shipped required in `81612c5` (v0.1.0) and was never changed since; `validate_or_raise` re-raises the raw `ValidationError` unchanged in every version, so the reporting user's version is irrelevant — upgrading to 0.10.1 is the fix.

## Fix

- `Management.start_date` → `datetime | None` (no `default=None`: the key must still be present, only `null` is tolerated — same convention as the six nullable datetimes in `profile_stock.py`). Precedent: v0.4.1's "Earnings Call: tolerate `industry: null`".

## Evidence-driven scope check

The full VIBE payload was captured and scanned for nulls: the only null in a **required** field was `managements[].startDate`. All other nulls (`cgScore`, `treasuryShares`, `preferredCapital`, `preferredShare`) were already typed nullable — so this one-field fix is complete for the observed data.

**Report-only catalog (unchanged, no evidence of nulls yet):** required datetimes that could plausibly go null for some symbol someday — same file: `Auditor.audit_end_date`, `VotingShare.as_of_date`, `CompanyProfile.audit_end`; elsewhere: `shareholder`/`nvdr_holder` `book_close_date`, TFEX `first/last_trading_date`, `financial` `begin/end_date`, and ~15 more. Widen only when proven, per the evidence-first discipline.

## Also in this PR

- **First test suite for this service** (`tests/services/set/test_profile_company.py`, 16 tests, mocked `AsyncDataFetcher`; fixture is the real captured VIBE payload, which naturally carries the vacant-seat regression case).
- Docs: field type + `.strftime()` guard in the management example; CLAUDE.md Known Gotchas entry.
- CHANGELOG 0.10.1 entry; version bumped in `pyproject.toml` + `settfex/__init__.py` (+ `uv.lock`).

## Verification

- `uv run pytest` — 411 passed (16 new), coverage 80.34%
- `uv run ruff check .` / `uv run mypy .` (strict) — clean
- Live: `get_company_profile("VIBE")` now succeeds (`start_date=None` on the vacant seat, `2024-09-01` on the held one); `verify_profile_company.py` passes across CPN/PTT/CPALL/KBANK/BBL/AOT in en+th.

🤖 Generated with [Claude Code](https://claude.com/claude-code)