### PR TITLE
docs(news): add historical-news notebook example (§11, rolling 5-year window)

### DIFF
--- a/examples/set/16_news.ipynb
+++ b/examples/set/16_news.ipynb
@@ -263,6 +263,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c4eec24",
+   "source": "## 11. Historical news & the rolling 5-year window\n\nThe endpoint serves a **rolling ~5-year history — exactly 1826 days** (5 × 365 + 1 leap day). A window whose `from_date` is older than `today − 1826 days` is rejected with **HTTP 400**, surfaced by the library as `FetchError` (**not** `InvalidDateError` — that one is only for malformed dd/MM/yyyy strings). The check is on the window's **start**, and the API does **not** clip to the allowed range: one day too old and the whole request fails.\n\n> Live-verified 2026-07-20. The boundary is *rolling* — always `today − 1826 days`, never a fixed calendar date. Within the window, historical queries work exactly like the date-window query in §4.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b5d68439",
+   "source": "# Fetch a historical window well inside the 5-year limit (~1 year ago).\n# Keep it small — there is no pagination, so a wide window returns everything at once.\nhist_to = date.today() - timedelta(days=365)\nhist_from = hist_to - timedelta(days=5)\n\nhist = await get_news(from_date=hist_from, to_date=hist_to)\nprint(f\"{hist_from} -> {hist_to}: {hist.count} items\")\n\nif hist.news_info_list:\n    dts = [item.news_datetime for item in hist.news_info_list]\n    print(f\"  earliest: {min(dts):%Y-%m-%d %H:%M}\")\n    print(f\"  latest:   {max(dts):%Y-%m-%d %H:%M}\\n\")\n    for item in hist.news_info_list[:5]:\n        print(f\"  {item.news_datetime:%Y-%m-%d}  {item.symbol:10s} {item.headline[:60]}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "ac22b85d",
+   "source": "from settfex.exceptions import FetchError\n\nOLDEST_DAYS = 1826  # rolling 5-year window (= 5*365 + 1 leap day), live-verified 2026-07-20\noldest_ok = date.today() - timedelta(days=OLDEST_DAYS)\ntoo_old = date.today() - timedelta(days=OLDEST_DAYS + 1)\n\n\nasync def try_from(from_d: date) -> None:\n    \"\"\"Probe a single-day window and report OK (served) vs rejected (too old).\"\"\"\n    days_back = (date.today() - from_d).days\n    try:\n        res = await get_news(from_date=from_d, to_date=from_d)\n        print(f\"  {from_d} (today-{days_back}d): OK       -> {res.count} items\")\n    except FetchError as exc:\n        # HTTP 400 for over-old windows surfaces as FetchError (NOT InvalidDateError)\n        print(f\"  {from_d} (today-{days_back}d): rejected -> {type(exc).__name__} (HTTP 400)\")\n\n\nprint(f\"Oldest servable date today: {oldest_ok}\\n\")\nawait try_from(oldest_ok)  # exactly the boundary -> OK\nawait try_from(too_old)    # one day too old   -> FetchError",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "379cbbc1e968416e875cc15c1202d7eb",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

Adds **Section 11 — Historical news & the rolling 5-year window** to `examples/set/16_news.ipynb`. Complements the existing "Date window" section (§4) by showing how to query **historical** news and where the endpoint's history actually ends.

## Cells added (before "Use Cases")

1. **Markdown** — explains the endpoint serves a **rolling ~5-year history = exactly 1826 days** (5×365 + leap day). Over-old windows → **HTTP 400**, surfaced as `FetchError` (not `InvalidDateError`); the check is on `from_date` and the API does **not** clip to the allowed range; the boundary is rolling (`today − 1826 days`).
2. **Code** — fetches a historical window ~1 year back and prints count + earliest/latest + sample headlines.
3. **Code** — boundary demo: `today − 1826d` is served, `today − 1827d` is gracefully caught as `FetchError`.

## Verification

Both code cells were executed against the live SET API:

- Historical fetch: `2025-07-15 → 2025-07-20: 413 items`
- Boundary: `2021-07-20 (today-1826d): OK → 160 items` · `2021-07-19 (today-1827d): rejected → FetchError (HTTP 400)`

No saved outputs (matches the notebook's existing convention). SET notebook count unchanged (16), so `CLAUDE.md` needs no update. This documents the same limit already noted in `CLAUDE.md` Known Gotchas (PR #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)