### PR TITLE
chore(gitignore): ignore local tmp/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,9 @@ backups/
 *.db
 *.sqlite
 
+# Local scratch (e.g. HAR captures, ad-hoc dumps) — may contain cookies/tokens; never commit
+tmp/
+
 # OS specific
 .DS_Store
 .DS_Store?


### PR DESCRIPTION
## Summary

`tmp/` sat untracked in `git status` with no ignore rule. It holds local scratch (currently a `har/` directory) — HAR captures can embed session cookies/tokens, so the directory must never be committable.

- Adds `tmp/` to `.gitignore` under a new "Local scratch" section (`.gitignore:183`)
- Verified: `git check-ignore` matches `tmp/` and `tmp/har`; nothing under `tmp/` was ever tracked, so no untracking needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)