### PR TITLE
feat(set): News service — company news/disclosures for all stocks (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-19
+
+### Added
+
+- **SET News service** (`settfex.services.set.news`) — company news/disclosures for **all
+  stocks** in one call, from `GET /api/set/news/search`: `get_news()` /
+  `NewsService.fetch_news()` (typed `NewsSearchResponse` with `count`, `filter_by_symbol()`,
+  `filter_today()`, `filter_by_tag()`) / `fetch_news_raw()`, plus a `Stock.get_news()` accessor
+  with the symbol pre-filled. Filters: `symbol`, `from_date`/`to_date` (accepts
+  `datetime.date`/`datetime` objects or dd/MM/yyyy strings — the API rejects ISO dates with an
+  opaque HTTP 400, so strings are validated **eagerly** via the new `InvalidDateError`),
+  `keyword`, `source_id` (default `"company"`; pass `None` for all sources — the API silently
+  ignores unrecognized values, which the service warns about), and `lang` (`en`/`th`).
+  Tz-aware timestamps, SessionManager/Incapsula bypass, and permissive typing for the three
+  never-observed alert fields (`viewClarification`/`marketAlertTypeId`/`percentPriceChange`)
+  so a future non-null value cannot break parsing. Without date filters the API returns the
+  latest-trading-day window (~150–200 items); no pagination observed, so keep windows modest.
+- **`InvalidDateError`** in `settfex.exceptions` (subclasses `ValueError`), re-exported from
+  the top-level `settfex` namespace, and the `SET_NEWS_SEARCH_ENDPOINT` constant.
+- Example notebook `examples/set/16_news.ipynb` and service doc
+  `docs/settfex/services/set/news.md`.
+
+### Fixed
+
+- **Docs: corrected the stale services inventory** in `CLAUDE.md`/`README.md` — the TFEX
+  underlying-price service (shipped in 0.3.0) was missing from the inventory, the TFEX
+  notebook list, and the notebook counts. Totals are now 19 services (16 SET + 3 TFEX) and
+  19 notebooks.
+
 ## [0.10.1] - 2026-07-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ settfex/
 ├── settfex/                    # Main package
 │   ├── services/              # Business logic and API integrations
 │   │   ├── set/              # SET-specific services
-│   │   │   ├── constants.py, list.py, earnings_call.py
+│   │   │   ├── constants.py, list.py, earnings_call.py, news.py
 │   │   │   ├── index/        # Market index services: list, info (quotation),
 │   │   │   │                 #   composition (constituents), chart_quotation,
 │   │   │   │                 #   index.py (SetIndex facade), utils.py
@@ -26,12 +26,12 @@ settfex/
 │   │   │                     #   nvdr_holder, board_of_director, trading_stat,
 │   │   │                     #   price_performance, chart_quotation,
 │   │   │                     #   latest_historical_trading, financial/, stock.py, utils.py
-│   │   └── tfex/             # TFEX services: list.py, trading_statistics.py
+│   │   └── tfex/             # TFEX services: list.py, trading_statistics.py, underlying_price.py
 │   └── utils/                # http.py, data_fetcher.py, session_manager.py,
 │                             #   session_cache.py, logging.py
 ├── tests/                     # Mirror of settfex/ with test_ prefix
 ├── docs/                      # Service docs, guides, solutions
-├── examples/                  # 15 Jupyter notebooks (13 SET + 2 TFEX)
+├── examples/                  # 19 Jupyter notebooks (16 SET + 3 TFEX)
 ├── scripts/                   # Verification scripts per service
 ├── .github/                   # CI and agent instructions
 ├── pyproject.toml             # uv-based config
@@ -116,9 +116,9 @@ data = await get_highlight_data("CPALL")   # or convenience function
 all_stocks = await get_stock_list()        # no cookie params needed
 ```
 
-## Services Inventory (17 total)
+## Services Inventory (19 total)
 
-### SET Services (15)
+### SET Services (16)
 
 | # | Service | Module | Endpoint Pattern | Key Data |
 |---|---|---|---|---|
@@ -137,13 +137,15 @@ all_stocks = await get_stock_list()        # no cookie params needed
 | 13 | Chart Quotation / Latest Price | `stock/chart_quotation.py` | `/api/set/stock/{sym}/chart-quotation` | Intraday/historical per-minute series (price/volume/value/%chg, intermissions, prior close); **latest *traded* price relative to now** — `get_latest_price()` (→ `Quotation`), model `get_latest_quotation()`/`get_latest_price()` (→ float, `prior` fallback); skips null future/lunch/no-trade buckets; Asia/Bangkok tz-safe `as_of`; hyphen-safe symbols (`JAS-W4`) |
 | 14 | Latest Historical Trading | `stock/latest_historical_trading.py` | `/api/set/stock/{sym}/latest-historical-trading` | Latest trading-day summary: OHLCV, change/%change, and valuation metrics |
 | 15 | Market Index | `index/{list,info,composition,chart_quotation,index}.py` | `/api/set/index/list`, `/api/set/index/info/list`, `/api/set/index/{sym}/info`, `/api/set/index/{sym}/composition`, `/api/set/index/{sym}/chart-quotation` | 55-index directory (INDEX/INDUSTRY/SECTOR levels; mai industries use `-m` query symbols); page-header quotes (last/chg/%chg/OHLC/vol/value/marketStatus/tz-aware timestamp); constituents w/ full quote rows incl. bid/offer (string prices coerced); `SetIndex` facade + `get_index_latest_price()` (reuses stock ChartQuotation); index symbols keep casing (`sSET`, `AGRO-m`); `SET`/`mai` have no composition (404 w/ helpful error). |
+| 16 | News | `news.py` | `/api/set/news/search` | Company news/disclosures for **all stocks** in one call (default `sourceId=company`, latest-trading-day window); filters: `symbol`, `fromDate`/`toDate` (**dd/MM/yyyy only** — ISO → HTTP 400; validated eagerly via `InvalidDateError`), `keyword`, `source_id` (`None` = all sources; unrecognized values silently ignored by the API), en/th; helpers `count`/`filter_today()`/`filter_by_tag()`/`filter_by_symbol()`; `Stock.get_news()` accessor; no pagination — keep date windows modest |
 
-### TFEX Services (2)
+### TFEX Services (3)
 
 | # | Service | Module | Endpoint Pattern | Key Data |
 |---|---|---|---|---|
 | 1 | Series List | `list.py` | `/api/set/tfex/series/list` | Futures/options, 8 filter methods, contract details |
 | 2 | Trading Statistics | `trading_statistics.py` | `/api/set/tfex/series/{sym}/trading-statistics` | Settlement, margin (IM/MM), theoretical price, days to maturity |
+| 3 | Underlying Price | `underlying_price.py` | `/api/set/tfex/series/{sym}/underlying-price` | Underlying instrument price (SET50 index spot for index futures/options): last/prior/high/low, change, total volume/value, P/E, P/BV |
 
 ### Unified Stock Class (`stock/stock.py`)
 Single entry point for SET stock data — initialize with symbol, access all services via lazy-init properties:
@@ -153,6 +155,7 @@ highlight = await stock.get_highlight_data()
 profile = await stock.get_profile()
 financials = await stock.get_balance_sheet()
 latest = await stock.get_latest_price()    # latest traded price vs now
+news = await stock.get_news()              # company news/disclosures for this symbol
 # ... all stock services accessible
 ```
 
@@ -234,6 +237,8 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full, versioned release history — t
 - **No composition for whole-market indices:** `SET` and `mai` have no `/composition` endpoint (the API returns HTTP 404) — query a sub-index (e.g. `SET50`), a sector, or an industry instead. The service raises with a helpful message.
 - **Two distinct `chart_quotation.py` modules:** `services/set/stock/chart_quotation.py` (per-stock) and `services/set/index/chart_quotation.py` (per-index) are different files — don't conflate them.
 - **Company-profile management `startDate` can be null:** SET reports a vacant/undisclosed executive seat with `"startDate": null` and an empty `name` (e.g. `VIBE`) — `Management.start_date` is `datetime | None`; guard before calling `.strftime()` on it.
+- **News API date format (dd/MM/yyyy ONLY):** `fromDate`/`toDate` on `/api/set/news/search` reject ISO `yyyy-MM-dd` with an opaque HTTP 400. The news service converts `datetime.date`/`datetime` objects automatically and validates strings eagerly, raising `InvalidDateError` before any request is made.
+- **News API `sourceId` is not validated:** any value other than `company` (including empty) is silently ignored and returns ALL sources (a superset incl. TFEX rows and `set-releases` items). `source_id=None` is the intended all-sources switch; `"company"` is the only verified filter value — the service logs a warning for unverified values.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This includes pandas, matplotlib, and jupyter notebook support.
 - [Stock List](examples/set/01_stock_list.ipynb) → [Highlight Data](examples/set/02_highlight_data.ipynb) → [Price Performance](examples/set/10_price_performance.ipynb) → [Financial Statements](examples/set/11_financial.ipynb)
 
 **Professional Trading :** Master all features for institutional use:
-- All 15 SET notebooks + TFEX notebooks (see below)
+- All 16 SET notebooks + TFEX notebooks (see below)
 
 ### 📊 SET Examples (Stock Exchange of Thailand)
 
@@ -60,6 +60,7 @@ All examples include beginner explanations, professional trading use cases, and 
 13. **[Chart Quotation & Latest Price](examples/set/13_chart_quotation.ipynb)** - Intraday series and the latest traded price relative to now
 14. **[Latest Historical Trading](examples/set/14_latest_historical_trading.ipynb)** - Latest trading-day summary: OHLCV, P/E, P/BV, market cap
 15. **[Market Index](examples/set/15_market_index.ipynb)** - Index directory, SET50/SETESG quotations, constituents, and index membership per stock
+16. **[SET News](examples/set/16_news.ipynb)** - Company news/disclosures for all stocks: symbol/date/keyword filters, Thai headlines
 
 ### 📈 TFEX Examples (Thailand Futures Exchange)
 
@@ -67,6 +68,7 @@ Professional derivatives trading workflows with margin calculations and risk man
 
 1. **[Series List](examples/tfex/01_series_list.ipynb)** - Discover futures/options, rollover monitoring, options chains
 2. **[Trading Statistics](examples/tfex/02_trading_statistics.ipynb)** - Margin requirements, position sizing, P/L tracking
+3. **[Underlying Price](examples/tfex/03_underlying_price.ipynb)** - Underlying instrument prices for TFEX series (SET50 spot for index futures/options)
 
 **[📂 View All Examples](examples/)** - Complete index with learning guides
 
@@ -91,6 +93,7 @@ Want to dig deeper? Check out our detailed guides:
 - **[Latest Historical Trading Service](docs/settfex/services/set/latest_historical_trading.md)** - Latest trading day summary with OHLCV and valuation metrics
 - **[Earnings Call (Opportunity Day) Service](docs/settfex/services/set/earnings_call.md)** - OPPDAY earnings-call calendar with YouTube links, as models or a DataFrame
 - **[Market Index Service](docs/settfex/services/set/index.md)** - Index directory (SET50/SET100/sSET/SETESG/...), quotations, constituents, and latest index value
+- **[News Service](docs/settfex/services/set/news.md)** - Company news and disclosures for all stocks, with symbol/date/keyword filters
 
 ### TFEX Services
 
@@ -458,6 +461,30 @@ text = await get_earnings_call_transcript(6319)   # …or one presentation's tra
 > pass `proxies={"http": ..., "https": ...}`. Results can vary by IP.
 
 **👉 [Learn more about the Earnings Call Service](docs/settfex/services/set/earnings_call.md)**
+
+---
+
+#### 📰 Get SET News & Disclosures (All Stocks)
+
+Company news for the whole market in one call — or filtered by symbol, date window, and keyword:
+
+```python
+from settfex.services.set import get_news
+
+# Latest trading day, ALL stocks (company disclosures, English)
+news = await get_news()
+print(f"{news.count} items")
+
+# One stock, Thai headlines, a July window
+# (dates are dd/MM/yyyy or datetime.date objects — ISO strings raise InvalidDateError)
+cpall = await get_news(symbol="CPALL", lang="th", from_date="01/07/2026", to_date="17/07/2026")
+
+# Helpers: today's items, financial statements only
+today = news.filter_today()
+fin = news.filter_by_tag("financial-statement")
+```
+
+**👉 [Learn more about the News Service](docs/settfex/services/set/news.md)**
 
 ---
 

--- a/docs/settfex/services/set/news.md
+++ b/docs/settfex/services/set/news.md
@@ -1,0 +1,191 @@
+# SET News Service
+
+## Overview
+
+Fetches news and disclosures from the SET news search API (`GET /api/set/news/search`) —
+**market-wide by default**: one call returns the latest-trading-day company news for **all
+stocks** on SET/mai, in English or Thai. Optional filters narrow the result by symbol, date
+window, headline keyword, and source.
+
+Module: `settfex/services/set/news.py` · Three tiers: `get_news()` (one-call convenience,
+the LLM tool-calling entry point) → `NewsService.fetch_news()` (validated Pydantic models) →
+`NewsService.fetch_news_raw()` (raw `dict` escape hatch). Also available per-stock as
+`Stock("CPALL").get_news()`.
+
+> ### ⚠️ Two API gotchas (live-verified 2026-07-19)
+>
+> 1. **Dates are dd/MM/yyyy ONLY.** `fromDate`/`toDate` reject ISO `yyyy-MM-dd` with an
+>    opaque HTTP 400. The service converts `datetime.date`/`datetime` objects automatically
+>    and eagerly validates strings, raising `InvalidDateError` *before* any request.
+> 2. **`sourceId` is not validated.** Any value other than `company` (including empty) is
+>    silently ignored by the API and returns news from **all** sources (a superset that
+>    includes TFEX rows and `set-releases` items). `"company"` is the only verified filter
+>    value; pass `source_id=None` for the explicit all-sources behavior. Unverified values
+>    log a warning.
+
+## Quick Start
+
+```python
+import asyncio
+from settfex.services.set import get_news
+
+async def main() -> None:
+    # Latest trading day, ALL stocks, company disclosures, English headlines
+    news = await get_news()
+    print(f"{news.count} items")
+    for item in news.news_info_list[:5]:
+        print(f"{item.news_datetime:%Y-%m-%d %H:%M}  {item.symbol:8s} {item.headline}")
+
+asyncio.run(main())
+```
+
+```python
+# Thai headlines
+news = await get_news(lang="th")
+
+# One symbol only
+news = await get_news(symbol="CPALL")
+
+# A date window (date objects are converted to dd/MM/yyyy automatically)
+from datetime import date
+news = await get_news(from_date=date(2026, 7, 1), to_date=date(2026, 7, 17))
+
+# Headline keyword
+news = await get_news(keyword="dividend")
+
+# All sources (SET-issued releases, TFEX, funds, ... — superset of company news)
+news = await get_news(source_id=None)
+```
+
+## Models
+
+### `NewsItem`
+
+One news/disclosure item. All 13 fields are always present in the API response.
+
+| Field | Alias | Type | Notes |
+|---|---|---|---|
+| `id` | — | `str` | Numeric string; ids differ per language |
+| `news_datetime` | `datetime` | `datetime` | Timezone-aware (Asia/Bangkok, +07:00) |
+| `symbol` | — | `str` | Security the news belongs to |
+| `source` | — | `str` | Disclosing source code (usually the symbol) |
+| `url` | — | `str` | Full news-detail page URL on set.or.th |
+| `headline` | — | `str` | Thai or English per requested `lang` |
+| `is_today_news` | `isTodayNews` | `bool` | Published-today flag |
+| `view_clarification` | `viewClarification` | `bool \| str \| None` | Only `null` observed as of 2026-07 |
+| `market_alert_type_id` | `marketAlertTypeId` | `int \| str \| None` | Only `null` observed as of 2026-07 |
+| `percent_price_change` | `percentPriceChange` | `float \| None` | Only `null` observed as of 2026-07 |
+| `tag` | — | `str` | Observed: `''`, `financial-statement`, `nav`, `ca`, `set-releases` |
+| `product` | — | `str` | Observed: `S`, `L`, `U`, `V`, `X`, `TFEX` |
+| `lang` | — | `str` | `'th'` or `'en'` (item data, not the request param) |
+
+The three alert fields have never been observed non-null (checked across 3,378 items); they
+are typed permissively so a future non-null value cannot break parsing.
+
+### `NewsSearchResponse`
+
+| Member | Description |
+|---|---|
+| `total_count: int` | Total matches reported by the API |
+| `news_info_list: list[NewsItem]` | The items (a `null` list parses as empty) |
+| `count` (property) | `len(news_info_list)` — matches `total_count`; a mismatch logs a pagination-canary warning |
+| `filter_by_symbol(symbol)` | Case-insensitive symbol filter |
+| `filter_today()` | Items with `is_today_news=True` |
+| `filter_by_tag(tag)` | Case-insensitive exact tag match |
+
+## Service Class
+
+### `NewsService(config: FetcherConfig | None = None)`
+
+#### `fetch_news(...) -> NewsSearchResponse` / `fetch_news_raw(...) -> dict`
+
+Both take the same parameters:
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `lang` | `Language` | `"en"` | `en`/`th` (aliases `eng`/`english`/`tha`/`thai` accepted) |
+| `symbol` | `str \| None` | `None` | Auto-uppercased; `None` = all stocks |
+| `from_date` | `date \| str \| None` | `None` | `datetime.date`/`datetime`, or a dd/MM/yyyy string |
+| `to_date` | `date \| str \| None` | `None` | Same formats as `from_date` |
+| `keyword` | `str \| None` | `None` | Headline keyword; URL-encoded automatically |
+| `source_id` | `str \| None` | `"company"` | `None` = all sources (see gotcha #2) |
+
+Without dates the API returns the **latest trading day** only (~150–200 items). No
+pagination has been observed — a 17-day window returned 2,804 items in one response — so
+keep windows modest.
+
+## Convenience Function
+
+```python
+async def get_news(
+    lang="en", symbol=None, from_date=None, to_date=None,
+    keyword=None, source_id="company", config=None,
+) -> NewsSearchResponse
+```
+
+## Usage Examples
+
+### Today's disclosures, grouped by tag
+
+```python
+news = await get_news()
+print(f"financial statements: {len(news.filter_by_tag('financial-statement'))}")
+print(f"NAV reports:          {len(news.filter_by_tag('nav'))}")
+print(f"published today:      {len(news.filter_today())}")
+```
+
+### Per-stock news via the unified Stock class
+
+```python
+from settfex.services.set import Stock
+
+stock = Stock("CPALL")
+news = await stock.get_news(from_date="01/07/2026", to_date="17/07/2026")
+for item in news.news_info_list:
+    print(f"{item.news_datetime:%Y-%m-%d}  {item.headline}")
+```
+
+### Export to pandas
+
+```python
+import pandas as pd
+
+news = await get_news()
+df = pd.DataFrame([item.model_dump() for item in news.news_info_list])
+df = df.sort_values("news_datetime", ascending=False)
+```
+
+## Error Handling
+
+```python
+from settfex import FetchError, InvalidDateError
+from settfex.exceptions import InvalidLanguageError, InvalidSymbolError
+
+try:
+    news = await get_news(from_date="2026-07-15")   # ISO date -> caught BEFORE any request
+except InvalidDateError as exc:
+    print(exc)   # Invalid from_date '2026-07-15': expected dd/MM/yyyy (e.g. '15/07/2026') ...
+except InvalidLanguageError:
+    ...          # bad lang value
+except FetchError as exc:
+    ...          # HTTP/transport failure; exc.status_code when available
+```
+
+`ResponseParseError` (a `ValueError`) is raised for malformed/non-finite JSON, and
+`SymbolNotFoundError` for an HTTP 404.
+
+## API Endpoint
+
+```
+GET https://www.set.or.th/api/set/news/search?sourceId=company&lang={en|th}
+    [&symbol={SYMBOL}] [&fromDate=dd/MM/yyyy] [&toDate=dd/MM/yyyy] [&keyword={TEXT}]
+```
+
+Same host and Incapsula bot wall as the other SET services — `SessionManager` cookie
+warm-up is automatic (plain `curl` is blocked).
+
+## Related Services
+
+- [Stock List](list.md) — the symbol universe to join news onto
+- [Corporate Actions](corporate_action.md) — structured XD/XM events (vs. free-text news)
+- [Earnings Call (Opportunity Day)](earnings_call.md) — OPPDAY calendar and transcripts

--- a/examples/set/16_news.ipynb
+++ b/examples/set/16_news.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# SET News Service — Company News & Disclosures for All Stocks\n",
+    "\n",
+    "Fetch news/disclosures from the SET news search API — **market-wide in one call** (every stock on SET/mai), in English or Thai.\n",
+    "\n",
+    "**You will learn how to:**\n",
+    "- Fetch the latest trading day's company news for ALL stocks\n",
+    "- Filter by symbol, date window, and headline keyword\n",
+    "- Use the response helpers (`filter_today`, `filter_by_tag`, `filter_by_symbol`)\n",
+    "- Read Thai headlines and switch to the all-sources feed\n",
+    "- Access per-stock news via the unified `Stock` class\n",
+    "\n",
+    "> ⚠️ **Two API gotchas** (live-verified): dates must be **dd/MM/yyyy** (ISO `yyyy-MM-dd` → HTTP 400 — the library validates eagerly and raises `InvalidDateError`), and `sourceId` values other than `company` are silently ignored (→ ALL sources). Pass `source_id=None` when you *want* all sources."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import date, timedelta\n",
+    "\n",
+    "from settfex.services.set import Stock, get_news\n",
+    "\n",
+    "# In Jupyter, await works directly (no asyncio.run needed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 2. Latest company news — all stocks, one call\n",
+    "\n",
+    "Without date filters the API returns the **latest trading day** window (~150–200 items). Default `source_id=\"company\"` = company disclosures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "news = await get_news()\n",
+    "\n",
+    "print(f\"Items: {news.count} (totalCount={news.total_count})\")\n",
+    "for item in news.news_info_list[:8]:\n",
+    "    print(f\"{item.news_datetime:%Y-%m-%d %H:%M}  {item.symbol:10s} {item.headline[:70]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 3. Filter by symbol\n",
+    "\n",
+    "Symbols are auto-uppercased (`'cpall'` → `'CPALL'`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick a symbol that has news in the current window (first item's symbol)\n",
+    "symbol = news.news_info_list[0].symbol\n",
+    "\n",
+    "symbol_news = await get_news(symbol=symbol.lower())\n",
+    "print(f\"{symbol}: {symbol_news.count} item(s)\")\n",
+    "for item in symbol_news.news_info_list:\n",
+    "    print(f\"  {item.news_datetime:%Y-%m-%d %H:%M}  {item.headline[:70]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 4. Date window\n",
+    "\n",
+    "Pass `datetime.date`/`datetime` objects (converted to dd/MM/yyyy automatically) or dd/MM/yyyy strings. Keep windows modest — there is no pagination, so a 17-day window already returns ~2,800 items in one response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "to_d = date.today()\n",
+    "from_d = to_d - timedelta(days=7)\n",
+    "\n",
+    "week = await get_news(from_date=from_d, to_date=to_d)\n",
+    "print(f\"Last 7 days: {week.count} items\")\n",
+    "\n",
+    "# Items per day\n",
+    "per_day: dict[str, int] = {}\n",
+    "for item in week.news_info_list:\n",
+    "    key = item.news_datetime.strftime(\"%Y-%m-%d\")\n",
+    "    per_day[key] = per_day.get(key, 0) + 1\n",
+    "for day, n in sorted(per_day.items()):\n",
+    "    print(f\"  {day}: {n}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 5. Headline keyword search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dividend_news = await get_news(keyword=\"dividend\")\n",
+    "print(f\"Headlines matching 'dividend': {dividend_news.count}\")\n",
+    "for item in dividend_news.news_info_list[:5]:\n",
+    "    print(f\"  {item.symbol:10s} {item.headline[:70]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## 6. Response helpers\n",
+    "\n",
+    "Observed tags: `''`, `financial-statement`, `nav`, `ca`, `set-releases`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Published today:       {len(news.filter_today())}\")\n",
+    "print(f\"Financial statements:  {len(news.filter_by_tag('financial-statement'))}\")\n",
+    "print(f\"NAV reports:           {len(news.filter_by_tag('nav'))}\")\n",
+    "print(f\"For {symbol}:          {len(news.filter_by_symbol(symbol))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## 7. Thai headlines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thai_news = await get_news(lang=\"th\")\n",
+    "print(f\"Thai items: {thai_news.count}\")\n",
+    "for item in thai_news.news_info_list[:5]:\n",
+    "    print(f\"  {item.symbol:10s} {item.headline[:60]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## 8. All sources (superset)\n",
+    "\n",
+    "`source_id=None` omits the parameter → SET-issued releases, funds, DW/TFEX rows are included on top of company disclosures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_sources = await get_news(source_id=None)\n",
+    "print(f\"All sources: {all_sources.count}  vs  company only: {news.count}\")\n",
+    "\n",
+    "extra_tags = {item.tag for item in all_sources.news_info_list} - {\n",
+    "    item.tag for item in news.news_info_list\n",
+    "}\n",
+    "print(f\"Extra tags in the superset: {extra_tags}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {},
+   "source": [
+    "## 9. Per-stock access via the unified `Stock` class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8309879909854d7188b41380fd92a7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stock = Stock(\"CPALL\")\n",
+    "cpall_news = await stock.get_news(from_date=from_d, to_date=to_d)\n",
+    "print(f\"CPALL news in the last 7 days: {cpall_news.count}\")\n",
+    "for item in cpall_news.news_info_list[:5]:\n",
+    "    print(f\"  {item.news_datetime:%Y-%m-%d}  {item.headline[:70]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ed186c9a28b402fb0bc4494df01f08d",
+   "metadata": {},
+   "source": [
+    "## 10. Export to pandas (optional: `pip install \"settfex[dataframe]\"`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb1e1581032b452c9409d6c6813c49d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    df = pd.DataFrame([item.model_dump() for item in week.news_info_list])\n",
+    "    df = df.sort_values(\"news_datetime\", ascending=False)\n",
+    "    display(df[[\"news_datetime\", \"symbol\", \"headline\", \"tag\", \"url\"]].head(10))\n",
+    "except ImportError:\n",
+    "    print('pandas not installed — pip install \"settfex[dataframe]\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379cbbc1e968416e875cc15c1202d7eb",
+   "metadata": {},
+   "source": [
+    "## Use Cases\n",
+    "\n",
+    "- **Disclosure monitoring**: poll `get_news()` intraday and alert on new items for your portfolio symbols (`filter_by_symbol`)\n",
+    "- **Earnings season tracking**: `filter_by_tag('financial-statement')` per day\n",
+    "- **Event-driven research**: date-window queries joined onto price history\n",
+    "- **AI/LLM pipelines**: `get_news()` is the flat tool-calling entry point; feed `headline` + `url` into a summarizer per symbol\n",
+    "\n",
+    "**See also**: `docs/settfex/services/set/news.md` · Corporate Actions (05) for structured XD/XM events · Earnings Call (12) for OPPDAY transcripts"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/set/README.md
+++ b/examples/set/README.md
@@ -289,6 +289,23 @@ Complete, beginner-friendly tutorials for all SET (Stock Exchange of Thailand) s
 - Breadth/heatmap dashboards from constituent quotes
 - Index membership monitoring for rebalance events
 
+---
+
+### 16. SET News (`16_news.ipynb`)
+**What it does**: Company news/disclosures for ALL stocks (latest trading day or a date window), en/th
+
+**Learn how to**:
+- Fetch market-wide company news in one call
+- Filter by symbol, dd/MM/yyyy date window, and headline keyword
+- Use `filter_today` / `filter_by_tag` / `filter_by_symbol` helpers
+- Switch to the all-sources feed (`source_id=None`) and Thai headlines
+- Access per-stock news via `Stock("CPALL").get_news()`
+
+**Use cases**:
+- Portfolio disclosure monitoring and alerting
+- Earnings-season tracking via the `financial-statement` tag
+- Event-driven research joined onto price history
+
 ## Learning Path
 
 ### Beginners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.10.1"
+version = "0.11.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,13 +35,14 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 __author__ = "batt"
 __license__ = "MIT"
 
 # Public API exports - import commonly used classes/functions
 from settfex.exceptions import (
     FetchError,
+    InvalidDateError,
     InvalidLanguageError,
     InvalidSymbolError,
     SymbolNotFoundError,
@@ -52,6 +53,7 @@ from settfex.services.set import (
     IndexInfo,
     IndexListResponse,
     Language,
+    NewsSearchResponse,
     SetIndex,
     Stock,
     StockHighlightData,
@@ -62,6 +64,7 @@ from settfex.services.set import (
     get_index_composition,
     get_index_info,
     get_index_list,
+    get_news,
     get_profile,
     get_stock_list,
 )
@@ -85,6 +88,7 @@ __all__ = [
     "get_index_list",
     "get_index_info",
     "get_index_composition",
+    "get_news",
     # Data Models
     "StockListResponse",
     "StockHighlightData",
@@ -93,6 +97,7 @@ __all__ = [
     "IndexListResponse",
     "IndexInfo",
     "IndexCompositionResponse",
+    "NewsSearchResponse",
     # Utilities
     "AsyncDataFetcher",
     "FetcherConfig",
@@ -102,6 +107,7 @@ __all__ = [
     "SymbolNotFoundError",
     "InvalidSymbolError",
     "InvalidLanguageError",
+    "InvalidDateError",
     # Types
     "Language",
 ]

--- a/settfex/exceptions.py
+++ b/settfex/exceptions.py
@@ -24,6 +24,7 @@ __all__ = [
     "SymbolNotFoundError",
     "InvalidSymbolError",
     "InvalidLanguageError",
+    "InvalidDateError",
     "raise_for_status",
 ]
 
@@ -93,6 +94,10 @@ class InvalidSymbolError(ValueError):
 
 class InvalidLanguageError(ValueError):
     """A language string was not recognized (not ``en``/``th`` or an accepted alias)."""
+
+
+class InvalidDateError(ValueError):
+    """A date string was not in the format the target API accepts (dd/MM/yyyy for SET news)."""
 
 
 def raise_for_status(

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -17,6 +17,7 @@ from settfex.services.set.constants import (
     SET_INDEX_INFO_LIST_ENDPOINT,
     SET_INDEX_LIST_ENDPOINT,
     SET_LCP_BASE_URL,
+    SET_NEWS_SEARCH_ENDPOINT,
     SET_NVDR_HOLDER_ENDPOINT,
     SET_PRICE_PERFORMANCE_ENDPOINT,
     SET_STOCK_HIGHLIGHT_DATA_ENDPOINT,
@@ -67,6 +68,12 @@ from settfex.services.set.list import (
     StockSymbol,
     get_stock_list,
     suggest_symbol,
+)
+from settfex.services.set.news import (
+    NewsItem,
+    NewsSearchResponse,
+    NewsService,
+    get_news,
 )
 from settfex.services.set.stock import (
     Account,
@@ -146,6 +153,7 @@ __all__ = [
     "SET_EARNINGS_CALL_SEARCH_ENDPOINT",
     "SET_EARNINGS_CALL_DETAIL_ENDPOINT",
     "SET_EARNINGS_CALL_FILTER_ENDPOINT",
+    "SET_NEWS_SEARCH_ENDPOINT",
     # Stock List Service
     "StockListService",
     "StockListResponse",
@@ -187,6 +195,11 @@ __all__ = [
     "fetch_transcripts",
     "get_earnings_call_transcript",
     "fetch_youtube_transcript",
+    # News Service
+    "NewsService",
+    "NewsItem",
+    "NewsSearchResponse",
+    "get_news",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/constants.py
+++ b/settfex/services/set/constants.py
@@ -20,6 +20,11 @@ SET_FINANCIAL_CASH_FLOW_ENDPOINT = "/api/set/factsheet/{symbol}/financialstateme
 SET_STOCK_CHART_QUOTATION_ENDPOINT = "/api/set/stock/{symbol}/chart-quotation"
 SET_STOCK_LATEST_HISTORICAL_TRADING_ENDPOINT = "/api/set/stock/{symbol}/latest-historical-trading"
 
+# News search API (market-wide; uses ?lang=). sourceId=company filters to company disclosures —
+# unrecognized sourceId values are silently ignored (returns ALL sources). fromDate/toDate are
+# dd/MM/yyyy ONLY (ISO dates -> HTTP 400).
+SET_NEWS_SEARCH_ENDPOINT = "/api/set/news/search"
+
 # Market index endpoints (note: the index API uses ?language=, not ?lang= like stock endpoints)
 SET_INDEX_LIST_ENDPOINT = "/api/set/index/list"
 SET_INDEX_INFO_LIST_ENDPOINT = "/api/set/index/info/list"

--- a/settfex/services/set/news.py
+++ b/settfex/services/set/news.py
@@ -1,0 +1,448 @@
+"""SET News Service - Fetch news/disclosures for all stocks from the SET news search API.
+
+Two live-verified API gotchas (2026-07-19):
+
+- ``fromDate``/``toDate`` accept **dd/MM/yyyy only** (e.g. ``15/07/2026``); ISO ``yyyy-MM-dd``
+  is rejected with an opaque HTTP 400. Date filters are therefore converted from
+  ``datetime.date``/``datetime`` objects automatically, and date strings are validated
+  eagerly, raising :class:`~settfex.exceptions.InvalidDateError` before any request is made.
+- ``sourceId`` is not validated by the API: any unrecognized value (including empty) is
+  silently ignored and returns news from ALL sources. ``"company"`` is the only verified
+  filter value; pass ``source_id=None`` for the explicit all-sources behavior.
+
+Without date filters the API returns the latest-trading-day window only (~150-200 items).
+No pagination has been observed (a 17-day window returned 2,804 items in one response), so
+keep date windows modest.
+"""
+
+from datetime import date, datetime
+from typing import Any
+from urllib.parse import urlencode
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from settfex.exceptions import InvalidDateError, InvalidSymbolError, raise_for_status
+from settfex.services.set.constants import SET_BASE_URL, SET_NEWS_SEARCH_ENDPOINT
+from settfex.services.set.stock.utils import Language, normalize_language, normalize_symbol
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import decode_json, validate_or_raise
+
+# The SET news API accepts dates ONLY as dd/MM/yyyy (ISO yyyy-MM-dd -> HTTP 400).
+NEWS_DATE_FORMAT = "%d/%m/%Y"
+
+# Page-specific referer for the news search API (part of the Incapsula bypass).
+NEWS_REFERER = "https://www.set.or.th/en/market/news-and-alert/news"
+
+
+def _format_date_param(value: date | str, param_name: str) -> str:
+    """
+    Convert/validate a date filter into the API's dd/MM/yyyy wire format.
+
+    ``datetime.date``/``datetime`` objects are formatted directly; strings are parsed and
+    re-formatted (canonicalizing e.g. '5/7/2026' to '05/07/2026').
+
+    Args:
+        value: A ``datetime.date``/``datetime`` object, or a dd/MM/yyyy string
+        param_name: Parameter name used in the error message ('from_date'/'to_date')
+
+    Returns:
+        The date as a dd/MM/yyyy string
+
+    Raises:
+        InvalidDateError: If a string value is not a valid dd/MM/yyyy date
+    """
+    if isinstance(value, date):  # datetime subclasses date; one check covers both
+        return value.strftime(NEWS_DATE_FORMAT)
+    text = value.strip()
+    try:
+        parsed = datetime.strptime(text, NEWS_DATE_FORMAT)
+    except ValueError as exc:
+        error_msg = (
+            f"Invalid {param_name} '{value}': expected dd/MM/yyyy (e.g. '15/07/2026') or a "
+            f"datetime.date/datetime object. Note: the SET news API rejects ISO yyyy-MM-dd "
+            f"dates with HTTP 400."
+        )
+        logger.error(error_msg)
+        raise InvalidDateError(error_msg) from exc
+    return parsed.strftime(NEWS_DATE_FORMAT)
+
+
+class NewsItem(BaseModel):
+    """Model for a single news/disclosure item from the SET news search API."""
+
+    id: str = Field(
+        description="News id (numeric string, e.g. '105467000'; ids differ per language)"
+    )
+    news_datetime: datetime = Field(
+        alias="datetime",
+        description="Publication timestamp (timezone-aware, Asia/Bangkok +07:00)",
+    )
+    symbol: str = Field(description="Security symbol the news belongs to")
+    source: str = Field(description="Disclosing source code (usually the same symbol)")
+    url: str = Field(description="Full URL of the news detail page on set.or.th")
+    headline: str = Field(description="News headline (Thai or English, per requested lang)")
+    is_today_news: bool = Field(alias="isTodayNews", description="Whether published today")
+    view_clarification: bool | str | None = Field(
+        default=None,
+        alias="viewClarification",
+        description="Trading-alert clarification marker; only null observed as of 2026-07",
+    )
+    market_alert_type_id: int | str | None = Field(
+        default=None,
+        alias="marketAlertTypeId",
+        description="Market alert type id; only null observed as of 2026-07",
+    )
+    percent_price_change: float | None = Field(
+        default=None,
+        alias="percentPriceChange",
+        description="Price change tied to a market alert; only null observed as of 2026-07",
+    )
+    tag: str = Field(
+        default="",
+        description=(
+            "Category tag (observed: '', 'financial-statement', 'nav', 'ca', 'set-releases')"
+        ),
+    )
+    product: str = Field(description="Product code (observed: 'S', 'L', 'U', 'V', 'X', 'TFEX')")
+    lang: str = Field(description="Language of this item ('th' or 'en')")
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+        str_strip_whitespace=True,  # Strip whitespace from strings
+    )
+
+
+class NewsSearchResponse(BaseModel):
+    """Response model for the SET news search API."""
+
+    total_count: int = Field(alias="totalCount", description="Total matches reported by the API")
+    news_info_list: list[NewsItem] = Field(
+        default_factory=list, alias="newsInfoList", description="News items"
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+    )
+
+    @field_validator("news_info_list", mode="before")
+    @classmethod
+    def _null_to_empty_list(cls, value: Any) -> Any:
+        """Treat a ``null`` news list as an empty result set rather than failing validation."""
+        return [] if value is None else value
+
+    @property
+    def count(self) -> int:
+        """Number of items returned (matches ``total_count``; no pagination observed)."""
+        return len(self.news_info_list)
+
+    def filter_by_symbol(self, symbol: str) -> list[NewsItem]:
+        """
+        Filter news items by security symbol (case-insensitive).
+
+        Args:
+            symbol: Stock symbol to match (e.g., 'CPALL', 'cpall')
+
+        Returns:
+            List of news items for the specified symbol
+        """
+        target = symbol.strip().upper()
+        return [n for n in self.news_info_list if n.symbol.upper() == target]
+
+    def filter_today(self) -> list[NewsItem]:
+        """
+        Return only items flagged as published today.
+
+        Returns:
+            List of news items with ``is_today_news=True``
+        """
+        return [n for n in self.news_info_list if n.is_today_news]
+
+    def filter_by_tag(self, tag: str) -> list[NewsItem]:
+        """
+        Filter news items by category tag (case-insensitive exact match).
+
+        Args:
+            tag: Category tag (e.g., 'financial-statement', 'nav', 'ca', 'set-releases')
+
+        Returns:
+            List of news items with the specified tag
+        """
+        target = tag.strip().lower()
+        return [n for n in self.news_info_list if n.tag.lower() == target]
+
+
+class NewsService:
+    """
+    Service for fetching news/disclosures from the SET news search API.
+
+    Market-wide by default: one call returns the latest-trading-day news for ALL stocks
+    (company disclosures via ``sourceId=company``). Optional filters narrow the result by
+    symbol, date window (dd/MM/yyyy), headline keyword, and source.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """
+        Initialize the news service.
+
+        Args:
+            config: Optional fetcher configuration (uses defaults if None)
+
+        Example:
+            >>> # Uses SessionManager for automatic cookie handling
+            >>> service = NewsService()
+        """
+        self.config = config or FetcherConfig()
+        self.base_url = SET_BASE_URL
+        logger.info(f"NewsService initialized with base_url={self.base_url}")
+
+    @staticmethod
+    def _normalize_inputs(lang: Language, symbol: str | None) -> tuple[Language, str | None]:
+        """Normalize the language and (optional) symbol, raising typed errors when invalid."""
+        lang = normalize_language(lang)
+        if symbol is not None:
+            symbol = normalize_symbol(symbol)
+            if not symbol:
+                error_msg = "Stock symbol cannot be empty; pass symbol=None for all stocks"
+                logger.error(error_msg)
+                raise InvalidSymbolError(error_msg)
+        return lang, symbol
+
+    def _build_url(
+        self,
+        lang: str,
+        symbol: str | None,
+        from_date: date | str | None,
+        to_date: date | str | None,
+        keyword: str | None,
+        source_id: str | None,
+    ) -> str:
+        """Build the news search URL, encoding only the parameters actually provided."""
+        params: list[tuple[str, str]] = []
+        if source_id:
+            if source_id != "company":
+                logger.warning(
+                    f"sourceId '{source_id}' is not a verified value; the SET API silently "
+                    f"ignores unrecognized sourceId values and returns ALL sources"
+                )
+            params.append(("sourceId", source_id))
+        if symbol:
+            params.append(("symbol", symbol))
+        if from_date is not None:
+            params.append(("fromDate", _format_date_param(from_date, "from_date")))
+        if to_date is not None:
+            params.append(("toDate", _format_date_param(to_date, "to_date")))
+        if keyword and keyword.strip():
+            params.append(("keyword", keyword.strip()))
+        params.append(("lang", lang))
+        # safe="/" keeps dd/MM/yyyy dates byte-identical to the live-verified wire format
+        # while still percent-encoding free-text keywords (spaces, Thai text).
+        query = urlencode(params, safe="/")
+        return f"{self.base_url}{SET_NEWS_SEARCH_ENDPOINT}?{query}"
+
+    async def _request_json(self, url: str, symbol: str | None, context: str) -> Any:
+        """Fetch ``url`` and return the decoded JSON body, raising typed errors on failure."""
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            # Page-specific referer is part of the Incapsula bot-detection bypass
+            headers = AsyncDataFetcher.get_set_api_headers(referer=NEWS_REFERER)
+
+            # Fetch raw response - SessionManager handles cookies automatically
+            response = await fetcher.fetch(url, headers=headers)
+
+            if response.status_code != 200:
+                error_msg = (
+                    f"Failed to fetch news (symbol={symbol or 'all'}): HTTP {response.status_code}"
+                )
+                logger.error(error_msg)
+                raise_for_status(response.status_code, error_msg, symbol=symbol)
+
+            return decode_json(response.text, context=context)
+
+    async def fetch_news(
+        self,
+        lang: Language = "en",
+        symbol: str | None = None,
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        keyword: str | None = None,
+        source_id: str | None = "company",
+    ) -> NewsSearchResponse:
+        """
+        Fetch news/disclosures — market-wide (all stocks) by default.
+
+        Without date filters the API returns the latest-trading-day window only. No
+        pagination has been observed; keep date windows modest (a 17-day window already
+        returns ~2,800 items).
+
+        Args:
+            lang: Language for headlines ('en' or 'th', default: 'en')
+            symbol: Optional stock symbol filter (e.g., "CPALL"); None = all stocks
+            from_date: Optional window start — ``datetime.date``/``datetime`` or a
+                dd/MM/yyyy string (the API rejects ISO dates with HTTP 400)
+            to_date: Optional window end (same formats as ``from_date``)
+            keyword: Optional headline keyword filter (e.g., "dividend")
+            source_id: News source filter; ``"company"`` (default) = company disclosures,
+                ``None`` = all sources. Unrecognized values are silently ignored by the API
+                (equivalent to all sources) — a warning is logged for them.
+
+        Returns:
+            NewsSearchResponse with total count and the list of news items
+
+        Raises:
+            InvalidSymbolError: If an explicitly passed symbol is empty.
+            InvalidLanguageError: If the language is not recognized.
+            InvalidDateError: If a date string is not a valid dd/MM/yyyy date.
+            SymbolNotFoundError: If the API returns HTTP 404.
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = NewsService()
+            >>> news = await service.fetch_news()
+            >>> print(f"Items: {news.count}")
+            >>> for item in news.news_info_list[:5]:
+            ...     print(f"{item.news_datetime:%Y-%m-%d %H:%M} {item.symbol}: {item.headline}")
+        """
+        lang, symbol = self._normalize_inputs(lang, symbol)
+        url = self._build_url(
+            lang=lang,
+            symbol=symbol,
+            from_date=from_date,
+            to_date=to_date,
+            keyword=keyword,
+            source_id=source_id,
+        )
+        context = f"{symbol} (news-search)" if symbol else "set news-search"
+
+        logger.info(f"Fetching news (lang={lang}) from {url}")
+
+        data = await self._request_json(url, symbol=symbol, context=context)
+
+        # Validate response using Pydantic (context-rich on failure)
+        result = validate_or_raise(NewsSearchResponse, data, context=context)
+
+        if result.total_count != result.count:
+            logger.warning(
+                f"news-search totalCount={result.total_count} != items returned="
+                f"{result.count}; the API may have introduced pagination"
+            )
+
+        logger.info(f"Successfully fetched {result.count} news items")
+        return result
+
+    async def fetch_news_raw(
+        self,
+        lang: Language = "en",
+        symbol: str | None = None,
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        keyword: str | None = None,
+        source_id: str | None = "company",
+    ) -> dict[str, Any]:
+        """
+        Fetch news as raw dictionary without Pydantic validation.
+
+        Useful for debugging or when you need the raw API response.
+
+        Args:
+            lang: Language for headlines ('en' or 'th', default: 'en')
+            symbol: Optional stock symbol filter (e.g., "CPALL"); None = all stocks
+            from_date: Optional window start — ``datetime.date``/``datetime`` or a
+                dd/MM/yyyy string (the API rejects ISO dates with HTTP 400)
+            to_date: Optional window end (same formats as ``from_date``)
+            keyword: Optional headline keyword filter (e.g., "dividend")
+            source_id: News source filter; ``"company"`` (default) = company disclosures,
+                ``None`` = all sources
+
+        Returns:
+            Raw dictionary from API (keys: ``totalCount``, ``newsInfoList``)
+
+        Raises:
+            InvalidSymbolError: If an explicitly passed symbol is empty.
+            InvalidLanguageError: If the language is not recognized.
+            InvalidDateError: If a date string is not a valid dd/MM/yyyy date.
+            SymbolNotFoundError: If the API returns HTTP 404.
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = NewsService()
+            >>> raw_data = await service.fetch_news_raw()
+            >>> print(raw_data.keys())
+        """
+        lang, symbol = self._normalize_inputs(lang, symbol)
+        url = self._build_url(
+            lang=lang,
+            symbol=symbol,
+            from_date=from_date,
+            to_date=to_date,
+            keyword=keyword,
+            source_id=source_id,
+        )
+        context = f"{symbol} (news-search)" if symbol else "set news-search"
+
+        logger.info(f"Fetching raw news (lang={lang}) from {url}")
+
+        data = await self._request_json(url, symbol=symbol, context=context)
+        logger.debug(
+            f"Raw response keys: {list(data.keys()) if isinstance(data, dict) else type(data)}"
+        )
+        return data  # type: ignore[no-any-return]
+
+
+# Convenience function for quick access
+async def get_news(
+    lang: Language = "en",
+    symbol: str | None = None,
+    from_date: date | str | None = None,
+    to_date: date | str | None = None,
+    keyword: str | None = None,
+    source_id: str | None = "company",
+    config: FetcherConfig | None = None,
+) -> NewsSearchResponse:
+    """
+    Convenience function to fetch news/disclosures — all stocks by default.
+
+    Args:
+        lang: Language for headlines ('en' or 'th', default: 'en')
+        symbol: Optional stock symbol filter (e.g., "CPALL"); None = all stocks
+        from_date: Optional window start — ``datetime.date``/``datetime`` or a dd/MM/yyyy
+            string (the SET news API rejects ISO dates with HTTP 400)
+        to_date: Optional window end (same formats as ``from_date``)
+        keyword: Optional headline keyword filter (e.g., "dividend")
+        source_id: News source filter; ``"company"`` (default) = company disclosures,
+            ``None`` = all sources
+        config: Optional fetcher configuration
+
+    Returns:
+        NewsSearchResponse with total count and the list of news items
+
+    Raises:
+        InvalidSymbolError: If an explicitly passed symbol is empty.
+        InvalidLanguageError: If the language is not recognized.
+        InvalidDateError: If a date string is not a valid dd/MM/yyyy date.
+        SymbolNotFoundError: If the API returns HTTP 404.
+        FetchError: On other HTTP or transport failures.
+        ResponseParseError: If the response cannot be parsed.
+
+    Example:
+        >>> from settfex.services.set import get_news
+        >>> # Latest trading day, all stocks, English headlines
+        >>> news = await get_news()
+        >>> print(f"Items: {news.count}")
+        >>>
+        >>> # Thai headlines for one symbol over a date window
+        >>> from datetime import date
+        >>> news = await get_news(
+        ...     lang="th", symbol="CPALL", from_date=date(2026, 7, 1), to_date=date(2026, 7, 17)
+        ... )
+    """
+    service = NewsService(config=config)
+    return await service.fetch_news(
+        lang=lang,
+        symbol=symbol,
+        from_date=from_date,
+        to_date=to_date,
+        keyword=keyword,
+        source_id=source_id,
+    )

--- a/settfex/services/set/stock/stock.py
+++ b/settfex/services/set/stock/stock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -25,6 +25,7 @@ from settfex.services.set.stock.utils import Language, normalize_symbol
 from settfex.utils.data_fetcher import FetcherConfig
 
 if TYPE_CHECKING:
+    from settfex.services.set.news import NewsSearchResponse, NewsService
     from settfex.services.set.stock.profile_stock import StockProfile, StockProfileService
     from settfex.services.set.stock.shareholder import ShareholderData, ShareholderService
 
@@ -75,6 +76,7 @@ class Stock:
         self._latest_historical_trading_service: LatestHistoricalTradingService | None = None
         self._profile_service: StockProfileService | None = None
         self._shareholder_service: ShareholderService | None = None
+        self._news_service: NewsService | None = None
 
         logger.info(f"Stock instance created for symbol '{self.symbol}'")
 
@@ -287,6 +289,62 @@ class Stock:
         """
         logger.debug(f"Fetching shareholder data for {self.symbol} (lang={lang})")
         return await self.shareholder_service.fetch_shareholder_data(symbol=self.symbol, lang=lang)
+
+    @property
+    def news_service(self) -> NewsService:
+        """
+        Get or create news service instance.
+
+        Returns:
+            NewsService instance
+        """
+        if self._news_service is None:
+            from settfex.services.set.news import NewsService
+
+            self._news_service = NewsService(config=self.config)
+        return self._news_service
+
+    async def get_news(
+        self,
+        lang: Language = "en",
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        keyword: str | None = None,
+    ) -> NewsSearchResponse:
+        """
+        Fetch company news/disclosures for this stock.
+
+        Args:
+            lang: Language for headlines ('en' or 'th', default: 'en')
+            from_date: Optional window start — ``datetime.date``/``datetime`` or a
+                dd/MM/yyyy string (the SET news API rejects ISO dates); default:
+                latest trading day only
+            to_date: Optional window end (same formats as ``from_date``)
+            keyword: Optional headline keyword filter
+
+        Returns:
+            NewsSearchResponse with this stock's news items
+
+        Raises:
+            InvalidDateError: If a date string is not a valid dd/MM/yyyy date.
+            InvalidLanguageError: If the language is not recognized.
+            FetchError: On HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> stock = Stock("CPALL")
+            >>> news = await stock.get_news()
+            >>> for item in news.news_info_list[:5]:
+            ...     print(f"{item.news_datetime:%Y-%m-%d %H:%M} {item.headline}")
+        """
+        logger.debug(f"Fetching news for {self.symbol} (lang={lang})")
+        return await self.news_service.fetch_news(
+            lang=lang,
+            symbol=self.symbol,
+            from_date=from_date,
+            to_date=to_date,
+            keyword=keyword,
+        )
 
     # Future service methods (placeholders for documentation)
     # async def get_financials(self, lang: Language = "en") -> FinancialsData:

--- a/tests/services/set/test_news.py
+++ b/tests/services/set/test_news.py
@@ -1,0 +1,400 @@
+"""Tests for the SET news search service."""
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.exceptions import (
+    FetchError,
+    InvalidDateError,
+    InvalidLanguageError,
+    InvalidSymbolError,
+    SymbolNotFoundError,
+)
+from settfex.services.set.news import (
+    NewsItem,
+    NewsSearchResponse,
+    NewsService,
+    get_news,
+)
+from settfex.services.set.stock.stock import Stock
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
+
+# Thailand has no DST, so a fixed +07:00 offset is equivalent to Asia/Bangkok.
+BKK = timezone(timedelta(hours=7))
+
+# Sample test data based on the actual API response (live-verified 2026-07-19).
+SAMPLE: dict[str, Any] = {
+    "totalCount": 3,
+    "newsInfoList": [
+        {
+            "id": "105467000",
+            "datetime": "2026-07-17T21:06:00+07:00",
+            "symbol": "CPALL",
+            "source": "CPALL",
+            "url": (
+                "https://www.set.or.th/en/market/news-and-alert/newsdetails"
+                "?id=105467000&symbol=CPALL"
+            ),
+            "headline": "Financial Performance Quarter 2 (F45)",
+            "isTodayNews": False,
+            "viewClarification": None,
+            "marketAlertTypeId": None,
+            "percentPriceChange": None,
+            "tag": "financial-statement",
+            "product": "S",
+            "lang": "en",
+        },
+        {
+            "id": "105467001",
+            "datetime": "2026-07-17T08:00:00+07:00",
+            "symbol": "PTT",
+            "source": "PTT",
+            "url": (
+                "https://www.set.or.th/en/market/news-and-alert/newsdetails?id=105467001&symbol=PTT"
+            ),
+            "headline": "Notification of the Resignation of the Chief Executive Officer",
+            "isTodayNews": True,
+            "viewClarification": None,
+            "marketAlertTypeId": None,
+            "percentPriceChange": None,
+            "tag": "",
+            "product": "S",
+            "lang": "en",
+        },
+        {
+            "id": "105467002",
+            "datetime": "2026-07-17T17:30:00+07:00",
+            "symbol": "S50U26",
+            "source": "TFEX",
+            "url": (
+                "https://www.set.or.th/en/market/news-and-alert/newsdetails"
+                "?id=105467002&symbol=S50U26"
+            ),
+            "headline": "TFEX Daily Settlement Price",
+            "isTodayNews": False,
+            "viewClarification": None,
+            "marketAlertTypeId": None,
+            "percentPriceChange": None,
+            "tag": "set-releases",
+            "product": "TFEX",
+            "lang": "en",
+        },
+    ],
+}
+
+
+def _response(
+    payload: dict[str, Any] | None = None,
+    *,
+    status_code: int = 200,
+    text: str | None = None,
+) -> FetchResponse:
+    """Build a FetchResponse whose body is ``payload`` as JSON (or the literal ``text``)."""
+    body = text if text is not None else json.dumps(payload)
+    return FetchResponse(
+        status_code=status_code,
+        content=body.encode("utf-8"),
+        text=body,
+        headers={},
+        url="https://www.set.or.th/api/set/news/search?sourceId=company&lang=en",
+        elapsed=0.1,
+    )
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Patch AsyncDataFetcher inside the news module; yield its async instance.
+
+    The patched class mock is attached as ``.cls`` so tests can assert on the referer passed
+    to ``get_set_api_headers``.
+    """
+    with patch("settfex.services.set.news.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        fetcher_instance.cls = mock
+        yield fetcher_instance
+
+
+class TestModelParsing:
+    """Pydantic parsing: camelCase aliases, timezone handling, null-tolerant fields."""
+
+    def test_news_item_aliases_and_structure(self):
+        """camelCase payload lands in snake_case fields via aliases."""
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        assert response.total_count == 3
+        assert len(response.news_info_list) == 3
+        item = response.news_info_list[0]
+        assert isinstance(item, NewsItem)
+        assert item.id == "105467000"
+        assert item.symbol == "CPALL"
+        assert item.is_today_news is False
+        assert item.tag == "financial-statement"
+        assert item.product == "S"
+        assert item.lang == "en"
+
+    def test_datetime_is_tz_aware(self):
+        """The publication timestamp keeps its +07:00 offset."""
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        item = response.news_info_list[0]
+        assert item.news_datetime.tzinfo is not None
+        assert item.news_datetime == datetime(2026, 7, 17, 21, 6, tzinfo=BKK)
+
+    def test_null_only_fields_tolerate_null(self):
+        """viewClarification/marketAlertTypeId/percentPriceChange accept null."""
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        item = response.news_info_list[0]
+        assert item.view_clarification is None
+        assert item.market_alert_type_id is None
+        assert item.percent_price_change is None
+
+    def test_null_only_fields_tolerate_future_values(self):
+        """If SET starts populating the alert fields, permissive unions absorb them."""
+        raw = dict(SAMPLE["newsInfoList"][0])
+        raw.update({"viewClarification": True, "marketAlertTypeId": 3, "percentPriceChange": -1.5})
+        item = NewsItem.model_validate(raw)
+        assert item.view_clarification is True
+        assert item.market_alert_type_id == 3
+        assert item.percent_price_change == -1.5
+
+        raw.update({"viewClarification": "Y", "marketAlertTypeId": "3"})
+        item = NewsItem.model_validate(raw)
+        assert item.view_clarification == "Y"
+        assert item.market_alert_type_id == "3"
+
+    def test_populate_by_name(self):
+        """Models can be built from snake_case field names as well as aliases."""
+        item = NewsItem(
+            id="1",
+            news_datetime=datetime(2026, 7, 17, 9, 0, tzinfo=BKK),
+            symbol="CPALL",
+            source="CPALL",
+            url="https://www.set.or.th/x",
+            headline="Test",
+            is_today_news=True,
+            product="S",
+            lang="en",
+        )
+        assert item.symbol == "CPALL"
+        assert item.tag == ""
+        assert item.view_clarification is None
+
+    def test_response_null_news_list_becomes_empty(self):
+        """A null newsInfoList (empty result set) parses as an empty list."""
+        response = NewsSearchResponse.model_validate({"totalCount": 0, "newsInfoList": None})
+        assert response.count == 0
+        assert response.news_info_list == []
+
+
+class TestResponseHelpers:
+    """Count property and filter helpers on NewsSearchResponse."""
+
+    def test_count(self):
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        assert response.count == 3
+
+    def test_filter_by_symbol_case_insensitive(self):
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        items = response.filter_by_symbol("cpall")
+        assert len(items) == 1
+        assert items[0].symbol == "CPALL"
+
+    def test_filter_today(self):
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        items = response.filter_today()
+        assert len(items) == 1
+        assert items[0].symbol == "PTT"
+
+    def test_filter_by_tag_case_insensitive(self):
+        response = NewsSearchResponse.model_validate(SAMPLE)
+        items = response.filter_by_tag("FINANCIAL-STATEMENT")
+        assert len(items) == 1
+        assert items[0].symbol == "CPALL"
+
+
+@pytest.mark.asyncio
+class TestNewsService:
+    """Service behavior: URL building, headers, normalization, error paths."""
+
+    async def test_init_default_config(self):
+        service = NewsService()
+        assert service.config is not None
+        assert service.base_url == "https://www.set.or.th"
+
+    async def test_init_custom_config(self):
+        config = FetcherConfig(timeout=60, max_retries=5)
+        service = NewsService(config=config)
+        assert service.config.timeout == 60
+        assert service.config.max_retries == 5
+
+    async def test_fetch_news_success(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await NewsService().fetch_news()
+        assert isinstance(result, NewsSearchResponse)
+        assert result.count == 3
+        assert all(isinstance(item, NewsItem) for item in result.news_info_list)
+
+    async def test_url_default_params(self, mock_fetcher):
+        """Default call queries company disclosures in English with no other filters."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news()
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "/api/set/news/search?" in url
+        assert "sourceId=company" in url
+        assert "lang=en" in url
+        assert "symbol=" not in url
+        assert "fromDate" not in url
+        assert "toDate" not in url
+        assert "keyword" not in url
+
+    async def test_url_with_all_filters(self, mock_fetcher):
+        """All filters land on the wire; date objects are zero-padded dd/MM/yyyy."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news(
+            symbol="cpall",
+            from_date=date(2026, 7, 5),
+            to_date="17/07/2026",
+            keyword="dividend",
+        )
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "symbol=CPALL" in url
+        assert "fromDate=05/07/2026" in url
+        assert "toDate=17/07/2026" in url
+        assert "keyword=dividend" in url
+
+    async def test_url_source_id_none_omits_param(self, mock_fetcher):
+        """source_id=None is the explicit all-sources switch (param omitted)."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news(source_id=None)
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "sourceId" not in url
+
+    async def test_keyword_is_url_encoded(self, mock_fetcher):
+        """Free-text keywords are encoded while date slashes stay literal."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news(keyword="cash dividend", from_date="15/07/2026")
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert " " not in url
+        assert "cash+dividend" in url
+        assert "fromDate=15/07/2026" in url
+
+    async def test_date_string_is_canonicalized(self, mock_fetcher):
+        """A non-zero-padded dd/MM/yyyy string is re-formatted to the canonical form."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news(from_date="5/7/2026")
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "fromDate=05/07/2026" in url
+
+    async def test_date_accepts_datetime_object(self, mock_fetcher):
+        """A datetime (subclass of date) converts to dd/MM/yyyy."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news(from_date=datetime(2026, 7, 5, 9, 30))
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "fromDate=05/07/2026" in url
+
+    async def test_referer_header(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news()
+        referer = mock_fetcher.cls.get_set_api_headers.call_args.kwargs["referer"]
+        assert referer == "https://www.set.or.th/en/market/news-and-alert/news"
+
+    async def test_lang_normalization(self, mock_fetcher):
+        """Thai aliases normalize to lang=th on the wire."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        service = NewsService()
+        for alias in ("th", "TH", "tha", "thai"):
+            await service.fetch_news(lang=alias)  # type: ignore[arg-type]
+            url = mock_fetcher.fetch.call_args.args[0]
+            assert "lang=th" in url
+
+    async def test_invalid_language_raises(self, mock_fetcher):
+        with pytest.raises(InvalidLanguageError, match="Invalid language"):
+            await NewsService().fetch_news(lang="fr")  # type: ignore[arg-type]
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_invalid_date_string_raises(self, mock_fetcher):
+        """ISO and other malformed date strings fail eagerly, before any request."""
+        with pytest.raises(InvalidDateError, match="dd/MM/yyyy"):
+            await NewsService().fetch_news(from_date="2026-07-15")
+        with pytest.raises(InvalidDateError, match="dd/MM/yyyy"):
+            await NewsService().fetch_news(to_date="15-07-2026")
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_empty_symbol_raises(self, mock_fetcher):
+        with pytest.raises(InvalidSymbolError):
+            await NewsService().fetch_news(symbol="   ")
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_http_error_raises_fetch_error(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(status_code=400, text="Bad Request")
+        with pytest.raises(FetchError) as exc_info:
+            await NewsService().fetch_news()
+        assert exc_info.value.status_code == 400
+
+    async def test_http_404_with_symbol_raises_symbol_not_found(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(status_code=404, text="Not Found")
+        with pytest.raises(SymbolNotFoundError):
+            await NewsService().fetch_news(symbol="XXXX")
+
+    async def test_json_decode_error(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(text="Invalid JSON")
+        with pytest.raises(ResponseParseError, match="news"):
+            await NewsService().fetch_news()
+
+
+@pytest.mark.asyncio
+class TestFetchRaw:
+    """fetch_news_raw returns the raw dict and shares the URL builder."""
+
+    async def test_fetch_news_raw_returns_dict(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        raw = await NewsService().fetch_news_raw()
+        assert isinstance(raw, dict)
+        assert raw["totalCount"] == 3
+        assert "newsInfoList" in raw
+
+    async def test_fetch_news_raw_builds_same_url(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        await NewsService().fetch_news_raw(symbol="ptt", from_date=date(2026, 7, 1))
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "symbol=PTT" in url
+        assert "fromDate=01/07/2026" in url
+        assert "sourceId=company" in url
+
+
+@pytest.mark.asyncio
+class TestConvenienceFunction:
+    """Top-level get_news() passes arguments through."""
+
+    async def test_get_news_passthrough(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await get_news(symbol="CPALL")
+        assert isinstance(result, NewsSearchResponse)
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "symbol=CPALL" in url
+
+    async def test_get_news_custom_config(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        result = await get_news(config=FetcherConfig(timeout=60))
+        assert isinstance(result, NewsSearchResponse)
+        assert result.count == 3
+
+
+@pytest.mark.asyncio
+class TestStockIntegration:
+    """Stock.get_news() delegates with the symbol pre-filled."""
+
+    async def test_stock_get_news_prefills_symbol(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE)
+        stock = Stock("cpall")
+        result = await stock.get_news()
+        assert isinstance(result, NewsSearchResponse)
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert "symbol=CPALL" in url
+        assert "sourceId=company" in url

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Adds SET service #16 — **News** (`settfex.services.set.news`): company news/disclosures for **all stocks** in one call from `GET /api/set/news/search`, following the house three-tier pattern:

- `get_news()` — one-call convenience (LLM tool-calling entry point)
- `NewsService.fetch_news()` → typed `NewsSearchResponse` (`count`, `filter_by_symbol()`, `filter_today()`, `filter_by_tag()`)
- `NewsService.fetch_news_raw()` — raw dict escape hatch
- Plus `Stock("CPALL").get_news()` with the symbol pre-filled

**Filters** (all live-verified against the real API): `symbol`, `from_date`/`to_date`, `keyword`, `source_id`, `lang` (`en`/`th`).

## Two live-verified API gotchas (documented + guarded)

1. **Dates are dd/MM/yyyy ONLY** — ISO `yyyy-MM-dd` → opaque HTTP 400. The service converts `datetime.date`/`datetime` objects automatically and validates strings eagerly via the new **`InvalidDateError`** (a `ValueError`), so the failure is typed and self-explaining, before any request is made.
2. **`sourceId` is not validated by the API** — any unrecognized value (incl. empty) is silently ignored and returns ALL sources. `"company"` is the only verified value; `source_id=None` is the explicit all-sources switch (unverified values log a warning).

Both are recorded in CLAUDE.md **Known Gotchas** and the service doc.

## Also in this PR

- **Stale-inventory fix:** the TFEX underlying-price service (shipped in 0.3.0) was missing from the CLAUDE.md/README inventories, TFEX notebook list, and notebook counts — corrected to **19 services (16 SET + 3 TFEX)** and 19 notebooks.
- Service doc `docs/settfex/services/set/news.md`, notebook `examples/set/16_news.ipynb`, CHANGELOG 0.11.0 entry, version bump in `pyproject.toml` + `settfex/__init__.py` + `uv.lock`.

## Verification

- `uv run pytest` — **443 passed**, coverage 81% (32 new tests in `tests/services/set/test_news.py`)
- `uv run mypy settfex/` (strict) and `uv run mypy .` — clean
- `uv run ruff check .` and `uv run ruff format --check .` — clean
- **Live verification** (`scripts/settfex/services/set/verify_news.py`, local-only since `scripts/` is gitignored): **8/8 PASS** — 153 en / 157 th items on the latest trading day, symbol filter, 7-day window (796 items), keyword filter, all-sources superset (206 ≥ 153), eager ISO-date rejection, response helpers, and `Stock.get_news()`

## Release note

This PR does **not** push the `v0.11.0` tag — per the release process, pushing the tag after merge triggers the PyPI OIDC publish + GitHub Release (the CHANGELOG `## [0.11.0]` section becomes the release body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)