### PR TITLE
feat(sec): SEC IDISC document service — list & download raw disclosures (0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-20
+
+### Added
+
+- **SEC IDISC document services** (`settfex.services.sec`) — list and download the **raw
+  disclosure documents** companies file with the Thai SEC (`market.sec.or.th`), for any
+  SET/mai-listed issuer. Covers **five categories**: financial statements (the original
+  `FINANCIAL_STATEMENTS.XLSX` package), Form 56-1, Form 56-2, Key Financial Ratio, and MD&A.
+  - Three tiers: `get_sec_documents()` / `download_sec_document(s)()` (flat convenience, LLM
+    entry points) → `FinancialReportService.fetch_documents()` / `DocumentDownloadService`
+    (typed `SecDocument` / `DownloadedFile` models) → `fetch_documents_raw()` (raw parsed rows).
+  - Unified `SecCompany("CPALL")` facade; company resolver `resolve_company()` /
+    `search_companies()` (maps a symbol/name → SEC `uniqueIDReference`).
+  - Listing replays the ASP.NET WebForms search (GET fresh `__VIEWSTATE` tokens → form POST →
+    HTML-table parse via the stdlib `html.parser`, no new dependency) and follows the
+    "display all results" ViewMore pages so large sections are returned in full
+    (`follow_view_more=True`). Category filtering, `en`/`th`, and dd/mm/yyyy date windows
+    (`datetime.date`/`datetime` objects or strings; ISO strings raise `InvalidDateError`).
+  - Downloads return the raw bytes as `DownloadedFile` (with `.save(dest)`), with concurrent
+    `download_all()` (bounded, tolerant of per-item failures, optional `tqdm` progress).
+    Dead links are detected: the SEC host answers a missing file with an HTML "file not found"
+    page under HTTP 200, which raises `FetchError` instead of returning a garbage payload.
+  - Verified `market.sec.or.th` endpoints: `POST …/api/company/valuebyuniqueId`,
+    `GET`/`POST …/{lang}/FinancialReport/{FS|R561|R562|KFR}`, `GET …/{lang}/ViewMore/{slug}`,
+    `GET …/Download?FILEID=…`, `GET …/ipos/Common/IPOSGetFile.aspx?id=…`.
+- **`AsyncDataFetcher` extensions** (backward-compatible): form-encoded POST via a new `data=`
+  argument (alongside `json_body=`), and a `decode_text=False` flag to fetch binary payloads
+  (zip/xlsx/pdf) without the wasteful text decode. Both default to current behavior.
+- Example notebook `examples/sec/01_financial_report.ipynb` and service doc
+  `docs/settfex/services/sec/financial_report.md`.
+
 ## [0.11.0] - 2026-07-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,14 @@ settfex/
 │   │   │                     #   nvdr_holder, board_of_director, trading_stat,
 │   │   │                     #   price_performance, chart_quotation,
 │   │   │                     #   latest_historical_trading, financial/, stock.py, utils.py
-│   │   └── tfex/             # TFEX services: list.py, trading_statistics.py, underlying_price.py
+│   │   ├── tfex/             # TFEX services: list.py, trading_statistics.py, underlying_price.py
+│   │   └── sec/              # SEC IDISC (market.sec.or.th) document services: constants.py,
+│   │                         #   company.py, financial_report.py, download.py, sec.py, utils.py
 │   └── utils/                # http.py, data_fetcher.py, session_manager.py,
 │                             #   session_cache.py, logging.py
 ├── tests/                     # Mirror of settfex/ with test_ prefix
 ├── docs/                      # Service docs, guides, solutions
-├── examples/                  # 19 Jupyter notebooks (16 SET + 3 TFEX)
+├── examples/                  # 20 Jupyter notebooks (16 SET + 3 TFEX + 1 SEC)
 ├── scripts/                   # Verification scripts per service
 ├── .github/                   # CI and agent instructions
 ├── pyproject.toml             # uv-based config
@@ -116,7 +118,7 @@ data = await get_highlight_data("CPALL")   # or convenience function
 all_stocks = await get_stock_list()        # no cookie params needed
 ```
 
-## Services Inventory (19 total)
+## Services Inventory (20 total)
 
 ### SET Services (16)
 
@@ -147,6 +149,14 @@ all_stocks = await get_stock_list()        # no cookie params needed
 | 2 | Trading Statistics | `trading_statistics.py` | `/api/set/tfex/series/{sym}/trading-statistics` | Settlement, margin (IM/MM), theoretical price, days to maturity |
 | 3 | Underlying Price | `underlying_price.py` | `/api/set/tfex/series/{sym}/underlying-price` | Underlying instrument price (SET50 index spot for index futures/options): last/prior/high/low, change, total volume/value, P/E, P/BV |
 
+### SEC Services (1)
+
+Host is **`market.sec.or.th`** (the Thai SEC IDISC system), NOT set.or.th — a separate top-level package `services/sec/`.
+
+| # | Service | Module | Endpoint Pattern | Key Data |
+|---|---|---|---|---|
+| 1 | SEC Documents | `sec/{company,financial_report,download,sec}.py` | `POST /public/idisc/api/company/valuebyuniqueId`; `GET`/`POST /public/idisc/{lang}/FinancialReport/{FS\|R561\|R562\|KFR}`; `GET /public/idisc/{lang}/ViewMore/{slug}`; `GET /public/idisc/Download?FILEID=`; `GET /ipos/Common/IPOSGetFile.aspx?id=` | List + download **raw disclosure documents** for any issuer across 5 categories (`DocumentCategory`: financial_statement/form_56_1/form_56_2/key_financial_ratio/mda). Company resolver (`resolve_company` → 10-digit uniqueIDReference); listing replays the ASP.NET WebForms search (GET `__VIEWSTATE` → form POST → stdlib HTML-table parse), follows ViewMore for complete large sections; downloads return raw bytes (`DownloadedFile.save()`), concurrent `download_all`, soft-404 detection (dead links = HTML "file not found" under HTTP 200 → `FetchError`). `SecCompany("CPALL")` facade; `get_sec_documents()`/`download_sec_document(s)()`. dd/mm/yyyy dates. Stateless host (no SessionManager). |
+
 ### Unified Stock Class (`stock/stock.py`)
 Single entry point for SET stock data — initialize with symbol, access all services via lazy-init properties:
 ```python
@@ -166,6 +176,15 @@ index = SetIndex("SET50")
 info = await index.get_info()                  # last/chg/OHLC/vol/value/status
 constituents = await index.get_constituents()  # 50 stocks w/ quote rows
 latest = await index.get_latest_price()        # latest traded index value vs now
+```
+
+### Unified SecCompany Class (`sec/sec.py`)
+Entry point for an issuer's SEC disclosure documents (host `market.sec.or.th`):
+```python
+sec = SecCompany("CPALL")
+docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
+file = await sec.download(docs[0], dest_dir="./out")   # DownloadedFile (raw bytes) + save
+files = await sec.download_all(docs, dest_dir="./out")  # concurrent
 ```
 
 ## API Design Principles
@@ -240,6 +259,10 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full, versioned release history — t
 - **News API date format (dd/MM/yyyy ONLY):** `fromDate`/`toDate` on `/api/set/news/search` reject ISO `yyyy-MM-dd` with an opaque HTTP 400. The news service converts `datetime.date`/`datetime` objects automatically and validates strings eagerly, raising `InvalidDateError` before any request is made.
 - **News API `sourceId` is not validated:** any value other than `company` (including empty) is silently ignored and returns ALL sources (a superset incl. TFEX rows and `set-releases` items). `source_id=None` is the intended all-sources switch; `"company"` is the only verified filter value — the service logs a warning for unverified values.
 - **News API history is a rolling ~5-year window (1826 days):** the `/api/set/news/search` endpoint serves only the trailing **1826 days** (= 5 calendar years incl. the leap day) — live-probed 2026-07-20: `from_date` = today−1826d works, today−1827d and older → **HTTP 400**. The check is on `from_date` (the window's *start*); if it predates the cutoff the whole request 400s (it does **not** clip to the allowed range). This surfaces as `FetchError`, **not** `InvalidDateError` (the latter is only for malformed dd/MM/yyyy strings). The boundary is rolling — always `today − 1826 days`.
+- **SEC service is a different host + HTML, not JSON:** `services/sec/` targets `market.sec.or.th` (Thai SEC IDISC), an ASP.NET WebForms app — NOT set.or.th. The document search has no JSON list endpoint; it is a form postback returning HTML tables that the service parses (stdlib `html.parser`). It reuses `AsyncDataFetcher` with `use_session=False` (stateless, like `earnings_call.py`); dates are **dd/mm/yyyy** (note: SET news is dd/MM/yyyy — same digits, but the SEC form is its own endpoint). Do not route SEC URLs through SessionManager (its auto-detect would mis-warm them as SET).
+- **SEC VIEWSTATE tokens are mandatory and must be fresh:** the search POST must echo `__VIEWSTATE`/`__VIEWSTATEGENERATOR`/`__EVENTVALIDATION` scraped from a fresh GET of the same page. Omitting them does **not** error — it silently returns a wrong, broader result set (43 vs 7 rows in testing). `FinancialReportService` always GETs tokens immediately before each POST; no cookie/session binding is needed (cross-request works).
+- **SEC downloads can be soft-404s (HTTP 200 + HTML):** a dead `Download?FILEID=` link returns an HTML page `ไม่พบไฟล์ที่ระบุ` ("file not found") under **HTTP 200**, notably for some recent `dat/annual/` (56-2) rows whose file actually lives under `dat/f56/`. `DocumentDownloadService.download` validates the content-type and raises `FetchError` instead of returning the garbage bytes; `download_all(..., continue_on_error=True)` skips such items.
+- **A SEC `FS` search returns three categories at once:** querying `ddlReportType=FS` returns financial statements **+** Key Financial Ratio **+** MD&A sections in one HTML response (each its own table); large sections truncate inline and expose a `ViewMore/{fs-norm|fs-kf|fs-mda}` link the listing follows (`follow_view_more=True`). MD&A rows use different columns (Date/Time/Heading/Link, no Name) — the mapper fills `company_name` from the resolved company as a fallback.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Want to dig deeper? Check out our detailed guides:
 - **[TFEX Series List Service](docs/settfex/services/tfex/list.md)** - Get all futures and options series on TFEX
 - **[TFEX Trading Statistics Service](docs/settfex/services/tfex/trading_statistics.md)** - Trading statistics, settlement prices, and margin requirements
 
+### SEC Services (market.sec.or.th)
+
+- **[SEC Document Service](docs/settfex/services/sec/financial_report.md)** - List and download the raw disclosure documents filed with the Thai SEC (the original financial-statement Excel package, Form 56-1, Form 56-2, Key Financial Ratio, MD&A)
+
 ### Utilities
 
 - **[AsyncDataFetcher](docs/settfex/utils/data_fetcher.md)** - Low-level async HTTP client

--- a/docs/settfex/services/sec/financial_report.md
+++ b/docs/settfex/services/sec/financial_report.md
@@ -1,0 +1,193 @@
+# SEC Document Service (market.sec.or.th)
+
+## Overview
+
+Lists and downloads **raw disclosure documents** filed with the Thai SEC's information-disclosure
+system (IDISC), for any SET/mai-listed issuer. Unlike the SET services (which return *modeled*
+market data), this returns the **original source files** companies file — e.g. the
+`FINANCIAL_STATEMENTS.XLSX` package, and the annual Form 56-1 / 56-2 PDFs.
+
+Covers **five document categories**: financial statements, Form 56-1 (Annual Registration
+Statement), Form 56-2 (Annual Report / "One Report"), Key Financial Ratio, and MD&A.
+
+Modules: `settfex/services/sec/` · Host: `https://market.sec.or.th` (an ASP.NET WebForms app —
+stateless, no login; `curl_cffi` browser impersonation passes its bot wall). Three tiers, as
+everywhere in settfex:
+
+- `get_sec_documents()` / `download_sec_document(s)()` — flat convenience (LLM entry points).
+- `FinancialReportService.fetch_documents()` / `DocumentDownloadService.download()` — validated
+  Pydantic models.
+- `FinancialReportService.fetch_documents_raw()` — raw parsed rows (escape hatch).
+
+Also available as a facade: `SecCompany("CPALL")`.
+
+> ### ⚠️ API gotchas (live-verified 2026-07-20)
+>
+> 1. **HTML, not JSON.** The search is an ASP.NET WebForms postback returning HTML tables; the
+>    service replays it (GET fresh `__VIEWSTATE`/`__EVENTVALIDATION` tokens → form POST) and
+>    parses the tables. Omitting the tokens does **not** error — it silently returns a wrong,
+>    broader result set — so fresh tokens are fetched before every search.
+> 2. **Dates are dd/mm/yyyy.** `from_date`/`to_date` accept `datetime.date`/`datetime` objects
+>    (converted automatically) or dd/mm/yyyy strings; ISO strings raise `InvalidDateError`.
+> 3. **Soft 404s.** A dead download link returns an HTML "file not found" page under **HTTP
+>    200** (notably some recent `dat/annual/` 56-2 rows). Downloads validate the content-type
+>    and raise `FetchError` instead of returning the error page as bytes.
+> 4. **Large sections truncate** inline and expose a "display all results" ViewMore link; the
+>    listing follows it (default `follow_view_more=True`) so results are complete.
+
+## Quick Start
+
+```python
+import asyncio
+from settfex.services.sec import get_sec_documents, download_sec_document
+
+async def main() -> None:
+    # List all disclosure documents for CPALL in a date window
+    docs = await get_sec_documents("CPALL", from_date="01/01/2025", to_date="31/12/2026")
+    print(f"{len(docs)} documents")
+    for d in docs[:5]:
+        print(f"{d.category.value:20} {d.year} {d.period or ''} {d.file_kind} -> {d.file_url}")
+
+    # Download the first financial-statement package (a zip with the original XLSX)
+    fs = next(d for d in docs if d.category.value == "financial_statement" and d.file_kind == "zip")
+    file = await download_sec_document(fs, dest_dir="./sec_docs")
+    print(f"saved {file.filename} ({file.size:,} bytes)")
+
+asyncio.run(main())
+```
+
+```python
+from datetime import date
+
+# Only certain categories
+docs = await get_sec_documents(
+    "PTT", types=["financial_statement", "form_56_1"],
+    from_date=date(2024, 1, 1), to_date=date(2026, 12, 31),
+)
+
+# Download everything, concurrently, into a folder
+from settfex.services.sec import download_sec_documents
+files = await download_sec_documents(docs, dest_dir="./out", max_concurrency=5, progress=True)
+```
+
+## Document categories
+
+`DocumentCategory` values (pass as enum members or their string values):
+
+| Value | Meaning | Download payload |
+|---|---|---|
+| `financial_statement` | Quarterly/annual financial statements | zip: `FINANCIAL_STATEMENTS.XLSX` + auditor report + notes |
+| `form_56_1` | Annual Registration Statement (56-1) | zip containing the One-Report PDF |
+| `form_56_2` | Annual Report / One Report (56-2) | zip containing the One-Report PDF |
+| `key_financial_ratio` | Key financial ratios | file (via IPOS) |
+| `mda` | Management Discussion & Analysis | PDF |
+
+A single financial-statement search returns the statement, KFR **and** MD&A sections together;
+the service maps requested categories to the minimal set of underlying queries automatically.
+
+## Models
+
+### `SecDocument`
+
+| Field | Type | Notes |
+|---|---|---|
+| `company_name` | `str` | Issuer name (row 'Name' cell, or resolved fallback for MD&A) |
+| `unique_id` | `str` | SEC uniqueIDReference the search was run for |
+| `category` | `DocumentCategory` | One of the five categories |
+| `section` | `str` | Raw section heading (record-count suffix stripped) |
+| `title` | `str \| None` | Document heading (MD&A rows carry this instead of a Name) |
+| `year` | `int \| None` | Reporting year |
+| `period` | `str \| None` | `'Q1'`/`'Q2'`/`'Q3'`/`'Year'` (statements) |
+| `statement_type` | `str \| None` | `'Company'` or `'Consolidated'` |
+| `status` | `str \| None` | `'Reviewed'` or `'Audited'` |
+| `business_type` | `str \| None` | KFR rows only |
+| `as_of` | `date \| None` | Row date ('As Of' for statements, 'Date' for MD&A) |
+| `receive_date` | `date \| None` | Filing date (56-1/56-2) |
+| `file_url` | `str` | Absolute download URL |
+| `file_id` | `str \| None` | FILEID path, or `'ipos:<id>'` for IPOS-hosted files |
+| `file_kind` | `str \| None` | `'zip'`/`'pdf'`/… |
+
+### `CompanyMatch`
+
+`company_name` (alias `Text`), `unique_id` (alias `Value`), `is_primary` (alias `Flag`, True for
+the symbol's listed company).
+
+### `DownloadedFile`
+
+`filename`, `content: bytes`, `content_type`, `size`, `file_url`, `document: SecDocument | None`,
+plus `.save(dest)` — writes to `dest/<filename>` if `dest` is a directory, else to `dest`.
+
+## Service classes
+
+### `FinancialReportService`
+
+```python
+fetch_documents(unique_id, *, company_name=None, types=None, from_date=None, to_date=None,
+                lang="en", follow_view_more=True) -> list[SecDocument]
+fetch_documents_raw(unique_id, *, code, from_date=None, to_date=None, lang="en") -> list[dict]
+```
+
+### `DocumentDownloadService`
+
+```python
+download(target, *, referer=...) -> DownloadedFile          # target: SecDocument | URL | FILEID
+download_all(targets, *, dest_dir=None, max_concurrency=5,
+             continue_on_error=True, progress=False) -> list[DownloadedFile]
+```
+
+`download_all` runs bounded-concurrent downloads; with `continue_on_error=True` (default) a
+failed item (e.g. a soft-404 dead link) is logged and skipped rather than failing the batch.
+
+## Convenience functions
+
+```python
+resolve_company(query, lang="en") -> CompanyMatch | None
+get_sec_documents(query, *, types=None, from_date=None, to_date=None,
+                  lang="en", follow_view_more=True) -> list[SecDocument]
+download_sec_document(target, *, dest_dir=None) -> DownloadedFile
+download_sec_documents(targets, *, dest_dir=None, max_concurrency=5,
+                       continue_on_error=True, progress=False) -> list[DownloadedFile]
+```
+
+## Unified facade — `SecCompany`
+
+```python
+from settfex.services.sec import SecCompany
+
+sec = SecCompany("CPALL")
+company = await sec.resolve()                       # CompanyMatch (cached)
+docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
+file = await sec.download(docs[0], dest_dir="./out")
+files = await sec.download_all(docs, dest_dir="./out")
+```
+
+## Error handling
+
+```python
+from settfex import FetchError, InvalidDateError
+
+try:
+    docs = await get_sec_documents("CPALL", from_date="2026-01-01")  # ISO -> caught locally
+except InvalidDateError as exc:
+    print(exc)   # expected dd/mm/yyyy
+
+file = await download_sec_document(doc)  # dead link -> FetchError ("soft 404")
+```
+
+## Verified endpoints
+
+```
+POST /public/idisc/api/company/valuebyuniqueId      {"lang","content"} -> [{"Text","Value","Flag"}]
+GET  /public/idisc/{lang}/FinancialReport/{TYPE}     -> page + __VIEWSTATE tokens
+POST /public/idisc/{lang}/FinancialReport/{TYPE}     form postback -> result HTML
+GET  /public/idisc/{lang}/ViewMore/{slug}?...        -> complete section (fs-norm/fs-kf/fs-mda)
+GET  /public/idisc/Download?FILEID=<path>            -> zip/pdf bytes
+GET  /ipos/Common/IPOSGetFile.aspx?id=<id>&sq=0&v=10 -> zip bytes
+```
+`{TYPE}` ∈ `FS` (statements + KFR + MD&A) · `R561` · `R562` · `KFR`.
+
+## Related services
+
+- [Financial Statements (SET factsheet)](../set/financial.md) — *modeled* balance sheet / income
+  / cash flow from SET (vs. the raw XLSX package here).
+- [News](../set/news.md) — SET company news/disclosures.

--- a/examples/sec/01_financial_report.ipynb
+++ b/examples/sec/01_financial_report.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md01",
+   "metadata": {},
+   "source": [
+    "# SEC Document Service — Raw Disclosure Documents (market.sec.or.th)\n",
+    "\n",
+    "List and **download the original documents** companies file with the Thai SEC's information-disclosure\n",
+    "system (IDISC): the financial-statement **Excel** package, **Form 56-1**, **Form 56-2**, Key Financial\n",
+    "Ratio, and MD&A — for any SET/mai-listed issuer.\n",
+    "\n",
+    "**You will learn how to:**\n",
+    "- Resolve a symbol/name to its SEC company record\n",
+    "- List available documents across all five categories (with complete large sections)\n",
+    "- Filter by category and date window\n",
+    "- Download a document to bytes and save it to disk (and peek inside the zip)\n",
+    "- Download many concurrently, and handle dead links\n",
+    "- Use the `SecCompany` facade\n",
+    "\n",
+    "> ⚠️ **Notes:** this is a **different host** from the SET services (`market.sec.or.th`, an ASP.NET site).\n",
+    "> Dates are **dd/mm/yyyy**. Some links are dead on the SEC side and return an HTML \"file not found\" page\n",
+    "> under HTTP 200 — the download service detects this and raises `FetchError`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md02",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:08.994339Z",
+     "iopub.status.busy": "2026-07-20T08:08:08.993611Z",
+     "iopub.status.idle": "2026-07-20T08:08:09.558335Z",
+     "shell.execute_reply": "2026-07-20T08:08:09.556068Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import tempfile\n",
+    "import zipfile\n",
+    "from collections import Counter\n",
+    "\n",
+    "from settfex.services.sec import (\n",
+    "    DocumentCategory,\n",
+    "    SecCompany,\n",
+    "    download_sec_document,\n",
+    "    download_sec_documents,\n",
+    "    get_sec_documents,\n",
+    "    resolve_company,\n",
+    ")\n",
+    "\n",
+    "# In Jupyter, await works directly (no asyncio.run needed)\n",
+    "SYMBOL = \"CPALL\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md04",
+   "metadata": {},
+   "source": [
+    "## 2. Resolve a company\n",
+    "\n",
+    "Map a symbol or name to the SEC `uniqueIDReference` (the join key)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:09.566672Z",
+     "iopub.status.busy": "2026-07-20T08:08:09.566281Z",
+     "iopub.status.idle": "2026-07-20T08:08:09.863333Z",
+     "shell.execute_reply": "2026-07-20T08:08:09.861050Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "company = await resolve_company(SYMBOL)\n",
+    "print(company.company_name, \"->\", company.unique_id, \"| primary:\", company.is_primary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md06",
+   "metadata": {},
+   "source": [
+    "## 3. List documents — all five categories\n",
+    "\n",
+    "Without a date window the SEC form uses its own default; pass `from_date`/`to_date` for history.\n",
+    "Large sections are completed automatically (`follow_view_more=True`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:09.870153Z",
+     "iopub.status.busy": "2026-07-20T08:08:09.869557Z",
+     "iopub.status.idle": "2026-07-20T08:08:14.426772Z",
+     "shell.execute_reply": "2026-07-20T08:08:14.424879Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "docs = await get_sec_documents(SYMBOL, from_date=\"01/01/2024\", to_date=\"31/12/2026\")\n",
+    "print(f\"total: {len(docs)}\")\n",
+    "print(dict(Counter(d.category.value for d in docs)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md08",
+   "metadata": {},
+   "source": [
+    "## 4. Filter by category\n",
+    "\n",
+    "Pass `DocumentCategory` members or their string values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:14.433988Z",
+     "iopub.status.busy": "2026-07-20T08:08:14.433400Z",
+     "iopub.status.idle": "2026-07-20T08:08:18.694413Z",
+     "shell.execute_reply": "2026-07-20T08:08:18.692597Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fs_and_561 = await get_sec_documents(\n",
+    "    SYMBOL,\n",
+    "    types=[DocumentCategory.FINANCIAL_STATEMENT, \"form_56_1\"],\n",
+    "    from_date=\"01/01/2024\", to_date=\"31/12/2026\",\n",
+    ")\n",
+    "for d in fs_and_561[:8]:\n",
+    "    print(f\"{d.category.value:20} y={d.year} {d.statement_type or '':12} {d.period or '':4}\"\n",
+    "          f\" {d.status or '':9} {d.file_kind or '?'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md10",
+   "metadata": {},
+   "source": [
+    "## 5. Inspect a `SecDocument`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:18.701863Z",
+     "iopub.status.busy": "2026-07-20T08:08:18.700827Z",
+     "iopub.status.idle": "2026-07-20T08:08:18.712403Z",
+     "shell.execute_reply": "2026-07-20T08:08:18.710820Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "doc = next(d for d in docs if d.category == DocumentCategory.FINANCIAL_STATEMENT and d.file_kind == \"zip\")\n",
+    "for field, value in doc.model_dump().items():\n",
+    "    print(f\"{field:16}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md12",
+   "metadata": {},
+   "source": [
+    "## 6. Download one document — and peek inside the zip\n",
+    "\n",
+    "`download_sec_document` returns a `DownloadedFile` (filename + raw `bytes`). A financial-statement\n",
+    "package is a zip containing the original `FINANCIAL_STATEMENTS.XLSX` plus the auditor report and notes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:18.719869Z",
+     "iopub.status.busy": "2026-07-20T08:08:18.719098Z",
+     "iopub.status.idle": "2026-07-20T08:08:19.269856Z",
+     "shell.execute_reply": "2026-07-20T08:08:19.267849Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "file = await download_sec_document(doc)\n",
+    "print(f\"{file.filename}  ({file.size:,} bytes, {file.content_type})\")\n",
+    "print(\"contents:\", zipfile.ZipFile(io.BytesIO(file.content)).namelist())\n",
+    "\n",
+    "# Save to disk with .save(dir_or_path)\n",
+    "# file.save(\"./sec_downloads\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md14",
+   "metadata": {},
+   "source": [
+    "## 7. Download many concurrently, saving to a folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:19.276313Z",
+     "iopub.status.busy": "2026-07-20T08:08:19.275700Z",
+     "iopub.status.idle": "2026-07-20T08:08:19.953076Z",
+     "shell.execute_reply": "2026-07-20T08:08:19.951604Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "zips = [d for d in fs_and_561 if d.file_kind == \"zip\"][:3]\n",
+    "with tempfile.TemporaryDirectory() as tmp:\n",
+    "    got = await download_sec_documents(zips, dest_dir=tmp, max_concurrency=3)\n",
+    "    from pathlib import Path\n",
+    "    print(f\"downloaded {len(got)} file(s); on disk: {[p.name for p in Path(tmp).glob('*')]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md16",
+   "metadata": {},
+   "source": [
+    "## 8. Dead links (soft 404)\n",
+    "\n",
+    "Some links are dead on the SEC side and return an HTML \"file not found\" page under HTTP 200. The\n",
+    "download service detects this and raises `FetchError` (in a batch, such items are skipped by default)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:19.958527Z",
+     "iopub.status.busy": "2026-07-20T08:08:19.958121Z",
+     "iopub.status.idle": "2026-07-20T08:08:21.876106Z",
+     "shell.execute_reply": "2026-07-20T08:08:21.873317Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from settfex.exceptions import FetchError\n",
+    "\n",
+    "f56_2 = await get_sec_documents(SYMBOL, types=\"form_56_2\", from_date=\"01/01/2024\", to_date=\"31/12/2026\")\n",
+    "dead = next((d for d in f56_2 if \"dat/annual\" in (d.file_id or \"\")), None)\n",
+    "if dead:\n",
+    "    try:\n",
+    "        await download_sec_document(dead)\n",
+    "    except FetchError as exc:\n",
+    "        print(\"correctly raised:\", str(exc)[:80])\n",
+    "else:\n",
+    "    print(\"no dead dat/annual link for this symbol right now\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md18",
+   "metadata": {},
+   "source": [
+    "## 9. The `SecCompany` facade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T08:08:21.883534Z",
+     "iopub.status.busy": "2026-07-20T08:08:21.882843Z",
+     "iopub.status.idle": "2026-07-20T08:08:23.580064Z",
+     "shell.execute_reply": "2026-07-20T08:08:23.577021Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sec = SecCompany(\"CPALL\")\n",
+    "await sec.resolve()\n",
+    "recent = await sec.list_documents(types=\"form_56_1\", from_date=\"01/01/2022\", to_date=\"31/12/2026\")\n",
+    "print(f\"{len(recent)} Form 56-1 document(s)\")\n",
+    "for d in recent:\n",
+    "    print(f\"  {d.year}  received {d.receive_date}  {d.file_url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md20",
+   "metadata": {},
+   "source": [
+    "## Use Cases\n",
+    "\n",
+    "- **Fundamental research / AI pipelines**: pull the original `FINANCIAL_STATEMENTS.XLSX` for a universe of\n",
+    "  symbols and parse it yourself (finer detail than the modeled SET factsheet).\n",
+    "- **Annual-report archives**: bulk-download Form 56-1 / 56-2 One Reports per issuer per year.\n",
+    "- **Disclosure monitoring**: list recent documents on a schedule and download new filings.\n",
+    "\n",
+    "**See also**: `docs/settfex/services/sec/financial_report.md` · SET Financial Statements (notebook 11) for the\n",
+    "*modeled* balance sheet/income/cash-flow · News (notebook 16) for SET company news."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/sec/01_financial_report.ipynb
+++ b/examples/sec/01_financial_report.ipynb
@@ -149,11 +149,14 @@
     "fs_and_561 = await get_sec_documents(\n",
     "    SYMBOL,\n",
     "    types=[DocumentCategory.FINANCIAL_STATEMENT, \"form_56_1\"],\n",
-    "    from_date=\"01/01/2024\", to_date=\"31/12/2026\",\n",
+    "    from_date=\"01/01/2024\",\n",
+    "    to_date=\"31/12/2026\",\n",
     ")\n",
     "for d in fs_and_561[:8]:\n",
-    "    print(f\"{d.category.value:20} y={d.year} {d.statement_type or '':12} {d.period or '':4}\"\n",
-    "          f\" {d.status or '':9} {d.file_kind or '?'}\")"
+    "    print(\n",
+    "        f\"{d.category.value:20} y={d.year} {d.statement_type or '':12} {d.period or '':4}\"\n",
+    "        f\" {d.status or '':9} {d.file_kind or '?'}\"\n",
+    "    )"
    ]
   },
   {
@@ -178,7 +181,9 @@
    },
    "outputs": [],
    "source": [
-    "doc = next(d for d in docs if d.category == DocumentCategory.FINANCIAL_STATEMENT and d.file_kind == \"zip\")\n",
+    "doc = next(\n",
+    "    d for d in docs if d.category == DocumentCategory.FINANCIAL_STATEMENT and d.file_kind == \"zip\"\n",
+    ")\n",
     "for field, value in doc.model_dump().items():\n",
     "    print(f\"{field:16}: {value}\")"
    ]
@@ -242,6 +247,7 @@
     "with tempfile.TemporaryDirectory() as tmp:\n",
     "    got = await download_sec_documents(zips, dest_dir=tmp, max_concurrency=3)\n",
     "    from pathlib import Path\n",
+    "\n",
     "    print(f\"downloaded {len(got)} file(s); on disk: {[p.name for p in Path(tmp).glob('*')]}\")"
    ]
   },
@@ -272,7 +278,9 @@
    "source": [
     "from settfex.exceptions import FetchError\n",
     "\n",
-    "f56_2 = await get_sec_documents(SYMBOL, types=\"form_56_2\", from_date=\"01/01/2024\", to_date=\"31/12/2026\")\n",
+    "f56_2 = await get_sec_documents(\n",
+    "    SYMBOL, types=\"form_56_2\", from_date=\"01/01/2024\", to_date=\"31/12/2026\"\n",
+    ")\n",
     "dead = next((d for d in f56_2 if \"dat/annual\" in (d.file_id or \"\")), None)\n",
     "if dead:\n",
     "    try:\n",

--- a/examples/set/16_news.ipynb
+++ b/examples/set/16_news.ipynb
@@ -264,24 +264,61 @@
   {
    "cell_type": "markdown",
    "id": "5c4eec24",
-   "source": "## 11. Historical news & the rolling 5-year window\n\nThe endpoint serves a **rolling ~5-year history — exactly 1826 days** (5 × 365 + 1 leap day). A window whose `from_date` is older than `today − 1826 days` is rejected with **HTTP 400**, surfaced by the library as `FetchError` (**not** `InvalidDateError` — that one is only for malformed dd/MM/yyyy strings). The check is on the window's **start**, and the API does **not** clip to the allowed range: one day too old and the whole request fails.\n\n> Live-verified 2026-07-20. The boundary is *rolling* — always `today − 1826 days`, never a fixed calendar date. Within the window, historical queries work exactly like the date-window query in §4.",
-   "metadata": {}
+   "metadata": {},
+   "source": "## 11. Historical news & the rolling 5-year window\n\nThe endpoint serves a **rolling ~5-year history — exactly 1826 days** (5 × 365 + 1 leap day). A window whose `from_date` is older than `today − 1826 days` is rejected with **HTTP 400**, surfaced by the library as `FetchError` (**not** `InvalidDateError` — that one is only for malformed dd/MM/yyyy strings). The check is on the window's **start**, and the API does **not** clip to the allowed range: one day too old and the whole request fails.\n\n> Live-verified 2026-07-20. The boundary is *rolling* — always `today − 1826 days`, never a fixed calendar date. Within the window, historical queries work exactly like the date-window query in §4."
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "b5d68439",
-   "source": "# Fetch a historical window well inside the 5-year limit (~1 year ago).\n# Keep it small — there is no pagination, so a wide window returns everything at once.\nhist_to = date.today() - timedelta(days=365)\nhist_from = hist_to - timedelta(days=5)\n\nhist = await get_news(from_date=hist_from, to_date=hist_to)\nprint(f\"{hist_from} -> {hist_to}: {hist.count} items\")\n\nif hist.news_info_list:\n    dts = [item.news_datetime for item in hist.news_info_list]\n    print(f\"  earliest: {min(dts):%Y-%m-%d %H:%M}\")\n    print(f\"  latest:   {max(dts):%Y-%m-%d %H:%M}\\n\")\n    for item in hist.news_info_list[:5]:\n        print(f\"  {item.news_datetime:%Y-%m-%d}  {item.symbol:10s} {item.headline[:60]}\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# Fetch a historical window well inside the 5-year limit (~1 year ago).\n",
+    "# Keep it small — there is no pagination, so a wide window returns everything at once.\n",
+    "hist_to = date.today() - timedelta(days=365)\n",
+    "hist_from = hist_to - timedelta(days=5)\n",
+    "\n",
+    "hist = await get_news(from_date=hist_from, to_date=hist_to)\n",
+    "print(f\"{hist_from} -> {hist_to}: {hist.count} items\")\n",
+    "\n",
+    "if hist.news_info_list:\n",
+    "    dts = [item.news_datetime for item in hist.news_info_list]\n",
+    "    print(f\"  earliest: {min(dts):%Y-%m-%d %H:%M}\")\n",
+    "    print(f\"  latest:   {max(dts):%Y-%m-%d %H:%M}\\n\")\n",
+    "    for item in hist.news_info_list[:5]:\n",
+    "        print(f\"  {item.news_datetime:%Y-%m-%d}  {item.symbol:10s} {item.headline[:60]}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "ac22b85d",
-   "source": "from settfex.exceptions import FetchError\n\nOLDEST_DAYS = 1826  # rolling 5-year window (= 5*365 + 1 leap day), live-verified 2026-07-20\noldest_ok = date.today() - timedelta(days=OLDEST_DAYS)\ntoo_old = date.today() - timedelta(days=OLDEST_DAYS + 1)\n\n\nasync def try_from(from_d: date) -> None:\n    \"\"\"Probe a single-day window and report OK (served) vs rejected (too old).\"\"\"\n    days_back = (date.today() - from_d).days\n    try:\n        res = await get_news(from_date=from_d, to_date=from_d)\n        print(f\"  {from_d} (today-{days_back}d): OK       -> {res.count} items\")\n    except FetchError as exc:\n        # HTTP 400 for over-old windows surfaces as FetchError (NOT InvalidDateError)\n        print(f\"  {from_d} (today-{days_back}d): rejected -> {type(exc).__name__} (HTTP 400)\")\n\n\nprint(f\"Oldest servable date today: {oldest_ok}\\n\")\nawait try_from(oldest_ok)  # exactly the boundary -> OK\nawait try_from(too_old)    # one day too old   -> FetchError",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "ac22b85d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from settfex.exceptions import FetchError\n",
+    "\n",
+    "OLDEST_DAYS = 1826  # rolling 5-year window (= 5*365 + 1 leap day), live-verified 2026-07-20\n",
+    "oldest_ok = date.today() - timedelta(days=OLDEST_DAYS)\n",
+    "too_old = date.today() - timedelta(days=OLDEST_DAYS + 1)\n",
+    "\n",
+    "\n",
+    "async def try_from(from_d: date) -> None:\n",
+    "    \"\"\"Probe a single-day window and report OK (served) vs rejected (too old).\"\"\"\n",
+    "    days_back = (date.today() - from_d).days\n",
+    "    try:\n",
+    "        res = await get_news(from_date=from_d, to_date=from_d)\n",
+    "        print(f\"  {from_d} (today-{days_back}d): OK       -> {res.count} items\")\n",
+    "    except FetchError as exc:\n",
+    "        # HTTP 400 for over-old windows surfaces as FetchError (NOT InvalidDateError)\n",
+    "        print(f\"  {from_d} (today-{days_back}d): rejected -> {type(exc).__name__} (HTTP 400)\")\n",
+    "\n",
+    "\n",
+    "print(f\"Oldest servable date today: {oldest_ok}\\n\")\n",
+    "await try_from(oldest_ok)  # exactly the boundary -> OK\n",
+    "await try_from(too_old)  # one day too old   -> FetchError"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.11.0"
+version = "0.12.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 __author__ = "batt"
 __license__ = "MIT"
 
@@ -46,6 +46,18 @@ from settfex.exceptions import (
     InvalidLanguageError,
     InvalidSymbolError,
     SymbolNotFoundError,
+)
+
+# SEC IDISC document services (market.sec.or.th) — disclosure document retrieval
+from settfex.services.sec import (
+    DocumentCategory,
+    DownloadedFile,
+    SecCompany,
+    SecDocument,
+    download_sec_document,
+    download_sec_documents,
+    get_sec_documents,
+    resolve_company,
 )
 from settfex.services.set import (
     CompanyProfile,
@@ -89,6 +101,15 @@ __all__ = [
     "get_index_info",
     "get_index_composition",
     "get_news",
+    # SEC IDISC document services (market.sec.or.th)
+    "SecCompany",
+    "get_sec_documents",
+    "download_sec_document",
+    "download_sec_documents",
+    "resolve_company",
+    "SecDocument",
+    "DocumentCategory",
+    "DownloadedFile",
     # Data Models
     "StockListResponse",
     "StockHighlightData",

--- a/settfex/services/sec/__init__.py
+++ b/settfex/services/sec/__init__.py
@@ -1,0 +1,45 @@
+"""Thai SEC IDISC (market.sec.or.th) document services.
+
+Fetch and download raw disclosure documents — financial-statement Excel packages, Form 56-1,
+Form 56-2, Key Financial Ratio, and MD&A — for any SET/mai-listed issuer.
+"""
+
+from settfex.services.sec.company import (
+    CompanyMatch,
+    resolve_company,
+    search_companies,
+)
+from settfex.services.sec.download import (
+    DocumentDownloadService,
+    DownloadedFile,
+    download_sec_document,
+    download_sec_documents,
+)
+from settfex.services.sec.financial_report import (
+    CATEGORY_TO_REPORT_TYPE,
+    DocumentCategory,
+    FinancialReportService,
+    SecDocument,
+    category_for_section,
+    get_sec_documents,
+    row_to_document,
+)
+from settfex.services.sec.sec import SecCompany
+
+__all__ = [
+    "CATEGORY_TO_REPORT_TYPE",
+    "CompanyMatch",
+    "DocumentCategory",
+    "DocumentDownloadService",
+    "DownloadedFile",
+    "FinancialReportService",
+    "SecCompany",
+    "SecDocument",
+    "category_for_section",
+    "download_sec_document",
+    "download_sec_documents",
+    "get_sec_documents",
+    "resolve_company",
+    "row_to_document",
+    "search_companies",
+]

--- a/settfex/services/sec/company.py
+++ b/settfex/services/sec/company.py
@@ -66,9 +66,7 @@ async def search_companies(
 
     logger.info(f"Resolving SEC company for query={query!r} (lang={lang})")
     async with AsyncDataFetcher(config=_stateless_config(config)) as fetcher:
-        data: Any = await fetcher.fetch_json(
-            url, headers=headers, method="POST", json_body=body
-        )
+        data: Any = await fetcher.fetch_json(url, headers=headers, method="POST", json_body=body)
 
     if not isinstance(data, list):
         logger.warning(f"Unexpected company-search payload type: {type(data).__name__}")

--- a/settfex/services/sec/company.py
+++ b/settfex/services/sec/company.py
@@ -1,0 +1,98 @@
+"""SEC company resolution — map a symbol/name to the IDISC uniqueIDReference.
+
+The search page identifies an issuer by a 10-digit ``uniqueIDReference`` (e.g. CPALL =
+``0000003875``), obtained from a small JSON autocomplete API. This is a clean JSON POST and
+reuses the existing ``AsyncDataFetcher.fetch_json`` (stateless — no SessionManager).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.services.sec.constants import (
+    SEC_BASE_URL,
+    SEC_COMPANY_SEARCH_ENDPOINT,
+    SEC_REFERER,
+)
+from settfex.services.sec.utils import build_sec_headers
+from settfex.services.set.stock.utils import Language, normalize_language
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+
+
+class CompanyMatch(BaseModel):
+    """One issuer match from the SEC company autocomplete."""
+
+    company_name: str = Field(alias="Text", description="Full issuer name")
+    unique_id: str = Field(alias="Value", description="10-digit SEC uniqueIDReference")
+    is_primary: bool = Field(
+        default=False,
+        alias="Flag",
+        description="True for the primary/exact match (e.g. the symbol's listed company)",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+
+def _stateless_config(config: FetcherConfig | None) -> FetcherConfig:
+    """Force use_session=False (the SEC host is stateless), preserving other config."""
+    base = config or FetcherConfig()
+    return base.model_copy(update={"use_session": False})
+
+
+async def search_companies(
+    query: str,
+    lang: Language = "en",
+    *,
+    config: FetcherConfig | None = None,
+) -> list[CompanyMatch]:
+    """
+    Search issuers by name or symbol; returns all matches (primary match flagged).
+
+    Args:
+        query: Symbol or (partial) company name, e.g. "CPALL" or "CP ALL".
+        lang: Response language ('en' or 'th').
+        config: Optional fetcher configuration (use_session is forced off).
+
+    Returns:
+        List of CompanyMatch (may be empty). Primary/exact matches have is_primary=True.
+    """
+    lang = normalize_language(lang)
+    url = f"{SEC_BASE_URL}{SEC_COMPANY_SEARCH_ENDPOINT}"
+    body = {"lang": lang, "content": query.strip()}
+    headers = build_sec_headers(referer=SEC_REFERER, origin=True)
+
+    logger.info(f"Resolving SEC company for query={query!r} (lang={lang})")
+    async with AsyncDataFetcher(config=_stateless_config(config)) as fetcher:
+        data: Any = await fetcher.fetch_json(
+            url, headers=headers, method="POST", json_body=body
+        )
+
+    if not isinstance(data, list):
+        logger.warning(f"Unexpected company-search payload type: {type(data).__name__}")
+        return []
+    matches = [CompanyMatch.model_validate(item) for item in data]
+    logger.info(f"Found {len(matches)} company match(es) for {query!r}")
+    return matches
+
+
+async def resolve_company(
+    query: str,
+    lang: Language = "en",
+    *,
+    config: FetcherConfig | None = None,
+) -> CompanyMatch | None:
+    """
+    Resolve a symbol/name to a single best CompanyMatch (primary match preferred).
+
+    Returns the ``is_primary`` match if present, else the first match, else None.
+    """
+    matches = await search_companies(query, lang, config=config)
+    if not matches:
+        return None
+    for match in matches:
+        if match.is_primary:
+            return match
+    return matches[0]

--- a/settfex/services/sec/constants.py
+++ b/settfex/services/sec/constants.py
@@ -1,0 +1,60 @@
+"""Constants for the Thai SEC IDISC (market.sec.or.th) document services.
+
+The SEC information-disclosure system is a separate host from SET/TFEX — an ASP.NET
+WebForms app. ``curl_cffi`` browser impersonation passes its (passive) bot wall; no login
+or persistent session is required (the WebForms postback needs only fresh VIEWSTATE tokens).
+"""
+
+# Base URL for all SEC IDISC endpoints
+SEC_BASE_URL = "https://market.sec.or.th"
+
+# Company autocomplete — JSON POST {"lang","content"} -> [{"Text","Value","Flag"}]
+SEC_COMPANY_SEARCH_ENDPOINT = "/public/idisc/api/company/valuebyuniqueId"
+
+# Publication-document search page (ASP.NET WebForms). {lang} in {en,th}; {report_type} is a
+# ddlReportType code (see SEC_REPORT_TYPE_*). GET returns the form + VIEWSTATE tokens; POST the
+# form back to the same URL to run a search.
+SEC_FINANCIAL_REPORT_ENDPOINT = "/public/idisc/{lang}/FinancialReport/{report_type}"
+
+# "Display all results" page for a section that truncates inline. {slug} in SEC_VIEWMORE_SLUGS.
+# Query params: uniqueIDReference, dateFrom, dateTo (yyyyMMdd).
+SEC_VIEWMORE_ENDPOINT = "/public/idisc/{lang}/ViewMore/{slug}"
+
+# Per-file download handler — GET ?FILEID=<path> -> zip/pdf bytes (Content-Disposition names it).
+SEC_DOWNLOAD_ENDPOINT = "/public/idisc/Download"
+
+# Page-specific referer (part of the bot-detection posture, mirrors the SET services).
+SEC_REFERER = "https://market.sec.or.th/public/idisc/en/FinancialReport/ALL"
+
+# ddlReportType codes accepted by the search form.
+SEC_REPORT_TYPE_FINANCIAL_STATEMENT = "FS"  # returns FS + Key Financial Ratio + MD&A sections
+SEC_REPORT_TYPE_FORM_56_1 = "R561"
+SEC_REPORT_TYPE_FORM_56_2 = "R562"
+SEC_REPORT_TYPE_KEY_FINANCIAL_RATIO = "KFR"
+
+# ViewMore slugs (seen live) for the sections a FS search can truncate.
+SEC_VIEWMORE_SLUGS: dict[str, str] = {
+    "financial_statement": "fs-norm",
+    "key_financial_ratio": "fs-kf",
+    "mda": "fs-mda",
+}
+
+# The SEC search form's field names (ASP.NET control ids).
+SEC_FORM_FIELD_REPORT_TYPE = "ctl00$CPH$ddlReportType"
+SEC_FORM_FIELD_COMPANY = "ctl00$CPH$BsCompany"
+SEC_FORM_FIELD_COMPANY_TEXT = "ctl00$CPH$BsCompany_t"
+SEC_FORM_FIELD_COMPANY_VALUE = "ctl00$CPH$BsCompany_v"
+SEC_FORM_FIELD_DATE_FROM = "ctl00$CPH$BSDateFrom"
+SEC_FORM_FIELD_DATE_TO = "ctl00$CPH$BSDateTo"
+SEC_FORM_FIELD_SEARCH = "ctl00$CPH$btSearch"
+
+# Hidden ASP.NET postback tokens that must be echoed back (scraped from the GET page).
+SEC_ASPNET_TOKEN_FIELDS = ("__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION")
+
+# The search form accepts dd/MM/yyyy ONLY; ViewMore uses yyyyMMdd.
+SEC_FORM_DATE_FORMAT = "%d/%m/%Y"
+SEC_VIEWMORE_DATE_FORMAT = "%Y%m%d"
+
+# Result-panel container id and the Thai "file not found" soft-404 marker (HTTP 200 + text/html).
+SEC_RESULT_PANEL_ID = "ctl00_CPH_pnlControl"
+SEC_FILE_NOT_FOUND_MARKER = "ไม่พบไฟล์ที่ระบุ"

--- a/settfex/services/sec/download.py
+++ b/settfex/services/sec/download.py
@@ -1,0 +1,273 @@
+"""SEC document download service — fetch the raw document bytes and (optionally) save to disk.
+
+Downloads are plain GETs that return the original file package (e.g. a zip containing
+``FINANCIAL_STATEMENTS.XLSX``). The SEC host answers a dead link with an HTML "file not found"
+page under **HTTP 200**, so every download is validated (content-type / soft-404 marker) and a
+clear :class:`FetchError` is raised instead of returning a garbage payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.exceptions import FetchError
+from settfex.services.sec.constants import (
+    SEC_BASE_URL,
+    SEC_DOWNLOAD_ENDPOINT,
+    SEC_FILE_NOT_FOUND_MARKER,
+    SEC_REFERER,
+)
+from settfex.services.sec.financial_report import SecDocument
+from settfex.services.sec.utils import build_sec_headers
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+
+
+class DownloadedFile(BaseModel):
+    """A downloaded SEC document: filename + raw bytes, with optional source metadata."""
+
+    filename: str = Field(description="Filename (from Content-Disposition, or a sensible fallback)")
+    content: bytes = Field(description="Raw file bytes (e.g. a zip of the original XLSX/PDF)")
+    content_type: str = Field(default="", description="Response Content-Type header")
+    size: int = Field(description="Number of bytes")
+    file_url: str = Field(description="URL the bytes were fetched from")
+    document: SecDocument | None = Field(
+        default=None, description="The source SecDocument, when downloaded from a listing"
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def save(self, dest: str | Path) -> Path:
+        """
+        Write the bytes to disk. If ``dest`` is a directory (existing or trailing-slash), the
+        file is written as ``dest/<filename>``; otherwise ``dest`` is treated as the full path.
+        Parent directories are created. Returns the path written.
+        """
+        path = Path(dest)
+        if path.is_dir() or str(dest).endswith(("/", "\\")):
+            path = path / self.filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.content)
+        logger.info(f"Saved {self.size} bytes -> {path}")
+        return path
+
+
+def _filename_from_disposition(disposition: str, fallback: str) -> str:
+    """Extract a filename from a Content-Disposition header (handles both SEC variants)."""
+    if disposition:
+        match = re.search(
+            r"filename\*?=(?:UTF-8'')?\"?([^\";]+)\"?", disposition, re.IGNORECASE
+        )
+        if match:
+            return unquote(match.group(1).strip().strip('"'))
+        # IDISC returns the bare filename as the whole header value (no "filename=" key).
+        bare = disposition.strip().strip('"')
+        if bare and "=" not in bare:
+            return bare
+    return fallback
+
+
+def _fallback_filename(file_url: str, document: SecDocument | None) -> str:
+    """Best-effort filename when Content-Disposition is absent."""
+    if document and document.file_id and not document.file_id.startswith("ipos:"):
+        return document.file_id.rsplit("/", 1)[-1]
+    path = urlparse(file_url).path
+    base = path.rsplit("/", 1)[-1]
+    return base or "sec_download"
+
+
+class DocumentDownloadService:
+    """Download SEC documents to bytes (and optionally disk). Stateless host — no SessionManager."""
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        base = config or FetcherConfig()
+        self.config = base.model_copy(update={"use_session": False})
+        logger.info("DocumentDownloadService initialized (host=market.sec.or.th)")
+
+    @staticmethod
+    def _resolve_url(target: SecDocument | str) -> tuple[str, SecDocument | None]:
+        """Resolve a download target into (absolute_url, source_document|None)."""
+        if isinstance(target, SecDocument):
+            return target.file_url, target
+        text = target.strip()
+        if text.lower().startswith("http"):
+            return text, None
+        # Treat a bare string as a FILEID path.
+        return f"{SEC_BASE_URL}{SEC_DOWNLOAD_ENDPOINT}?FILEID={text}", None
+
+    async def download(
+        self,
+        target: SecDocument | str,
+        *,
+        fetcher: AsyncDataFetcher | None = None,
+        referer: str = SEC_REFERER,
+    ) -> DownloadedFile:
+        """
+        Download one document to a :class:`DownloadedFile`.
+
+        Args:
+            target: A :class:`SecDocument`, an absolute download URL, or a bare FILEID path.
+            fetcher: Optional shared fetcher (used by ``download_all`` for concurrency).
+            referer: Referer header for the request.
+
+        Raises:
+            FetchError: On HTTP failure, or when the SEC host returns its HTML "file not found"
+                page (a soft 404 served under HTTP 200).
+        """
+        url, document = self._resolve_url(target)
+        headers = build_sec_headers(referer=referer)
+
+        owns_fetcher = fetcher is None
+        fetcher = fetcher or AsyncDataFetcher(config=self.config)
+        try:
+            resp = await fetcher.fetch(url, headers=headers, decode_text=False)
+        finally:
+            if owns_fetcher:
+                await fetcher.__aexit__(None, None, None)
+
+        if resp.status_code != 200:
+            raise FetchError(
+                f"Failed to download {url}: HTTP {resp.status_code}", status_code=resp.status_code
+            )
+
+        content_type = (resp.headers.get("Content-Type") or resp.headers.get("content-type") or "")
+        # A real document is a binary type; an HTML body means a soft error (e.g. dead FILEID).
+        if "text/html" in content_type.lower():
+            snippet = resp.content[:400].decode("utf-8", "replace")
+            if SEC_FILE_NOT_FOUND_MARKER in snippet or "not found" in snippet.lower():
+                raise FetchError(f"SEC reports the file does not exist (soft 404): {url}")
+            raise FetchError(f"Unexpected HTML response (not a document) downloading {url}")
+
+        disposition = (
+            resp.headers.get("Content-Disposition")
+            or resp.headers.get("content-disposition")
+            or ""
+        )
+        filename = _filename_from_disposition(disposition, _fallback_filename(url, document))
+
+        logger.info(f"Downloaded {len(resp.content)} bytes ({content_type}) from {url}")
+        return DownloadedFile(
+            filename=filename,
+            content=resp.content,
+            content_type=content_type,
+            size=len(resp.content),
+            file_url=url,
+            document=document,
+        )
+
+    async def download_all(
+        self,
+        targets: list[SecDocument | str],
+        *,
+        dest_dir: str | Path | None = None,
+        max_concurrency: int = 5,
+        continue_on_error: bool = True,
+        progress: bool = False,
+    ) -> list[DownloadedFile]:
+        """
+        Download many documents concurrently (bounded), optionally saving each to ``dest_dir``.
+
+        Args:
+            targets: SecDocuments / URLs / FILEIDs to download.
+            dest_dir: If set, each file is also written here (created if needed).
+            max_concurrency: Max simultaneous downloads (default 5).
+            continue_on_error: If True (default) a failed item is logged and skipped; if False
+                the first failure propagates.
+            progress: Show a tqdm progress bar if the optional ``progress`` extra is installed.
+
+        Returns:
+            The successfully downloaded files (order not guaranteed under concurrency).
+        """
+        semaphore = asyncio.Semaphore(max(1, max_concurrency))
+        results: list[DownloadedFile] = []
+        bar = _make_progress_bar(len(targets)) if progress else None
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+
+            async def one(target: SecDocument | str) -> DownloadedFile | None:
+                async with semaphore:
+                    try:
+                        dl = await self.download(target, fetcher=fetcher)
+                    except Exception as exc:  # noqa: BLE001 - tolerant batch download
+                        if not continue_on_error:
+                            raise
+                        label = target.file_url if isinstance(target, SecDocument) else target
+                        logger.warning(f"Skipping download that failed ({label}): {exc}")
+                        return None
+                    if dest_dir is not None:
+                        dl.save(dest_dir)
+                    return dl
+
+            tasks = [asyncio.create_task(one(t)) for t in targets]
+            for coro in asyncio.as_completed(tasks):
+                dl = await coro
+                if bar is not None:
+                    bar.update(1)
+                if dl is not None:
+                    results.append(dl)
+
+        if bar is not None:
+            bar.close()
+        logger.info(f"Downloaded {len(results)}/{len(targets)} document(s)")
+        return results
+
+
+def _make_progress_bar(total: int) -> Any | None:
+    """Return a tqdm bar if the optional 'progress' extra is installed, else None."""
+    try:
+        from tqdm.auto import tqdm
+    except ImportError:
+        logger.warning("progress=True but tqdm is not installed; install settfex[progress]")
+        return None
+    return tqdm(total=total, desc="Downloading SEC documents", unit="file")
+
+
+async def download_sec_document(
+    target: SecDocument | str,
+    *,
+    dest_dir: str | Path | None = None,
+    config: FetcherConfig | None = None,
+) -> DownloadedFile:
+    """
+    Convenience: download one SEC document (optionally saving it to ``dest_dir``).
+
+    Args:
+        target: A :class:`SecDocument`, an absolute URL, or a bare FILEID path.
+        dest_dir: If set, also write the file here.
+        config: Optional fetcher configuration.
+    """
+    service = DocumentDownloadService(config=config)
+    dl = await service.download(target)
+    if dest_dir is not None:
+        dl.save(dest_dir)
+    return dl
+
+
+async def download_sec_documents(
+    targets: list[SecDocument | str],
+    *,
+    dest_dir: str | Path | None = None,
+    max_concurrency: int = 5,
+    continue_on_error: bool = True,
+    progress: bool = False,
+    config: FetcherConfig | None = None,
+) -> list[DownloadedFile]:
+    """
+    Convenience: download many SEC documents concurrently (optionally saving to ``dest_dir``).
+
+    See :meth:`DocumentDownloadService.download_all` for argument semantics.
+    """
+    service = DocumentDownloadService(config=config)
+    return await service.download_all(
+        targets,
+        dest_dir=dest_dir,
+        max_concurrency=max_concurrency,
+        continue_on_error=continue_on_error,
+        progress=progress,
+    )

--- a/settfex/services/sec/download.py
+++ b/settfex/services/sec/download.py
@@ -61,9 +61,7 @@ class DownloadedFile(BaseModel):
 def _filename_from_disposition(disposition: str, fallback: str) -> str:
     """Extract a filename from a Content-Disposition header (handles both SEC variants)."""
     if disposition:
-        match = re.search(
-            r"filename\*?=(?:UTF-8'')?\"?([^\";]+)\"?", disposition, re.IGNORECASE
-        )
+        match = re.search(r"filename\*?=(?:UTF-8'')?\"?([^\";]+)\"?", disposition, re.IGNORECASE)
         if match:
             return unquote(match.group(1).strip().strip('"'))
         # IDISC returns the bare filename as the whole header value (no "filename=" key).
@@ -136,7 +134,7 @@ class DocumentDownloadService:
                 f"Failed to download {url}: HTTP {resp.status_code}", status_code=resp.status_code
             )
 
-        content_type = (resp.headers.get("Content-Type") or resp.headers.get("content-type") or "")
+        content_type = resp.headers.get("Content-Type") or resp.headers.get("content-type") or ""
         # A real document is a binary type; an HTML body means a soft error (e.g. dead FILEID).
         if "text/html" in content_type.lower():
             snippet = resp.content[:400].decode("utf-8", "replace")
@@ -145,9 +143,7 @@ class DocumentDownloadService:
             raise FetchError(f"Unexpected HTML response (not a document) downloading {url}")
 
         disposition = (
-            resp.headers.get("Content-Disposition")
-            or resp.headers.get("content-disposition")
-            or ""
+            resp.headers.get("Content-Disposition") or resp.headers.get("content-disposition") or ""
         )
         filename = _filename_from_disposition(disposition, _fallback_filename(url, document))
 

--- a/settfex/services/sec/financial_report.py
+++ b/settfex/services/sec/financial_report.py
@@ -298,8 +298,15 @@ class FinancialReportService:
             results = await asyncio.gather(
                 *(
                     self._search_code(
-                        fetcher, code, unique_id, company_name, date_from, date_to,
-                        lang, follow_view_more, wanted,
+                        fetcher,
+                        code,
+                        unique_id,
+                        company_name,
+                        date_from,
+                        date_to,
+                        lang,
+                        follow_view_more,
+                        wanted,
                     )
                     for code in codes
                 )
@@ -325,9 +332,7 @@ class FinancialReportService:
         date_from = _format_sec_date(from_date, "from_date")
         date_to = _format_sec_date(to_date, "to_date")
         async with AsyncDataFetcher(config=self.config) as fetcher:
-            html = await self._run_search(
-                fetcher, code, unique_id, None, date_from, date_to, lang
-            )
+            html = await self._run_search(fetcher, code, unique_id, None, date_from, date_to, lang)
         return [dict(r) for r in parse_report_tables(html)]
 
     async def _run_search(
@@ -411,8 +416,10 @@ class FinancialReportService:
 
         if vm_targets:
             pages = await asyncio.gather(
-                *(fetcher.fetch(url, headers=build_sec_headers(referer=SEC_REFERER))
-                  for _, url in vm_targets)
+                *(
+                    fetcher.fetch(url, headers=build_sec_headers(referer=SEC_REFERER))
+                    for _, url in vm_targets
+                )
             )
             for (cat, _), page in zip(vm_targets, pages, strict=True):
                 replacements[cat] = [

--- a/settfex/services/sec/financial_report.py
+++ b/settfex/services/sec/financial_report.py
@@ -1,0 +1,469 @@
+"""SEC financial-report document models and the HTML-row → model mapper.
+
+The listing service (added on top of this module) replays the SEC search and turns each parsed
+result-table row into a :class:`SecDocument`. Models + mapping live here; the service that does
+the HTTP orchestration is appended below (see ``FinancialReportService``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import date, datetime
+from enum import Enum
+from html import unescape
+from urllib.parse import urljoin
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.exceptions import InvalidDateError
+from settfex.services.sec.company import resolve_company
+from settfex.services.sec.constants import (
+    SEC_BASE_URL,
+    SEC_FINANCIAL_REPORT_ENDPOINT,
+    SEC_FORM_DATE_FORMAT,
+    SEC_FORM_FIELD_COMPANY,
+    SEC_FORM_FIELD_COMPANY_TEXT,
+    SEC_FORM_FIELD_COMPANY_VALUE,
+    SEC_FORM_FIELD_DATE_FROM,
+    SEC_FORM_FIELD_DATE_TO,
+    SEC_FORM_FIELD_REPORT_TYPE,
+    SEC_FORM_FIELD_SEARCH,
+    SEC_REFERER,
+)
+from settfex.services.sec.utils import (
+    ReportRow,
+    build_sec_headers,
+    classify_download_href,
+    extract_aspnet_tokens,
+    parse_dmy_date,
+    parse_int,
+    parse_report_tables,
+)
+from settfex.services.set.stock.utils import Language, normalize_language
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+
+
+class DocumentCategory(str, Enum):
+    """The five disclosure-document categories exposed by the SEC IDISC search."""
+
+    FINANCIAL_STATEMENT = "financial_statement"
+    FORM_56_1 = "form_56_1"
+    FORM_56_2 = "form_56_2"
+    KEY_FINANCIAL_RATIO = "key_financial_ratio"
+    MDA = "mda"
+
+
+# Requested category -> the search ddlReportType code that returns it. A single "FS" search
+# returns the financial-statement, KFR and MD&A sections together, so those three share it.
+CATEGORY_TO_REPORT_TYPE: dict[DocumentCategory, str] = {
+    DocumentCategory.FINANCIAL_STATEMENT: "FS",
+    DocumentCategory.KEY_FINANCIAL_RATIO: "FS",
+    DocumentCategory.MDA: "FS",
+    DocumentCategory.FORM_56_1: "R561",
+    DocumentCategory.FORM_56_2: "R562",
+}
+
+
+class SecDocument(BaseModel):
+    """A single downloadable disclosure document parsed from a SEC result row."""
+
+    company_name: str = Field(description="Issuer name (row 'Name' cell, or resolved fallback)")
+    unique_id: str = Field(description="SEC uniqueIDReference the search was run for")
+    category: DocumentCategory = Field(description="Document category (from the section heading)")
+    section: str = Field(description="Raw section heading (record-count suffix stripped)")
+    title: str | None = Field(
+        default=None, description="Document heading/title (MD&A rows carry this instead of Name)"
+    )
+    year: int | None = Field(default=None, description="Reporting year, if the row has one")
+    period: str | None = Field(default=None, description="Period, e.g. 'Q1', 'Q3', 'Year'")
+    statement_type: str | None = Field(
+        default=None, description="'Company' or 'Consolidated' (financial statements only)"
+    )
+    status: str | None = Field(
+        default=None, description="'Reviewed' or 'Audited' (financial statements only)"
+    )
+    business_type: str | None = Field(
+        default=None, description="Business type (Key Financial Ratio rows only)"
+    )
+    as_of: date | None = Field(
+        default=None, description="Row date column ('As Of' for statements, 'Date' for MD&A)"
+    )
+    receive_date: date | None = Field(default=None, description="'Receive Date', if present")
+    file_url: str = Field(description="Absolute download URL for this document")
+    file_id: str | None = Field(
+        default=None, description="FILEID path (or 'ipos:<id>' for IPOS-hosted files)"
+    )
+    file_kind: str | None = Field(default=None, description="File extension: 'zip'/'pdf'/…")
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+
+_COUNT_SUFFIX = re.compile(r"\s*\(\s*[\d,]+\s*record\(s\)\s*found\s*\)\s*$", re.IGNORECASE)
+
+
+def _clean_section(heading: str) -> str:
+    """Strip the '( N record(s) found )' suffix from a section heading."""
+    return _COUNT_SUFFIX.sub("", heading).strip()
+
+
+def category_for_section(heading: str) -> DocumentCategory | None:
+    """
+    Classify a result-section heading into a DocumentCategory (or None to skip).
+
+    Skips the revision-tracking sections ("… need to be revised", "… ordered to amend").
+    Tolerant of the site's "Finanacial" misspelling.
+    """
+    lower = heading.lower()
+    if "56-1" in lower:
+        return DocumentCategory.FORM_56_1
+    if "56-2" in lower:
+        return DocumentCategory.FORM_56_2
+    if "revis" in lower or "amend" in lower or "order" in lower:
+        return None  # status-tracking sections, not downloadable disclosures
+    if "key financial ratio" in lower:
+        return DocumentCategory.KEY_FINANCIAL_RATIO
+    if "discussion and analysis" in lower or "md&a" in lower:
+        return DocumentCategory.MDA
+    if "finan" in lower and "statement" in lower:
+        return DocumentCategory.FINANCIAL_STATEMENT
+    return None
+
+
+# Result column header (lower-cased) -> SecDocument field. Sections differ: financial
+# statements use Name/Year/Status/Type/Period/As Of; MD&A uses Date/Time/Heading/Link.
+_HEADER_FIELD_MAP: dict[str, str] = {
+    "name": "company_name",
+    "heading": "title",
+    "year": "year",
+    "status": "status",
+    "type": "statement_type",
+    "period": "period",
+    "as of": "as_of",
+    "date": "as_of",
+    "receive date": "receive_date",
+    "business type": "business_type",
+}
+
+
+def row_to_document(
+    row: ReportRow, unique_id: str, *, company_name: str | None = None
+) -> SecDocument | None:
+    """
+    Map one parsed :class:`ReportRow` to a :class:`SecDocument`, or None if it isn't a real
+    downloadable row (unknown/skipped section, "Data not found", or no download link).
+
+    Args:
+        row: A parsed result-table row.
+        unique_id: The uniqueIDReference the search was run for.
+        company_name: Fallback issuer name for rows without a 'Name' cell (e.g. MD&A) — the
+            listing service passes the resolved company name here.
+    """
+    category = category_for_section(row["section"])
+    if category is None:
+        return None
+
+    href = row.get("href")
+    file_url, file_id, file_kind = classify_download_href(href)
+    if not file_url:
+        return None  # e.g. a "Data not found" placeholder row
+
+    headers = [h.lower() for h in row["headers"]]
+    cells = row["cells"]
+    values: dict[str, str] = {}
+    for header, cell in zip(headers, cells, strict=False):
+        field = _HEADER_FIELD_MAP.get(header)
+        if field:
+            values[field] = cell
+
+    resolved_name = values.get("company_name", "").strip() or (company_name or "").strip()
+
+    return SecDocument(
+        company_name=resolved_name,
+        unique_id=unique_id,
+        category=category,
+        section=_clean_section(row["section"]),
+        title=values.get("title") or None,
+        year=parse_int(values.get("year")),
+        period=values.get("period") or None,
+        statement_type=values.get("statement_type") or None,
+        status=values.get("status") or None,
+        business_type=values.get("business_type") or None,
+        as_of=parse_dmy_date(values.get("as_of")),
+        receive_date=parse_dmy_date(values.get("receive_date")),
+        file_url=file_url,
+        file_id=file_id,
+        file_kind=file_kind,
+    )
+
+
+# ViewMore slug -> the category whose complete list that page holds.
+_CATEGORY_FOR_VIEWMORE_SLUG: dict[str, DocumentCategory] = {
+    "fs-norm": DocumentCategory.FINANCIAL_STATEMENT,
+    "fs-kf": DocumentCategory.KEY_FINANCIAL_RATIO,
+    "fs-mda": DocumentCategory.MDA,
+}
+
+_VIEWMORE_HREF = re.compile(r'href="([^"]*?/ViewMore/([a-z0-9-]+)[^"]*)"', re.IGNORECASE)
+
+
+def _normalize_categories(
+    types: list[DocumentCategory | str] | DocumentCategory | str | None,
+) -> list[DocumentCategory]:
+    """Coerce the ``types`` argument into a de-duplicated list of DocumentCategory (all if None)."""
+    if types is None:
+        return list(DocumentCategory)
+    if isinstance(types, (DocumentCategory, str)):
+        types = [types]
+    out: list[DocumentCategory] = []
+    for t in types:
+        cat = t if isinstance(t, DocumentCategory) else DocumentCategory(t)
+        if cat not in out:
+            out.append(cat)
+    return out
+
+
+def _format_sec_date(value: date | str | None, param_name: str) -> str:
+    """Format a from/to date into the form's dd/MM/yyyy wire value ('' when None)."""
+    if value is None:
+        return ""
+    if isinstance(value, date):  # datetime subclasses date
+        return value.strftime(SEC_FORM_DATE_FORMAT)
+    text = value.strip()
+    if not text:
+        return ""
+    try:
+        datetime.strptime(text, SEC_FORM_DATE_FORMAT)
+    except ValueError as exc:
+        error_msg = (
+            f"Invalid {param_name} '{value}': expected dd/mm/yyyy (e.g. '31/12/2025') or a "
+            f"datetime.date/datetime object."
+        )
+        logger.error(error_msg)
+        raise InvalidDateError(error_msg) from exc
+    return text
+
+
+class FinancialReportService:
+    """
+    List downloadable SEC disclosure documents for an issuer.
+
+    Replays the ASP.NET WebForms search (GET fresh VIEWSTATE tokens → form POST), parses the
+    result tables into :class:`SecDocument` models, and (by default) follows the "display all
+    results" ViewMore pages so large sections are returned in full. Stateless host — no
+    SessionManager (``use_session`` is forced off).
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        base = config or FetcherConfig()
+        self.config = base.model_copy(update={"use_session": False})
+        logger.info("FinancialReportService initialized (host=market.sec.or.th)")
+
+    async def fetch_documents(
+        self,
+        unique_id: str,
+        *,
+        company_name: str | None = None,
+        types: list[DocumentCategory | str] | DocumentCategory | str | None = None,
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        lang: Language = "en",
+        follow_view_more: bool = True,
+    ) -> list[SecDocument]:
+        """
+        List documents for a resolved ``unique_id`` (10-digit SEC uniqueIDReference).
+
+        Args:
+            unique_id: The issuer's SEC uniqueIDReference (see ``resolve_company``).
+            company_name: Issuer name used as a fallback for rows lacking a Name cell (MD&A).
+            types: One or more :class:`DocumentCategory` (or their string values); None = all 5.
+            from_date / to_date: Window bounds — ``date``/``datetime`` or dd/mm/yyyy string.
+            lang: 'en' or 'th'.
+            follow_view_more: Follow ViewMore pages so truncated sections are returned in full.
+
+        Returns:
+            List of :class:`SecDocument` for the requested categories.
+        """
+        lang = normalize_language(lang)
+        categories = _normalize_categories(types)
+        date_from = _format_sec_date(from_date, "from_date")
+        date_to = _format_sec_date(to_date, "to_date")
+
+        # Minimal set of ddlReportType codes covering the requested categories.
+        codes = list(dict.fromkeys(CATEGORY_TO_REPORT_TYPE[c] for c in categories))
+        wanted = set(categories)
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            results = await asyncio.gather(
+                *(
+                    self._search_code(
+                        fetcher, code, unique_id, company_name, date_from, date_to,
+                        lang, follow_view_more, wanted,
+                    )
+                    for code in codes
+                )
+            )
+        docs = [d for group in results for d in group]
+        logger.info(f"Listed {len(docs)} SEC document(s) for uid={unique_id}")
+        return docs
+
+    async def fetch_documents_raw(
+        self,
+        unique_id: str,
+        *,
+        code: str,
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        lang: Language = "en",
+    ) -> list[dict[str, object]]:
+        """
+        Escape hatch: return the raw parsed result rows (section/headers/cells/href dicts) for a
+        single ddlReportType ``code`` ('FS'/'R561'/'R562'/'KFR'), without model mapping.
+        """
+        lang = normalize_language(lang)
+        date_from = _format_sec_date(from_date, "from_date")
+        date_to = _format_sec_date(to_date, "to_date")
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            html = await self._run_search(
+                fetcher, code, unique_id, None, date_from, date_to, lang
+            )
+        return [dict(r) for r in parse_report_tables(html)]
+
+    async def _run_search(
+        self,
+        fetcher: AsyncDataFetcher,
+        code: str,
+        unique_id: str,
+        company_name: str | None,
+        date_from: str,
+        date_to: str,
+        lang: Language,
+    ) -> str:
+        """GET fresh tokens then POST the search form; return the result HTML."""
+        report_url = (
+            f"{SEC_BASE_URL}{SEC_FINANCIAL_REPORT_ENDPOINT.format(lang=lang, report_type=code)}"
+        )
+        get_resp = await fetcher.fetch(report_url, headers=build_sec_headers(referer=SEC_REFERER))
+        tokens = extract_aspnet_tokens(get_resp.text)
+        if not tokens.get("__VIEWSTATE"):
+            from settfex.exceptions import FetchError
+
+            raise FetchError(
+                "SEC search page returned no __VIEWSTATE token — the page structure may have "
+                "changed, or the request was blocked."
+            )
+        form = {
+            **tokens,
+            SEC_FORM_FIELD_REPORT_TYPE: code,
+            SEC_FORM_FIELD_COMPANY: company_name or "",
+            SEC_FORM_FIELD_COMPANY_TEXT: company_name or "",
+            SEC_FORM_FIELD_COMPANY_VALUE: unique_id,
+            SEC_FORM_FIELD_DATE_FROM: date_from,
+            SEC_FORM_FIELD_DATE_TO: date_to,
+            SEC_FORM_FIELD_SEARCH: "Search",
+        }
+        post_resp = await fetcher.fetch(
+            report_url,
+            headers=build_sec_headers(referer=report_url, origin=True),
+            method="POST",
+            data=form,
+        )
+        return post_resp.text
+
+    async def _search_code(
+        self,
+        fetcher: AsyncDataFetcher,
+        code: str,
+        unique_id: str,
+        company_name: str | None,
+        date_from: str,
+        date_to: str,
+        lang: Language,
+        follow_view_more: bool,
+        wanted: set[DocumentCategory],
+    ) -> list[SecDocument]:
+        """Run one search code, map rows, and (optionally) complete sections via ViewMore."""
+        html = await self._run_search(
+            fetcher, code, unique_id, company_name, date_from, date_to, lang
+        )
+        inline = [
+            d
+            for r in parse_report_tables(html)
+            if (d := row_to_document(r, unique_id, company_name=company_name))
+            and d.category in wanted
+        ]
+        if not follow_view_more:
+            return inline
+
+        # Follow each ViewMore link whose category is wanted; its page holds the COMPLETE list
+        # for that section, so it replaces the truncated inline rows for that category.
+        replacements: dict[DocumentCategory, list[SecDocument]] = {}
+        seen_slugs: set[str] = set()
+        vm_targets: list[tuple[DocumentCategory, str]] = []
+        for href, slug in _VIEWMORE_HREF.findall(html):
+            slug = slug.lower()
+            cat = _CATEGORY_FOR_VIEWMORE_SLUG.get(slug)
+            if cat is None or cat not in wanted or slug in seen_slugs:
+                continue
+            seen_slugs.add(slug)
+            vm_targets.append((cat, urljoin(SEC_BASE_URL, unescape(href))))
+
+        if vm_targets:
+            pages = await asyncio.gather(
+                *(fetcher.fetch(url, headers=build_sec_headers(referer=SEC_REFERER))
+                  for _, url in vm_targets)
+            )
+            for (cat, _), page in zip(vm_targets, pages, strict=True):
+                replacements[cat] = [
+                    d
+                    for r in parse_report_tables(page.text)
+                    if (d := row_to_document(r, unique_id, company_name=company_name))
+                    and d.category == cat
+                ]
+
+        result = [d for d in inline if d.category not in replacements]
+        for docs in replacements.values():
+            result.extend(docs)
+        return result
+
+
+async def get_sec_documents(
+    query: str,
+    *,
+    types: list[DocumentCategory | str] | DocumentCategory | str | None = None,
+    from_date: date | str | None = None,
+    to_date: date | str | None = None,
+    lang: Language = "en",
+    follow_view_more: bool = True,
+    config: FetcherConfig | None = None,
+) -> list[SecDocument]:
+    """
+    Convenience: resolve a symbol/name and list its SEC disclosure documents (all 5 categories
+    by default). This is the flat, one-call entry point (LLM tool-calling friendly).
+
+    Args:
+        query: Symbol or company name (e.g. "CPALL").
+        types: One or more :class:`DocumentCategory` (or string values); None = all.
+        from_date / to_date: Window bounds — ``date``/``datetime`` or dd/mm/yyyy string.
+        lang: 'en' or 'th'.
+        follow_view_more: Follow ViewMore pages for complete large sections.
+        config: Optional fetcher configuration.
+
+    Returns:
+        List of :class:`SecDocument` (empty if the company cannot be resolved).
+    """
+    company = await resolve_company(query, lang, config=config)
+    if company is None:
+        logger.warning(f"No SEC company matched query={query!r}; returning no documents")
+        return []
+    service = FinancialReportService(config=config)
+    return await service.fetch_documents(
+        company.unique_id,
+        company_name=company.company_name,
+        types=types,
+        from_date=from_date,
+        to_date=to_date,
+        lang=lang,
+        follow_view_more=follow_view_more,
+    )

--- a/settfex/services/sec/sec.py
+++ b/settfex/services/sec/sec.py
@@ -1,0 +1,128 @@
+"""Unified SEC facade — one entry point for an issuer's disclosure documents.
+
+    >>> sec = SecCompany("CPALL")
+    >>> docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
+    >>> files = await sec.download_all(docs, dest_dir="./out")
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from loguru import logger
+
+from settfex.exceptions import SymbolNotFoundError
+from settfex.services.sec.company import CompanyMatch, resolve_company
+from settfex.services.sec.download import (
+    DocumentDownloadService,
+    DownloadedFile,
+)
+from settfex.services.sec.financial_report import (
+    DocumentCategory,
+    FinancialReportService,
+    SecDocument,
+)
+from settfex.services.set.stock.utils import Language, normalize_language
+from settfex.utils.data_fetcher import FetcherConfig
+
+
+class SecCompany:
+    """
+    Facade over the SEC IDISC services for a single issuer (by symbol or name).
+
+    The company is resolved lazily (and cached) on first use; the listing and download services
+    are lazy-initialized. All methods are async.
+    """
+
+    def __init__(
+        self,
+        symbol_or_name: str,
+        *,
+        lang: Language = "en",
+        config: FetcherConfig | None = None,
+    ) -> None:
+        self.query = symbol_or_name.strip()
+        self.lang: Language = normalize_language(lang)
+        self.config = config
+        self._company: CompanyMatch | None = None
+        self._report_service: FinancialReportService | None = None
+        self._download_service: DocumentDownloadService | None = None
+
+    async def resolve(self) -> CompanyMatch:
+        """Resolve (and cache) the issuer's SEC company record; raise if not found."""
+        if self._company is None:
+            company = await resolve_company(self.query, self.lang, config=self.config)
+            if company is None:
+                raise SymbolNotFoundError(
+                    f"No SEC issuer matched '{self.query}'", symbol=self.query
+                )
+            self._company = company
+            logger.info(
+                f"SecCompany '{self.query}' -> {company.company_name} ({company.unique_id})"
+            )
+        return self._company
+
+    @property
+    def report_service(self) -> FinancialReportService:
+        """Lazily-constructed listing service."""
+        if self._report_service is None:
+            self._report_service = FinancialReportService(config=self.config)
+        return self._report_service
+
+    @property
+    def download_service(self) -> DocumentDownloadService:
+        """Lazily-constructed download service."""
+        if self._download_service is None:
+            self._download_service = DocumentDownloadService(config=self.config)
+        return self._download_service
+
+    async def list_documents(
+        self,
+        *,
+        types: list[DocumentCategory | str] | DocumentCategory | str | None = None,
+        from_date: date | str | None = None,
+        to_date: date | str | None = None,
+        follow_view_more: bool = True,
+    ) -> list[SecDocument]:
+        """List this issuer's disclosure documents (all 5 categories by default)."""
+        company = await self.resolve()
+        return await self.report_service.fetch_documents(
+            company.unique_id,
+            company_name=company.company_name,
+            types=types,
+            from_date=from_date,
+            to_date=to_date,
+            lang=self.lang,
+            follow_view_more=follow_view_more,
+        )
+
+    async def download(
+        self,
+        target: SecDocument | str,
+        *,
+        dest_dir: str | Path | None = None,
+    ) -> DownloadedFile:
+        """Download one document (optionally saving to ``dest_dir``)."""
+        dl = await self.download_service.download(target)
+        if dest_dir is not None:
+            dl.save(dest_dir)
+        return dl
+
+    async def download_all(
+        self,
+        targets: list[SecDocument | str],
+        *,
+        dest_dir: str | Path | None = None,
+        max_concurrency: int = 5,
+        continue_on_error: bool = True,
+        progress: bool = False,
+    ) -> list[DownloadedFile]:
+        """Download many documents concurrently (optionally saving to ``dest_dir``)."""
+        return await self.download_service.download_all(
+            targets,
+            dest_dir=dest_dir,
+            max_concurrency=max_concurrency,
+            continue_on_error=continue_on_error,
+            progress=progress,
+        )

--- a/settfex/services/sec/sec.py
+++ b/settfex/services/sec/sec.py
@@ -1,8 +1,8 @@
 """Unified SEC facade — one entry point for an issuer's disclosure documents.
 
-    >>> sec = SecCompany("CPALL")
-    >>> docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
-    >>> files = await sec.download_all(docs, dest_dir="./out")
+>>> sec = SecCompany("CPALL")
+>>> docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
+>>> files = await sec.download_all(docs, dest_dir="./out")
 """
 
 from __future__ import annotations

--- a/settfex/services/sec/utils.py
+++ b/settfex/services/sec/utils.py
@@ -1,0 +1,226 @@
+"""Utilities for the SEC IDISC services: headers, ASP.NET token scraping, an HTML result-table
+parser (stdlib only), and small value coercers.
+
+The SEC site is server-rendered ASP.NET HTML with no JSON list endpoint, so listing means
+parsing HTML tables. Parsing uses the standard library ``html.parser`` (no new dependency).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from settfex.services.sec.constants import (
+    SEC_ASPNET_TOKEN_FIELDS,
+    SEC_BASE_URL,
+    SEC_REFERER,
+)
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+
+def build_sec_headers(referer: str = SEC_REFERER, *, origin: bool = False) -> dict[str, str]:
+    """
+    Browser-like headers for market.sec.or.th requests (Incapsula-friendly, mirrors SET).
+
+    ``Content-Type`` is intentionally omitted — ``curl_cffi`` sets it automatically for JSON
+    vs form bodies. Pass ``origin=True`` for POSTs that want an ``Origin`` header.
+    """
+    headers = {
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9,application/json,*/*;q=0.8"
+        ),
+        "Accept-Language": "en-US,en;q=0.9,th-TH;q=0.8,th;q=0.7",
+        "Cache-Control": "no-cache",
+        "Pragma": "no-cache",
+        "Referer": referer,
+        "Sec-Ch-Ua": '"Chromium";v="120", "Not=A?Brand";v="24", "Google Chrome";v="120"',
+        "Sec-Ch-Ua-Mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"Windows"',
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-User": "?1",
+        "Upgrade-Insecure-Requests": "1",
+    }
+    if origin:
+        headers["Origin"] = SEC_BASE_URL
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# ASP.NET postback token scraping
+# ---------------------------------------------------------------------------
+
+
+def extract_aspnet_tokens(html: str) -> dict[str, str]:
+    """
+    Scrape the hidden ASP.NET postback tokens (__VIEWSTATE etc.) from a GET page.
+
+    These MUST be echoed back on the search POST — omitting them does not error but silently
+    returns a wrong (broader) result set. Returns a dict with every field in
+    ``SEC_ASPNET_TOKEN_FIELDS`` (value ``""`` if a field is unexpectedly absent).
+    """
+    tokens: dict[str, str] = {}
+    for field in SEC_ASPNET_TOKEN_FIELDS:
+        match = re.search(
+            rf'id="{re.escape(field)}"[^>]*value="([^"]*)"', html
+        )
+        tokens[field] = unescape(match.group(1)) if match else ""
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# HTML result-table parsing
+# ---------------------------------------------------------------------------
+
+
+class ReportRow(dict[str, Any]):
+    """A parsed result-table row: ``section`` (card heading), ``headers``, ``cells``, ``href``."""
+
+
+class _ReportTableParser(HTMLParser):
+    """Extract (section-heading, column-headers, row-cells, first-href) tuples from result HTML.
+
+    The result panel is a sequence of ``<div class="card-heading">…</div>`` + ``<table>`` pairs;
+    each table has a ``<th>`` header row followed by ``<td>`` data rows. We track the current
+    heading and, per table, the header list; each data row is emitted with its section + the
+    first anchor href found in the row (the download link).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.rows: list[ReportRow] = []
+        self._section = ""
+        self._heading_depth = 0  # >0 while inside a card-heading div (handles nested divs)
+        self._heading_buf: list[str] = []
+        self._in_table = False
+        self._headers: list[str] = []
+        self._in_th = False
+        self._in_td = False
+        self._cell_buf: list[str] = []
+        self._row: list[str] = []
+        self._row_href: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        adict = {k: (v or "") for k, v in attrs}
+        cls = adict.get("class", "")
+        if tag == "div":
+            if self._heading_depth > 0:
+                self._heading_depth += 1
+            elif "card-heading" in cls:
+                self._heading_depth = 1
+                self._heading_buf = []
+        elif tag == "table":
+            self._in_table = True
+            self._headers = []
+        elif tag == "tr":
+            self._row = []
+            self._row_href = None
+        elif tag == "th" and self._in_table:
+            self._in_th = True
+            self._cell_buf = []
+        elif tag == "td" and self._in_table:
+            self._in_td = True
+            self._cell_buf = []
+        elif tag == "a" and self._in_td and self._row_href is None:
+            href = adict.get("href", "")
+            if href:
+                self._row_href = href
+
+    def handle_data(self, data: str) -> None:
+        if self._heading_depth > 0:
+            self._heading_buf.append(data)
+        elif self._in_th or self._in_td:
+            self._cell_buf.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "div" and self._heading_depth > 0:
+            self._heading_depth -= 1
+            if self._heading_depth == 0:
+                self._section = re.sub(r"\s+", " ", "".join(self._heading_buf)).strip()
+        elif tag == "th" and self._in_th:
+            self._headers.append(re.sub(r"\s+", " ", "".join(self._cell_buf)).strip())
+            self._in_th = False
+        elif tag == "td" and self._in_td:
+            self._row.append(re.sub(r"\s+", " ", "".join(self._cell_buf)).strip())
+            self._in_td = False
+        elif tag == "tr":
+            # Emit a data row only (header rows have <th>, so self._row stays empty for them).
+            if self._row and self._headers:
+                self.rows.append(
+                    ReportRow(
+                        section=self._section,
+                        headers=list(self._headers),
+                        cells=list(self._row),
+                        href=self._row_href,
+                    )
+                )
+            self._row = []
+            self._row_href = None
+        elif tag == "table":
+            self._in_table = False
+            self._headers = []
+
+
+def parse_report_tables(html: str) -> list[ReportRow]:
+    """Parse a SEC result page/panel into a flat list of :class:`ReportRow` (one per data row)."""
+    parser = _ReportTableParser()
+    parser.feed(html)
+    return parser.rows
+
+
+# ---------------------------------------------------------------------------
+# Value coercers
+# ---------------------------------------------------------------------------
+
+
+def parse_dmy_date(value: str | None) -> date | None:
+    """Parse a dd/MM/yyyy result-cell date; return None for blank/unparseable input."""
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return datetime.strptime(text, "%d/%m/%Y").date()
+    except ValueError:
+        return None
+
+
+def parse_int(value: str | None) -> int | None:
+    """Parse an integer from a result cell (e.g. a year); None if not an integer."""
+    if not value:
+        return None
+    match = re.search(r"-?\d+", value.replace(",", ""))
+    return int(match.group(0)) if match else None
+
+
+def classify_download_href(href: str | None) -> tuple[str, str | None, str | None]:
+    """
+    Resolve a row href to (absolute_url, file_id, file_kind).
+
+    - IDISC downloads: ``/public/idisc/Download?FILEID=<path>`` → file_id=<path>, kind from ext.
+    - IPOS downloads:  ``/ipos/Common/IPOSGetFile.aspx?id=<id>`` → file_id="ipos:<id>", kind=None.
+    Relative hrefs are resolved against the SEC base URL.
+    """
+    if not href:
+        return "", None, None
+    absolute = urljoin(SEC_BASE_URL + "/public/idisc/en/FinancialReport/ALL", unescape(href))
+    parsed = urlparse(absolute)
+    query = parse_qs(parsed.query)
+    if "FILEID" in query:
+        file_id = query["FILEID"][0]
+        ext = file_id.rsplit(".", 1)[-1].lower() if "." in file_id else None
+        kind = ext if ext in {"zip", "pdf", "xlsx", "doc", "docx"} else None
+        return absolute, file_id, kind
+    if parsed.path.lower().endswith("iposgetfile.aspx") and "id" in query:
+        return absolute, f"ipos:{query['id'][0]}", None
+    # Not a recognized download link (e.g. a "display all results" ViewMore link) — not a doc.
+    return "", None, None

--- a/settfex/services/sec/utils.py
+++ b/settfex/services/sec/utils.py
@@ -69,9 +69,7 @@ def extract_aspnet_tokens(html: str) -> dict[str, str]:
     """
     tokens: dict[str, str] = {}
     for field in SEC_ASPNET_TOKEN_FIELDS:
-        match = re.search(
-            rf'id="{re.escape(field)}"[^>]*value="([^"]*)"', html
-        )
+        match = re.search(rf'id="{re.escape(field)}"[^>]*value="([^"]*)"', html)
         tokens[field] = unescape(match.group(1)) if match else ""
     return tokens
 

--- a/settfex/utils/data_fetcher.py
+++ b/settfex/utils/data_fetcher.py
@@ -180,6 +180,7 @@ class AsyncDataFetcher:
         *,
         method: str = "GET",
         json_body: Any | None = None,
+        data: Any | None = None,
     ) -> Any:
         """
         Make an HTTP request using either a persistent session or a standalone request.
@@ -192,7 +193,10 @@ class AsyncDataFetcher:
             url: URL to fetch
             headers: HTTP headers to include
             method: HTTP method, "GET" (default) or "POST"
-            json_body: JSON-serializable body for POST requests (ignored for GET)
+            json_body: JSON-serializable body for a JSON POST (ignored for GET)
+            data: Form body for an ``application/x-www-form-urlencoded`` POST — a dict of
+                fields or a pre-encoded string (ignored for GET). Takes precedence over
+                ``json_body`` when both are given (e.g. ASP.NET WebForms postbacks).
 
         Returns:
             Response object from curl_cffi
@@ -225,6 +229,16 @@ class AsyncDataFetcher:
 
             def do_request() -> Any:
                 if method == "POST":
+                    # Form-encoded body (data) takes precedence over JSON body; curl_cffi
+                    # sets the matching Content-Type automatically for whichever is used.
+                    if data is not None:
+                        return requests.post(
+                            url,
+                            data=data,
+                            headers=headers,
+                            timeout=self.config.timeout,
+                            impersonate=self.config.browser_impersonate,  # type: ignore
+                        )
                     return requests.post(
                         url,
                         json=json_body,
@@ -254,6 +268,8 @@ class AsyncDataFetcher:
         *,
         method: str = "GET",
         json_body: Any | None = None,
+        data: Any | None = None,
+        decode_text: bool = True,
     ) -> FetchResponse:
         """
         Fetch data from a URL asynchronously with proper Unicode handling.
@@ -269,7 +285,14 @@ class AsyncDataFetcher:
             headers: Optional custom headers (merged with defaults)
             method: HTTP method, "GET" (default) or "POST". POST requires
                 FetcherConfig(use_session=False).
-            json_body: JSON-serializable body for POST requests (ignored for GET)
+            json_body: JSON-serializable body for a JSON POST (ignored for GET)
+            data: Form body for an ``application/x-www-form-urlencoded`` POST — a dict of
+                fields or a pre-encoded string. Takes precedence over ``json_body``
+                (ignored for GET).
+            decode_text: When True (default) decode the body to ``FetchResponse.text``
+                (UTF-8, latin1 fallback). Set False for binary payloads (zip/xlsx/pdf) to
+                skip the wasteful decode — ``text`` is then ``""`` and the raw bytes are
+                available on ``FetchResponse.content``.
 
         Returns:
             FetchResponse with status, content, and metadata
@@ -312,21 +335,26 @@ class AsyncDataFetcher:
 
                 # Make request (either via persistent session or standalone)
                 response = await self._make_request(
-                    url, default_headers, method=method, json_body=json_body
+                    url, default_headers, method=method, json_body=json_body, data=data
                 )
 
                 elapsed = time.time() - start_time
 
-                # Decode content with UTF-8 for Thai/Unicode support
-                try:
-                    text = response.content.decode("utf-8")
-                except UnicodeDecodeError:
-                    # Fallback to latin1 if UTF-8 fails
-                    logger.warning(f"UTF-8 decode failed for {url}, trying latin1")
-                    text = response.content.decode("latin1")
-                    encoding = "latin1"
+                if decode_text:
+                    # Decode content with UTF-8 for Thai/Unicode support
+                    try:
+                        text = response.content.decode("utf-8")
+                    except UnicodeDecodeError:
+                        # Fallback to latin1 if UTF-8 fails
+                        logger.warning(f"UTF-8 decode failed for {url}, trying latin1")
+                        text = response.content.decode("latin1")
+                        encoding = "latin1"
+                    else:
+                        encoding = "utf-8"
                 else:
-                    encoding = "utf-8"
+                    # Binary payload (zip/xlsx/pdf): skip decode; use .content for bytes.
+                    text = ""
+                    encoding = "binary"
 
                 # Create response object
                 fetch_response = FetchResponse(

--- a/tests/services/sec/__init__.py
+++ b/tests/services/sec/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the SEC IDISC (market.sec.or.th) document services."""

--- a/tests/services/sec/fixtures.py
+++ b/tests/services/sec/fixtures.py
@@ -110,14 +110,16 @@ REPORT_PAGE_HTML = """
 """
 
 # The Thai soft-404 body served under HTTP 200 for a dead FILEID.
-FILE_NOT_FOUND_HTML = (
-    "ไม่พบไฟล์ที่ระบุ<br/><a href='javascript:history.back();'>ย้อนกลับ</a>"
-)
+FILE_NOT_FOUND_HTML = "ไม่พบไฟล์ที่ระบุ<br/><a href='javascript:history.back();'>ย้อนกลับ</a>"
 
 COMPANY_SEARCH_JSON = [
     {"Text": "CP ALL PUBLIC COMPANY LIMITED", "Value": "0000003875", "Flag": True},
 ]
 COMPANY_SEARCH_MULTI_JSON = [
-    {"Text": "PTT AROMATICS AND REFINING PUBLIC COMPANY LIMITED", "Value": "0000006634", "Flag": False},
+    {
+        "Text": "PTT AROMATICS AND REFINING PUBLIC COMPANY LIMITED",
+        "Value": "0000006634",
+        "Flag": False,
+    },
     {"Text": "PTT PUBLIC COMPANY LIMITED", "Value": "0000001111", "Flag": True},
 ]

--- a/tests/services/sec/fixtures.py
+++ b/tests/services/sec/fixtures.py
@@ -1,0 +1,123 @@
+"""Realistic (trimmed) HTML fixtures mirroring live market.sec.or.th result markup.
+
+Structures captured live 2026-07-20: a FS search returns several ``card-heading`` + ``table``
+sections at once; MD&A uses Date/Time/Heading/Link columns (no Name); 56-1/56-2 use
+Name/Year/Receive Date; some rows link via /public/idisc/Download?FILEID=…, others via
+/ipos/Common/IPOSGetFile.aspx?id=…
+"""
+
+DL = "https://market.sec.or.th/public/idisc/Download?FILEID="
+IPOS = "https://market.sec.or.th/ipos/Common/IPOSGetFile.aspx?id="
+
+# A FS search response panel: revised (empty) + Financial Statements (2) + KFR (1) + MD&A (1).
+FS_SEARCH_HTML = f"""
+<div id="ctl00_CPH_pnlControl">
+  <div class="card card-table"><div class="card-heading">The Financial Statements which need to be revised ( 0 record(s) found)</div>
+    <table id="gPP06T01"><tbody>
+      <tr><th>Order Date</th><th>Company Name</th><th>Reviewed Financial Statement</th><th>Details</th></tr>
+      <tr><td colspan="4">Data not found</td></tr>
+    </tbody></table>
+  </div>
+  <div class="card card-table"><div class="card-heading">Finanacial Statements ( 2 record(s) found)</div>
+    <table id="gPP06T02"><tbody>
+      <tr><th>Name</th><th>Year</th><th>Status</th><th>Type</th><th>Period</th><th>As Of</th><th>Details</th></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2026</td><td>Reviewed</td><td>Company</td><td>Q1</td><td>31/03/2026</td>
+          <td class="icon30"><a href="{DL}dat/news/202605/0737FIN.zip" target="_blank"><img></a></td></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2025</td><td>Reviewed</td><td>Consolidated</td><td>Q3</td><td>30/09/2025</td>
+          <td class="icon30"><a href="{IPOS}726416&amp;sq=0&amp;v=10" target="_blank"><img></a></td></tr>
+    </tbody></table>
+  </div>
+  <div class="card card-table"><div class="card-heading">Key Financial Ratio ( 1 record(s) found)</div>
+    <table id="gPP06T03"><tbody>
+      <tr><th>Name</th><th>Business Type</th><th>Type</th><th>Period</th><th>Year</th><th>As Of</th><th>Details</th></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>Trading</td><td>Consolidated</td><td>Year</td><td>2025</td><td>31/12/2025</td>
+          <td><a href="{IPOS}693598&amp;sq=0&amp;v=10"><img></a></td></tr>
+    </tbody></table>
+  </div>
+  <div class="card card-table"><div class="card-heading">Management's Discussion and Analysis ( 1 record(s) found)</div>
+    <table id="gPP06T04"><tbody>
+      <tr><th>Date</th><th>Time</th><th>Heading</th><th>Link</th></tr>
+      <tr><td>25/02/2026</td><td>17:36</td><td>Management Discussion and Analysis Yearly Ending 31-Dec-2025</td>
+          <td><a href="{DL}dat/news/202602/0737NWS.pdf"><img></a></td></tr>
+    </tbody></table>
+  </div>
+</div>
+"""
+
+# A FS search where the Financial Statements section is truncated (1 inline row) with a
+# "display all results" ViewMore link (fs-norm).
+FS_TRUNCATED_HTML = f"""
+<div id="ctl00_CPH_pnlControl">
+  <div class="card card-table"><div class="card-heading">Finanacial Statements ( 3 record(s) found)</div>
+    <table id="gPP06T02"><tbody>
+      <tr><th>Name</th><th>Year</th><th>Status</th><th>Type</th><th>Period</th><th>As Of</th><th>Details</th></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2026</td><td>Reviewed</td><td>Company</td><td>Q1</td><td>31/03/2026</td>
+          <td><a href="{DL}dat/news/inline_only.zip"><img></a></td></tr>
+      <tr><td colspan="7"><a href="/public/idisc/en/ViewMore/fs-norm?uniqueIDReference=0000003875&amp;dateFrom=20200101&amp;dateTo=20260720">Click here to display all results</a></td></tr>
+    </tbody></table>
+  </div>
+</div>
+"""
+
+# The ViewMore fs-norm page: the COMPLETE FS list (3 rows).
+FS_VIEWMORE_HTML = f"""
+<div class="card card-table"><div class="card-heading">Finanacial Statements ( 3 record(s) found)</div>
+  <table id="gv"><tbody>
+    <tr><th>Name</th><th>Year</th><th>Status</th><th>Type</th><th>Period</th><th>As Of</th><th>Details</th></tr>
+    <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2026</td><td>Reviewed</td><td>Company</td><td>Q1</td><td>31/03/2026</td>
+        <td><a href="{DL}dat/news/full_1.zip"><img></a></td></tr>
+    <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2025</td><td>Audited</td><td>Company</td><td>Year</td><td>31/12/2025</td>
+        <td><a href="{DL}dat/news/full_2.zip"><img></a></td></tr>
+    <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2025</td><td>Audited</td><td>Consolidated</td><td>Year</td><td>31/12/2025</td>
+        <td><a href="{DL}dat/news/full_3.zip"><img></a></td></tr>
+  </tbody></table>
+</div>
+"""
+
+FORM_56_1_HTML = f"""
+<div id="ctl00_CPH_pnlControl">
+  <div class="card card-table"><div class="card-heading">Form 56-1 : Annual Registration Statements ( 2 record(s) found)</div>
+    <table id="g561"><tbody>
+      <tr><th>Name</th><th>Year</th><th>Receive Date</th><th>Details</th></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2025</td><td>26/03/2026</td>
+          <td><a href="{DL}dat/f56/0737E1N.zip"><img></a></td></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2024</td><td>31/03/2025</td>
+          <td><a href="{DL}dat/f56/0737ONE.zip"><img></a></td></tr>
+    </tbody></table>
+  </div>
+</div>
+"""
+
+FORM_56_2_HTML = f"""
+<div id="ctl00_CPH_pnlControl">
+  <div class="card card-table"><div class="card-heading">Form 56-2 : Annual Reports ( 1 record(s) found)</div>
+    <table id="g562"><tbody>
+      <tr><th>Name</th><th>Year</th><th>Receive Date</th><th>Details</th></tr>
+      <tr><td>CP ALL PUBLIC COMPANY LIMITED</td><td>2025</td><td>26/03/2026</td>
+          <td><a href="{DL}dat/annual/0737E1N.zip"><img></a></td></tr>
+    </tbody></table>
+  </div>
+</div>
+"""
+
+# The GET page carrying the hidden ASP.NET tokens.
+REPORT_PAGE_HTML = """
+<form id="aspnetForm">
+  <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="STATE123==" />
+  <input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="688223AE" />
+  <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="EVAL456==" />
+</form>
+"""
+
+# The Thai soft-404 body served under HTTP 200 for a dead FILEID.
+FILE_NOT_FOUND_HTML = (
+    "ไม่พบไฟล์ที่ระบุ<br/><a href='javascript:history.back();'>ย้อนกลับ</a>"
+)
+
+COMPANY_SEARCH_JSON = [
+    {"Text": "CP ALL PUBLIC COMPANY LIMITED", "Value": "0000003875", "Flag": True},
+]
+COMPANY_SEARCH_MULTI_JSON = [
+    {"Text": "PTT AROMATICS AND REFINING PUBLIC COMPANY LIMITED", "Value": "0000006634", "Flag": False},
+    {"Text": "PTT PUBLIC COMPANY LIMITED", "Value": "0000001111", "Flag": True},
+]

--- a/tests/services/sec/test_company.py
+++ b/tests/services/sec/test_company.py
@@ -1,0 +1,77 @@
+"""Tests for SEC company resolution (mocked JSON POST)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from settfex.services.sec.company import CompanyMatch, resolve_company, search_companies
+from tests.services.sec.fixtures import COMPANY_SEARCH_JSON, COMPANY_SEARCH_MULTI_JSON
+
+
+def _patch_company_fetcher(payload):
+    """Patch AsyncDataFetcher in the company module; fetch_json returns ``payload``."""
+    cls = patch("settfex.services.sec.company.AsyncDataFetcher").start()
+    instance = AsyncMock()
+    instance.fetch_json = AsyncMock(return_value=payload)
+    cls.return_value.__aenter__.return_value = instance
+    cls.return_value.__aexit__.return_value = None
+    return cls, instance
+
+
+class TestCompanyMatchModel:
+    def test_aliases(self) -> None:
+        m = CompanyMatch(Text="CP ALL", Value="0000003875", Flag=True)
+        assert m.company_name == "CP ALL"
+        assert m.unique_id == "0000003875"
+        assert m.is_primary is True
+
+    def test_flag_defaults_false(self) -> None:
+        m = CompanyMatch(Text="X", Value="1")
+        assert m.is_primary is False
+
+
+class TestSearchCompanies:
+    @pytest.mark.asyncio
+    async def test_returns_matches(self) -> None:
+        cls, instance = _patch_company_fetcher(COMPANY_SEARCH_JSON)
+        try:
+            matches = await search_companies("CPALL")
+        finally:
+            patch.stopall()
+        assert len(matches) == 1
+        assert matches[0].unique_id == "0000003875"
+        # POST with JSON body {lang, content}
+        _, kwargs = instance.fetch_json.call_args
+        assert kwargs["method"] == "POST"
+        assert kwargs["json_body"] == {"lang": "en", "content": "CPALL"}
+
+    @pytest.mark.asyncio
+    async def test_non_list_payload_returns_empty(self) -> None:
+        _patch_company_fetcher({"unexpected": "shape"})
+        try:
+            matches = await search_companies("CPALL")
+        finally:
+            patch.stopall()
+        assert matches == []
+
+
+class TestResolveCompany:
+    @pytest.mark.asyncio
+    async def test_prefers_primary_flag(self) -> None:
+        _patch_company_fetcher(COMPANY_SEARCH_MULTI_JSON)
+        try:
+            match = await resolve_company("PTT")
+        finally:
+            patch.stopall()
+        assert match is not None
+        assert match.is_primary is True
+        assert match.unique_id == "0000001111"
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_none(self) -> None:
+        _patch_company_fetcher([])
+        try:
+            match = await resolve_company("NOPE")
+        finally:
+            patch.stopall()
+        assert match is None

--- a/tests/services/sec/test_download.py
+++ b/tests/services/sec/test_download.py
@@ -1,0 +1,185 @@
+"""Tests for the SEC document download service (mocked bytes; soft-404 handling)."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from settfex.exceptions import FetchError
+from settfex.services.sec.download import (
+    DocumentDownloadService,
+    DownloadedFile,
+    _filename_from_disposition,
+)
+from settfex.services.sec.financial_report import DocumentCategory, SecDocument
+from settfex.utils.data_fetcher import FetchResponse
+from tests.services.sec.fixtures import FILE_NOT_FOUND_HTML
+
+ZIP_BYTES = b"PK\x03\x04\x14\x00\x00\x08" + b"\x00" * 32
+
+
+def _dl_resp(content: bytes, ctype: str, disposition: str | None = None, status: int = 200):
+    headers = {"Content-Type": ctype}
+    if disposition is not None:
+        headers["Content-Disposition"] = disposition
+    return FetchResponse(
+        status_code=status, content=content, text="", headers=headers,
+        url="https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/x.zip", elapsed=0.01,
+    )
+
+
+def _doc(file_url: str, file_id: str) -> SecDocument:
+    return SecDocument(
+        company_name="CP ALL", unique_id="0000003875",
+        category=DocumentCategory.FINANCIAL_STATEMENT, section="Financial Statements",
+        file_url=file_url, file_id=file_id, file_kind="zip",
+    )
+
+
+def _patch_download(router):
+    cls = patch("settfex.services.sec.download.AsyncDataFetcher").start()
+    instance = AsyncMock()
+    instance.fetch = AsyncMock(side_effect=router)
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=None)
+    cls.return_value = instance
+    return cls, instance
+
+
+class TestFilenameFromDisposition:
+    def test_bare_idisc_filename(self) -> None:
+        assert _filename_from_disposition("0737FIN.zip", "fallback") == "0737FIN.zip"
+
+    def test_attachment_filename(self) -> None:
+        assert _filename_from_disposition("Attachment; Filename=ALL_1_V10.zip", "fb") == (
+            "ALL_1_V10.zip"
+        )
+
+    def test_fallback_when_absent(self) -> None:
+        assert _filename_from_disposition("", "fallback.zip") == "fallback.zip"
+
+
+class TestDownloadedFileSave:
+    def test_save_to_directory(self, tmp_path: Path) -> None:
+        f = DownloadedFile(filename="a.zip", content=b"xyz", size=3, file_url="u")
+        out = f.save(tmp_path)
+        assert out == tmp_path / "a.zip"
+        assert out.read_bytes() == b"xyz"
+
+    def test_save_to_explicit_path(self, tmp_path: Path) -> None:
+        f = DownloadedFile(filename="a.zip", content=b"xyz", size=3, file_url="u")
+        target = tmp_path / "nested" / "custom.zip"
+        out = f.save(target)
+        assert out == target and out.exists()
+
+
+class TestResolveUrl:
+    def test_secdocument(self) -> None:
+        doc = _doc("https://market.sec.or.th/dl", "dat/x.zip")
+        assert DocumentDownloadService._resolve_url(doc) == (doc.file_url, doc)
+
+    def test_http_string(self) -> None:
+        url, doc = DocumentDownloadService._resolve_url("https://x/y.zip")
+        assert url == "https://x/y.zip" and doc is None
+
+    def test_bare_fileid(self) -> None:
+        url, doc = DocumentDownloadService._resolve_url("dat/news/x.zip")
+        assert url.endswith("Download?FILEID=dat/news/x.zip") and doc is None
+
+
+class TestDownload:
+    @pytest.mark.asyncio
+    async def test_success_returns_bytes_and_filename(self) -> None:
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _dl_resp(ZIP_BYTES, "application/zip", "myfile.zip")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            dl = await svc.download("dat/news/x.zip")
+        finally:
+            patch.stopall()
+        assert dl.filename == "myfile.zip"
+        assert dl.content == ZIP_BYTES and dl.size == len(ZIP_BYTES)
+        assert dl.content_type.startswith("application/zip")
+
+    @pytest.mark.asyncio
+    async def test_soft_404_raises(self) -> None:
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html; charset=utf-8")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            with pytest.raises(FetchError, match="soft 404"):
+                await svc.download("dat/annual/dead.zip")
+        finally:
+            patch.stopall()
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(self) -> None:
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _dl_resp(b"", "text/html", status=500)
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            with pytest.raises(FetchError, match="HTTP 500"):
+                await svc.download("dat/news/x.zip")
+        finally:
+            patch.stopall()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_html_raises(self) -> None:
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _dl_resp(b"<html>login</html>", "text/html")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            with pytest.raises(FetchError, match="not a document"):
+                await svc.download("dat/news/x.zip")
+        finally:
+            patch.stopall()
+
+
+class TestDownloadAll:
+    @pytest.mark.asyncio
+    async def test_batch_saves_and_skips_failures(self, tmp_path: Path) -> None:
+        good = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=ok.zip", "ok.zip")
+        bad = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=dead.zip", "dead.zip")
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if "dead.zip" in url:
+                return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html")
+            return _dl_resp(ZIP_BYTES, "application/zip", "ok.zip")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            got = await svc.download_all([good, bad], dest_dir=tmp_path, continue_on_error=True)
+        finally:
+            patch.stopall()
+        assert len(got) == 1  # bad one skipped
+        assert (tmp_path / "ok.zip").exists()
+
+    @pytest.mark.asyncio
+    async def test_continue_on_error_false_propagates(self) -> None:
+        bad = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=dead.zip", "dead.zip")
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            with pytest.raises(FetchError):
+                await svc.download_all([bad], continue_on_error=False)
+        finally:
+            patch.stopall()

--- a/tests/services/sec/test_download.py
+++ b/tests/services/sec/test_download.py
@@ -23,16 +23,24 @@ def _dl_resp(content: bytes, ctype: str, disposition: str | None = None, status:
     if disposition is not None:
         headers["Content-Disposition"] = disposition
     return FetchResponse(
-        status_code=status, content=content, text="", headers=headers,
-        url="https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/x.zip", elapsed=0.01,
+        status_code=status,
+        content=content,
+        text="",
+        headers=headers,
+        url="https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/x.zip",
+        elapsed=0.01,
     )
 
 
 def _doc(file_url: str, file_id: str) -> SecDocument:
     return SecDocument(
-        company_name="CP ALL", unique_id="0000003875",
-        category=DocumentCategory.FINANCIAL_STATEMENT, section="Financial Statements",
-        file_url=file_url, file_id=file_id, file_kind="zip",
+        company_name="CP ALL",
+        unique_id="0000003875",
+        category=DocumentCategory.FINANCIAL_STATEMENT,
+        section="Financial Statements",
+        file_url=file_url,
+        file_id=file_id,
+        file_kind="zip",
     )
 
 
@@ -90,8 +98,9 @@ class TestResolveUrl:
 class TestDownload:
     @pytest.mark.asyncio
     async def test_success_returns_bytes_and_filename(self) -> None:
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _dl_resp(ZIP_BYTES, "application/zip", "myfile.zip")
 
         _patch_download(router)
@@ -106,8 +115,9 @@ class TestDownload:
 
     @pytest.mark.asyncio
     async def test_soft_404_raises(self) -> None:
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html; charset=utf-8")
 
         _patch_download(router)
@@ -120,8 +130,9 @@ class TestDownload:
 
     @pytest.mark.asyncio
     async def test_http_error_raises(self) -> None:
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _dl_resp(b"", "text/html", status=500)
 
         _patch_download(router)
@@ -134,8 +145,9 @@ class TestDownload:
 
     @pytest.mark.asyncio
     async def test_unexpected_html_raises(self) -> None:
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _dl_resp(b"<html>login</html>", "text/html")
 
         _patch_download(router)
@@ -153,8 +165,9 @@ class TestDownloadAll:
         good = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=ok.zip", "ok.zip")
         bad = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=dead.zip", "dead.zip")
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if "dead.zip" in url:
                 return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html")
             return _dl_resp(ZIP_BYTES, "application/zip", "ok.zip")
@@ -172,8 +185,9 @@ class TestDownloadAll:
     async def test_continue_on_error_false_propagates(self) -> None:
         bad = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=dead.zip", "dead.zip")
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _dl_resp(FILE_NOT_FOUND_HTML.encode("utf-8"), "text/html")
 
         _patch_download(router)

--- a/tests/services/sec/test_financial_report.py
+++ b/tests/services/sec/test_financial_report.py
@@ -29,8 +29,12 @@ from tests.services.sec.fixtures import (
 
 def _resp(text: str, *, status: int = 200) -> FetchResponse:
     return FetchResponse(
-        status_code=status, content=text.encode("utf-8"), text=text, headers={},
-        url="https://market.sec.or.th/", elapsed=0.01,
+        status_code=status,
+        content=text.encode("utf-8"),
+        text=text,
+        headers={},
+        url="https://market.sec.or.th/",
+        elapsed=0.01,
     )
 
 
@@ -70,7 +74,9 @@ class TestRowToDocument:
     def test_financial_statement_row(self) -> None:
         rows = parse_report_tables(FS_SEARCH_HTML)
         fs = next(
-            d for r in rows if (d := row_to_document(r, "0000003875"))
+            d
+            for r in rows
+            if (d := row_to_document(r, "0000003875"))
             and d.category == DocumentCategory.FINANCIAL_STATEMENT
         )
         assert fs.year == 2026 and fs.statement_type == "Company" and fs.period == "Q1"
@@ -80,7 +86,8 @@ class TestRowToDocument:
     def test_mda_row_uses_company_fallback_and_title(self) -> None:
         rows = parse_report_tables(FS_SEARCH_HTML)
         mda = next(
-            d for r in rows
+            d
+            for r in rows
             if (d := row_to_document(r, "0000003875", company_name="CP ALL"))
             and d.category == DocumentCategory.MDA
         )
@@ -91,15 +98,18 @@ class TestRowToDocument:
     def test_ipos_row_maps_file_id(self) -> None:
         rows = parse_report_tables(FS_SEARCH_HTML)
         ipos = next(
-            d for r in rows if (d := row_to_document(r, "u"))
-            and d.file_id and d.file_id.startswith("ipos:")
+            d
+            for r in rows
+            if (d := row_to_document(r, "u")) and d.file_id and d.file_id.startswith("ipos:")
         )
         assert ipos.file_id == "ipos:726416"
 
     def test_data_not_found_row_returns_none(self) -> None:
         row = ReportRow(
             section="Finanacial Statements ( 0 record(s) found)",
-            headers=["Name", "Year"], cells=["Data not found"], href=None,
+            headers=["Name", "Year"],
+            cells=["Data not found"],
+            href=None,
         )
         assert row_to_document(row, "u") is None
 
@@ -136,8 +146,9 @@ class TestFinancialReportService:
     async def test_fetch_documents_filters_to_requested_category(self, monkeypatch) -> None:
         from unittest.mock import patch
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if method == "POST":
                 return _resp(FS_SEARCH_HTML)
             return _resp(REPORT_PAGE_HTML)
@@ -155,8 +166,9 @@ class TestFinancialReportService:
     async def test_fetch_documents_all_categories_from_fs(self) -> None:
         from unittest.mock import patch
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if method == "POST":
                 return _resp(FS_SEARCH_HTML)
             return _resp(REPORT_PAGE_HTML)
@@ -165,7 +177,8 @@ class TestFinancialReportService:
             _make_fetcher(cls, router)
             svc = FinancialReportService()
             docs = await svc.fetch_documents(
-                "u", types=["financial_statement", "key_financial_ratio", "mda"],
+                "u",
+                types=["financial_statement", "key_financial_ratio", "mda"],
                 follow_view_more=False,
             )
         cats = {d.category for d in docs}
@@ -179,8 +192,9 @@ class TestFinancialReportService:
     async def test_view_more_completes_truncated_section(self) -> None:
         from unittest.mock import patch
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if "ViewMore" in url:
                 return _resp(FS_VIEWMORE_HTML)
             if method == "POST":
@@ -206,8 +220,9 @@ class TestFinancialReportService:
 
         from settfex.exceptions import FetchError
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             return _resp("<html>blocked</html>")  # no tokens
 
         with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
@@ -220,8 +235,9 @@ class TestFinancialReportService:
     async def test_multiple_codes_for_mixed_categories(self) -> None:
         from unittest.mock import patch
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if method == "POST":
                 code = data["ctl00$CPH$ddlReportType"]
                 return _resp({"R561": FORM_56_1_HTML, "R562": FORM_56_2_HTML}[code])
@@ -234,7 +250,8 @@ class TestFinancialReportService:
                 "u", types=["form_56_1", "form_56_2"], follow_view_more=False
             )
         assert {d.category for d in docs} == {
-            DocumentCategory.FORM_56_1, DocumentCategory.FORM_56_2
+            DocumentCategory.FORM_56_1,
+            DocumentCategory.FORM_56_2,
         }
 
 
@@ -243,16 +260,22 @@ class TestGetSecDocuments:
     async def test_resolves_then_lists(self) -> None:
         from unittest.mock import AsyncMock, patch
 
-        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
-                         decode_text=True):
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
             if method == "POST":
                 return _resp(FORM_56_1_HTML)
             return _resp(REPORT_PAGE_HTML)
 
-        with patch("settfex.services.sec.financial_report.resolve_company",
-                   new=AsyncMock(return_value=CompanyMatch(
-                       Text="CP ALL", Value="0000003875", Flag=True))), \
-             patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+        with (
+            patch(
+                "settfex.services.sec.financial_report.resolve_company",
+                new=AsyncMock(
+                    return_value=CompanyMatch(Text="CP ALL", Value="0000003875", Flag=True)
+                ),
+            ),
+            patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls,
+        ):
             _make_fetcher(cls, router)
             docs = await get_sec_documents("CPALL", types="form_56_1", follow_view_more=False)
         assert len(docs) == 2 and docs[0].category == DocumentCategory.FORM_56_1
@@ -261,7 +284,9 @@ class TestGetSecDocuments:
     async def test_unresolved_company_returns_empty(self) -> None:
         from unittest.mock import AsyncMock, patch
 
-        with patch("settfex.services.sec.financial_report.resolve_company",
-                   new=AsyncMock(return_value=None)):
+        with patch(
+            "settfex.services.sec.financial_report.resolve_company",
+            new=AsyncMock(return_value=None),
+        ):
             docs = await get_sec_documents("NOPE")
         assert docs == []

--- a/tests/services/sec/test_financial_report.py
+++ b/tests/services/sec/test_financial_report.py
@@ -1,0 +1,267 @@
+"""Tests for SEC financial-report models, the row->document mapper, and the listing service."""
+
+from datetime import date
+
+import pytest
+
+from settfex.exceptions import InvalidDateError
+from settfex.services.sec.company import CompanyMatch
+from settfex.services.sec.financial_report import (
+    DocumentCategory,
+    FinancialReportService,
+    _format_sec_date,
+    _normalize_categories,
+    category_for_section,
+    get_sec_documents,
+    row_to_document,
+)
+from settfex.services.sec.utils import ReportRow, parse_report_tables
+from settfex.utils.data_fetcher import FetchResponse
+from tests.services.sec.fixtures import (
+    FORM_56_1_HTML,
+    FORM_56_2_HTML,
+    FS_SEARCH_HTML,
+    FS_TRUNCATED_HTML,
+    FS_VIEWMORE_HTML,
+    REPORT_PAGE_HTML,
+)
+
+
+def _resp(text: str, *, status: int = 200) -> FetchResponse:
+    return FetchResponse(
+        status_code=status, content=text.encode("utf-8"), text=text, headers={},
+        url="https://market.sec.or.th/", elapsed=0.01,
+    )
+
+
+def _make_fetcher(mock_cls, router):
+    """Wire a patched AsyncDataFetcher class mock so .fetch() dispatches through ``router``."""
+    from unittest.mock import AsyncMock
+
+    instance = AsyncMock()
+    instance.fetch.side_effect = router
+    mock_cls.return_value.__aenter__.return_value = instance
+    mock_cls.return_value.__aexit__.return_value = None
+    return instance
+
+
+class TestCategoryForSection:
+    def test_maps_known_sections(self) -> None:
+        assert category_for_section("Finanacial Statements ( 5 record(s) found)") == (
+            DocumentCategory.FINANCIAL_STATEMENT
+        )
+        assert category_for_section("Key Financial Ratio ( 1 )") == (
+            DocumentCategory.KEY_FINANCIAL_RATIO
+        )
+        assert category_for_section("Management's Discussion and Analysis ( 2 )") == (
+            DocumentCategory.MDA
+        )
+        assert category_for_section("Form 56-1 : Annual Registration Statements") == (
+            DocumentCategory.FORM_56_1
+        )
+        assert category_for_section("Form 56-2 : Annual Reports") == DocumentCategory.FORM_56_2
+
+    def test_skips_revision_sections(self) -> None:
+        assert category_for_section("The Financial Statements which need to be revised") is None
+        assert category_for_section("SEC has ordered to amend Finanacial Statements") is None
+
+
+class TestRowToDocument:
+    def test_financial_statement_row(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        fs = next(
+            d for r in rows if (d := row_to_document(r, "0000003875"))
+            and d.category == DocumentCategory.FINANCIAL_STATEMENT
+        )
+        assert fs.year == 2026 and fs.statement_type == "Company" and fs.period == "Q1"
+        assert fs.status == "Reviewed" and fs.as_of == date(2026, 3, 31)
+        assert fs.file_kind == "zip" and fs.file_id == "dat/news/202605/0737FIN.zip"
+
+    def test_mda_row_uses_company_fallback_and_title(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        mda = next(
+            d for r in rows
+            if (d := row_to_document(r, "0000003875", company_name="CP ALL"))
+            and d.category == DocumentCategory.MDA
+        )
+        assert mda.company_name == "CP ALL"  # MD&A rows have no Name column -> fallback
+        assert mda.title and "Discussion" in mda.title
+        assert mda.file_kind == "pdf"
+
+    def test_ipos_row_maps_file_id(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        ipos = next(
+            d for r in rows if (d := row_to_document(r, "u"))
+            and d.file_id and d.file_id.startswith("ipos:")
+        )
+        assert ipos.file_id == "ipos:726416"
+
+    def test_data_not_found_row_returns_none(self) -> None:
+        row = ReportRow(
+            section="Finanacial Statements ( 0 record(s) found)",
+            headers=["Name", "Year"], cells=["Data not found"], href=None,
+        )
+        assert row_to_document(row, "u") is None
+
+
+class TestNormalizeCategories:
+    def test_none_returns_all(self) -> None:
+        assert set(_normalize_categories(None)) == set(DocumentCategory)
+
+    def test_string_and_enum_and_dedup(self) -> None:
+        out = _normalize_categories(["financial_statement", DocumentCategory.FINANCIAL_STATEMENT])
+        assert out == [DocumentCategory.FINANCIAL_STATEMENT]
+
+    def test_single_value(self) -> None:
+        assert _normalize_categories("form_56_1") == [DocumentCategory.FORM_56_1]
+
+
+class TestFormatSecDate:
+    def test_date_object(self) -> None:
+        assert _format_sec_date(date(2025, 12, 31), "from_date") == "31/12/2025"
+
+    def test_valid_string_passthrough(self) -> None:
+        assert _format_sec_date("01/06/2026", "from_date") == "01/06/2026"
+
+    def test_none_is_empty(self) -> None:
+        assert _format_sec_date(None, "from_date") == ""
+
+    def test_iso_string_raises(self) -> None:
+        with pytest.raises(InvalidDateError):
+            _format_sec_date("2026-06-01", "from_date")
+
+
+class TestFinancialReportService:
+    @pytest.mark.asyncio
+    async def test_fetch_documents_filters_to_requested_category(self, monkeypatch) -> None:
+        from unittest.mock import patch
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if method == "POST":
+                return _resp(FS_SEARCH_HTML)
+            return _resp(REPORT_PAGE_HTML)
+
+        with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            svc = FinancialReportService()
+            docs = await svc.fetch_documents(
+                "0000003875", types="financial_statement", follow_view_more=False
+            )
+        assert {d.category for d in docs} == {DocumentCategory.FINANCIAL_STATEMENT}
+        assert len(docs) == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_documents_all_categories_from_fs(self) -> None:
+        from unittest.mock import patch
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if method == "POST":
+                return _resp(FS_SEARCH_HTML)
+            return _resp(REPORT_PAGE_HTML)
+
+        with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            svc = FinancialReportService()
+            docs = await svc.fetch_documents(
+                "u", types=["financial_statement", "key_financial_ratio", "mda"],
+                follow_view_more=False,
+            )
+        cats = {d.category for d in docs}
+        assert cats == {
+            DocumentCategory.FINANCIAL_STATEMENT,
+            DocumentCategory.KEY_FINANCIAL_RATIO,
+            DocumentCategory.MDA,
+        }
+
+    @pytest.mark.asyncio
+    async def test_view_more_completes_truncated_section(self) -> None:
+        from unittest.mock import patch
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if "ViewMore" in url:
+                return _resp(FS_VIEWMORE_HTML)
+            if method == "POST":
+                return _resp(FS_TRUNCATED_HTML)
+            return _resp(REPORT_PAGE_HTML)
+
+        with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            svc = FinancialReportService()
+            full = await svc.fetch_documents(
+                "u", types="financial_statement", follow_view_more=True
+            )
+            trunc = await svc.fetch_documents(
+                "u", types="financial_statement", follow_view_more=False
+            )
+        assert len(full) == 3  # ViewMore replaces the single truncated inline row
+        assert len(trunc) == 1
+        assert all("full_" in d.file_id for d in full)
+
+    @pytest.mark.asyncio
+    async def test_missing_viewstate_raises(self) -> None:
+        from unittest.mock import patch
+
+        from settfex.exceptions import FetchError
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            return _resp("<html>blocked</html>")  # no tokens
+
+        with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            svc = FinancialReportService()
+            with pytest.raises(FetchError, match="VIEWSTATE"):
+                await svc.fetch_documents("u", types="form_56_1")
+
+    @pytest.mark.asyncio
+    async def test_multiple_codes_for_mixed_categories(self) -> None:
+        from unittest.mock import patch
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if method == "POST":
+                code = data["ctl00$CPH$ddlReportType"]
+                return _resp({"R561": FORM_56_1_HTML, "R562": FORM_56_2_HTML}[code])
+            return _resp(REPORT_PAGE_HTML)
+
+        with patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            svc = FinancialReportService()
+            docs = await svc.fetch_documents(
+                "u", types=["form_56_1", "form_56_2"], follow_view_more=False
+            )
+        assert {d.category for d in docs} == {
+            DocumentCategory.FORM_56_1, DocumentCategory.FORM_56_2
+        }
+
+
+class TestGetSecDocuments:
+    @pytest.mark.asyncio
+    async def test_resolves_then_lists(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        async def router(url, headers=None, *, method="GET", json_body=None, data=None,
+                         decode_text=True):
+            if method == "POST":
+                return _resp(FORM_56_1_HTML)
+            return _resp(REPORT_PAGE_HTML)
+
+        with patch("settfex.services.sec.financial_report.resolve_company",
+                   new=AsyncMock(return_value=CompanyMatch(
+                       Text="CP ALL", Value="0000003875", Flag=True))), \
+             patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls:
+            _make_fetcher(cls, router)
+            docs = await get_sec_documents("CPALL", types="form_56_1", follow_view_more=False)
+        assert len(docs) == 2 and docs[0].category == DocumentCategory.FORM_56_1
+
+    @pytest.mark.asyncio
+    async def test_unresolved_company_returns_empty(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch("settfex.services.sec.financial_report.resolve_company",
+                   new=AsyncMock(return_value=None)):
+            docs = await get_sec_documents("NOPE")
+        assert docs == []

--- a/tests/services/sec/test_sec.py
+++ b/tests/services/sec/test_sec.py
@@ -16,8 +16,9 @@ _MATCH = CompanyMatch(Text="CP ALL PUBLIC COMPANY LIMITED", Value="0000003875", 
 
 class TestResolve:
     async def test_resolves_and_caches(self) -> None:
-        with patch("settfex.services.sec.sec.resolve_company",
-                   new=AsyncMock(return_value=_MATCH)) as mock_resolve:
+        with patch(
+            "settfex.services.sec.sec.resolve_company", new=AsyncMock(return_value=_MATCH)
+        ) as mock_resolve:
             sec = SecCompany("cpall")
             a = await sec.resolve()
             b = await sec.resolve()
@@ -25,23 +26,29 @@ class TestResolve:
         mock_resolve.assert_awaited_once()  # cached: resolver called once
 
     async def test_not_found_raises(self) -> None:
-        with patch("settfex.services.sec.sec.resolve_company",
-                   new=AsyncMock(return_value=None)), pytest.raises(SymbolNotFoundError):
+        with (
+            patch("settfex.services.sec.sec.resolve_company", new=AsyncMock(return_value=None)),
+            pytest.raises(SymbolNotFoundError),
+        ):
             await SecCompany("nope").resolve()
 
 
 class TestDelegation:
     async def test_list_documents_delegates(self) -> None:
         doc = SecDocument(
-            company_name="CP ALL", unique_id="0000003875",
-            category=DocumentCategory.FORM_56_1, section="Form 56-1",
-            file_url="u", file_id="dat/f56/x.zip", file_kind="zip",
+            company_name="CP ALL",
+            unique_id="0000003875",
+            category=DocumentCategory.FORM_56_1,
+            section="Form 56-1",
+            file_url="u",
+            file_id="dat/f56/x.zip",
+            file_kind="zip",
         )
-        with patch("settfex.services.sec.sec.resolve_company",
-                   new=AsyncMock(return_value=_MATCH)):
+        with patch("settfex.services.sec.sec.resolve_company", new=AsyncMock(return_value=_MATCH)):
             sec = SecCompany("CPALL")
-            with patch.object(sec.report_service, "fetch_documents",
-                              new=AsyncMock(return_value=[doc])) as mock_fetch:
+            with patch.object(
+                sec.report_service, "fetch_documents", new=AsyncMock(return_value=[doc])
+            ) as mock_fetch:
                 docs = await sec.list_documents(types="form_56_1")
         assert docs == [doc]
         # facade forwards the resolved unique_id + company_name
@@ -49,11 +56,11 @@ class TestDelegation:
         assert kwargs["company_name"] == "CP ALL PUBLIC COMPANY LIMITED"
 
     async def test_download_all_delegates(self) -> None:
-        with patch("settfex.services.sec.sec.resolve_company",
-                   new=AsyncMock(return_value=_MATCH)):
+        with patch("settfex.services.sec.sec.resolve_company", new=AsyncMock(return_value=_MATCH)):
             sec = SecCompany("CPALL")
-            with patch.object(sec.download_service, "download_all",
-                              new=AsyncMock(return_value=[])) as mock_dl:
+            with patch.object(
+                sec.download_service, "download_all", new=AsyncMock(return_value=[])
+            ) as mock_dl:
                 await sec.download_all(["dat/news/x.zip"], dest_dir="/tmp/out", max_concurrency=3)
         _, kwargs = mock_dl.call_args
         assert kwargs["dest_dir"] == "/tmp/out" and kwargs["max_concurrency"] == 3

--- a/tests/services/sec/test_sec.py
+++ b/tests/services/sec/test_sec.py
@@ -1,0 +1,59 @@
+"""Tests for the SecCompany facade (delegation + lazy resolve caching)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from settfex.exceptions import SymbolNotFoundError
+from settfex.services.sec.company import CompanyMatch
+from settfex.services.sec.financial_report import DocumentCategory, SecDocument
+from settfex.services.sec.sec import SecCompany
+
+pytestmark = pytest.mark.asyncio
+
+_MATCH = CompanyMatch(Text="CP ALL PUBLIC COMPANY LIMITED", Value="0000003875", Flag=True)
+
+
+class TestResolve:
+    async def test_resolves_and_caches(self) -> None:
+        with patch("settfex.services.sec.sec.resolve_company",
+                   new=AsyncMock(return_value=_MATCH)) as mock_resolve:
+            sec = SecCompany("cpall")
+            a = await sec.resolve()
+            b = await sec.resolve()
+        assert a is b and a.unique_id == "0000003875"
+        mock_resolve.assert_awaited_once()  # cached: resolver called once
+
+    async def test_not_found_raises(self) -> None:
+        with patch("settfex.services.sec.sec.resolve_company",
+                   new=AsyncMock(return_value=None)), pytest.raises(SymbolNotFoundError):
+            await SecCompany("nope").resolve()
+
+
+class TestDelegation:
+    async def test_list_documents_delegates(self) -> None:
+        doc = SecDocument(
+            company_name="CP ALL", unique_id="0000003875",
+            category=DocumentCategory.FORM_56_1, section="Form 56-1",
+            file_url="u", file_id="dat/f56/x.zip", file_kind="zip",
+        )
+        with patch("settfex.services.sec.sec.resolve_company",
+                   new=AsyncMock(return_value=_MATCH)):
+            sec = SecCompany("CPALL")
+            with patch.object(sec.report_service, "fetch_documents",
+                              new=AsyncMock(return_value=[doc])) as mock_fetch:
+                docs = await sec.list_documents(types="form_56_1")
+        assert docs == [doc]
+        # facade forwards the resolved unique_id + company_name
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["company_name"] == "CP ALL PUBLIC COMPANY LIMITED"
+
+    async def test_download_all_delegates(self) -> None:
+        with patch("settfex.services.sec.sec.resolve_company",
+                   new=AsyncMock(return_value=_MATCH)):
+            sec = SecCompany("CPALL")
+            with patch.object(sec.download_service, "download_all",
+                              new=AsyncMock(return_value=[])) as mock_dl:
+                await sec.download_all(["dat/news/x.zip"], dest_dir="/tmp/out", max_concurrency=3)
+        _, kwargs = mock_dl.call_args
+        assert kwargs["dest_dir"] == "/tmp/out" and kwargs["max_concurrency"] == 3

--- a/tests/services/sec/test_utils.py
+++ b/tests/services/sec/test_utils.py
@@ -1,0 +1,119 @@
+"""Tests for SEC utils: HTML parser, token scraping, href classification, value coercers."""
+
+from datetime import date
+
+from settfex.services.sec.utils import (
+    build_sec_headers,
+    classify_download_href,
+    extract_aspnet_tokens,
+    parse_dmy_date,
+    parse_int,
+    parse_report_tables,
+)
+from tests.services.sec.fixtures import (
+    FORM_56_1_HTML,
+    FS_SEARCH_HTML,
+    REPORT_PAGE_HTML,
+)
+
+
+class TestExtractAspnetTokens:
+    def test_extracts_all_three_tokens(self) -> None:
+        tokens = extract_aspnet_tokens(REPORT_PAGE_HTML)
+        assert tokens["__VIEWSTATE"] == "STATE123=="
+        assert tokens["__VIEWSTATEGENERATOR"] == "688223AE"
+        assert tokens["__EVENTVALIDATION"] == "EVAL456=="
+
+    def test_missing_tokens_yield_empty_strings(self) -> None:
+        tokens = extract_aspnet_tokens("<html>no tokens</html>")
+        assert tokens["__VIEWSTATE"] == ""
+        assert set(tokens) == {"__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION"}
+
+
+class TestParseReportTables:
+    def test_parses_all_sections_and_rows(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        sections = {r["section"] for r in rows}
+        assert any("Finanacial Statements" in s for s in sections)
+        assert any("Key Financial Ratio" in s for s in sections)
+        assert any("Discussion and Analysis" in s for s in sections)
+
+    def test_row_carries_headers_cells_and_href(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        fs_rows = [r for r in rows if "Finanacial Statements" in r["section"] and r.get("href")]
+        assert fs_rows, "expected at least one financial-statement data row with an href"
+        row = fs_rows[0]
+        assert "Name" in row["headers"] and "As Of" in row["headers"]
+        assert row["cells"][0] == "CP ALL PUBLIC COMPANY LIMITED"
+        assert "Download?FILEID=" in row["href"]
+
+    def test_header_row_not_emitted_as_data(self) -> None:
+        # The "Data not found" placeholder row has no href and a single colspan cell.
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        revised = [r for r in rows if "need to be revised" in r["section"]]
+        assert all(r.get("href") is None for r in revised)
+
+    def test_mda_row_has_date_time_heading_columns(self) -> None:
+        rows = parse_report_tables(FS_SEARCH_HTML)
+        mda = [r for r in rows if "Discussion and Analysis" in r["section"] and r.get("href")]
+        assert mda and mda[0]["headers"] == ["Date", "Time", "Heading", "Link"]
+        assert mda[0]["href"].endswith(".pdf")
+
+    def test_form_56_1_rows(self) -> None:
+        rows = parse_report_tables(FORM_56_1_HTML)
+        data = [r for r in rows if r.get("href")]
+        assert len(data) == 2
+        assert data[0]["headers"] == ["Name", "Year", "Receive Date", "Details"]
+
+
+class TestClassifyDownloadHref:
+    def test_idisc_zip(self) -> None:
+        url, fid, kind = classify_download_href(
+            "https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/x.zip"
+        )
+        assert fid == "dat/news/x.zip"
+        assert kind == "zip"
+
+    def test_idisc_pdf(self) -> None:
+        _, fid, kind = classify_download_href(
+            "https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/x.pdf"
+        )
+        assert kind == "pdf"
+
+    def test_ipos_href(self) -> None:
+        url, fid, kind = classify_download_href(
+            "https://market.sec.or.th/ipos/Common/IPOSGetFile.aspx?id=726416&sq=0&v=10"
+        )
+        assert fid == "ipos:726416"
+        assert kind is None
+
+    def test_amp_encoded_href_resolves(self) -> None:
+        url, fid, _ = classify_download_href(
+            "https://market.sec.or.th/ipos/Common/IPOSGetFile.aspx?id=1&amp;sq=0"
+        )
+        assert fid == "ipos:1"
+
+    def test_empty_href(self) -> None:
+        assert classify_download_href(None) == ("", None, None)
+
+
+class TestValueCoercers:
+    def test_parse_dmy_date(self) -> None:
+        assert parse_dmy_date("31/03/2026") == date(2026, 3, 31)
+        assert parse_dmy_date("") is None
+        assert parse_dmy_date("2026-03-31") is None  # ISO not accepted
+        assert parse_dmy_date(None) is None
+
+    def test_parse_int(self) -> None:
+        assert parse_int("2025") == 2025
+        assert parse_int("1,234") == 1234
+        assert parse_int("Year") is None
+        assert parse_int(None) is None
+
+
+class TestBuildSecHeaders:
+    def test_defaults_and_origin(self) -> None:
+        base = build_sec_headers()
+        assert "Referer" in base and "Origin" not in base
+        with_origin = build_sec_headers(origin=True)
+        assert with_origin["Origin"] == "https://market.sec.or.th"

--- a/tests/utils/test_data_fetcher.py
+++ b/tests/utils/test_data_fetcher.py
@@ -520,3 +520,62 @@ class TestAsyncDataFetcherPost:
         assert result is mock_resp
         assert mock_requests.get.called
         assert mock_requests.post.called is False
+
+    @pytest.mark.asyncio
+    async def test_standalone_post_form_data(self) -> None:
+        """Standalone POST with data= issues a form-encoded curl_cffi POST (not JSON)."""
+        fetcher = AsyncDataFetcher(config=FetcherConfig(use_session=False))
+        form = {"__VIEWSTATE": "abc", "ctl00$CPH$btSearch": "Search"}
+        mock_resp = Mock(status_code=200)
+
+        with patch("settfex.utils.data_fetcher.requests") as mock_requests:
+            mock_requests.post.return_value = mock_resp
+            result = await fetcher._make_request(
+                "https://market.sec.or.th/x", {"Referer": "https://market.sec.or.th/x"},
+                method="POST", data=form,
+            )
+
+        assert result is mock_resp
+        assert mock_requests.post.called
+        kwargs = mock_requests.post.call_args.kwargs
+        assert kwargs["data"] == form
+        assert "json" not in kwargs  # form path must not send a JSON body
+
+    @pytest.mark.asyncio
+    async def test_fetch_forwards_data(self) -> None:
+        """fetch(method='POST', data=...) forwards the form body to _make_request."""
+        fetcher = AsyncDataFetcher()
+        form = {"a": "1"}
+        mock_response = Mock(status_code=200, content=b"ok", headers={}, url="https://x/y")
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response) as mock:
+            await fetcher.fetch("https://x/y", method="POST", data=form)
+
+        assert mock.call_args.kwargs["data"] == form
+
+    @pytest.mark.asyncio
+    async def test_fetch_binary_skips_text_decode(self) -> None:
+        """decode_text=False returns raw bytes on .content and leaves .text empty."""
+        fetcher = AsyncDataFetcher()
+        raw = b"PK\x03\x04\x14\x00\x00\x08"  # zip magic + junk (invalid UTF-8)
+        mock_response = Mock(status_code=200, content=raw, headers={}, url="https://x/f.zip")
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response):
+            resp = await fetcher.fetch("https://x/f.zip", decode_text=False)
+
+        assert resp.content == raw
+        assert resp.text == ""
+        assert resp.encoding == "binary"
+
+    @pytest.mark.asyncio
+    async def test_fetch_binary_bytes_would_break_text_decode(self) -> None:
+        """The same non-UTF-8 bytes with default decode_text still succeed (latin1 fallback)."""
+        fetcher = AsyncDataFetcher()
+        raw = b"\xff\xfe\x00\x01"  # not valid UTF-8
+        mock_response = Mock(status_code=200, content=raw, headers={}, url="https://x/f.bin")
+
+        with patch.object(fetcher, "_make_request", return_value=mock_response):
+            resp = await fetcher.fetch("https://x/f.bin")  # decode_text defaults True
+
+        assert resp.content == raw
+        assert resp.encoding == "latin1"

--- a/tests/utils/test_data_fetcher.py
+++ b/tests/utils/test_data_fetcher.py
@@ -531,8 +531,10 @@ class TestAsyncDataFetcherPost:
         with patch("settfex.utils.data_fetcher.requests") as mock_requests:
             mock_requests.post.return_value = mock_resp
             result = await fetcher._make_request(
-                "https://market.sec.or.th/x", {"Referer": "https://market.sec.or.th/x"},
-                method="POST", data=form,
+                "https://market.sec.or.th/x",
+                {"Referer": "https://market.sec.or.th/x"},
+                method="POST",
+                data=form,
             )
 
         assert result is mock_resp

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

New **`settfex.services.sec`** package targeting **market.sec.or.th** (the Thai SEC information-disclosure / IDISC system) to **list and download the raw disclosure documents** companies file — the original `FINANCIAL_STATEMENTS.XLSX` package, **Form 56-1**, **Form 56-2**, Key Financial Ratio, and MD&A — for any SET/mai-listed issuer. This is source-document retrieval, complementing the SET services' *modeled* market data.

Ships as **v0.12.0**.

## What's included

**Three tiers + facade** (per the library's design pattern):
- `get_sec_documents()` / `download_sec_document(s)()` — flat convenience, LLM entry points
- `FinancialReportService.fetch_documents()` / `DocumentDownloadService` — typed `SecDocument` / `DownloadedFile` models
- `fetch_documents_raw()` — raw parsed rows; `SecCompany("CPALL")` facade; `resolve_company()` / `search_companies()`

**How it works (all reverse-engineered + live-verified):**
- **Company resolution** — JSON `POST /public/idisc/api/company/valuebyuniqueId` → 10-digit `uniqueIDReference`.
- **Listing** — replays the ASP.NET WebForms search (GET fresh `__VIEWSTATE` tokens → form POST → **stdlib `html.parser`** table parse, no new dependency) and follows the "display all results" **ViewMore** pages so large sections are complete. Category filtering, `en`/`th`, dd/mm/yyyy date windows (objects or strings; ISO → `InvalidDateError`).
- **Download** — plain GET → raw bytes as `DownloadedFile` (with `.save()`); concurrent `download_all()` (bounded, tolerant, optional `tqdm`). **Soft-404 detection**: a dead link returns an HTML "file not found" page under HTTP 200 → raised as `FetchError` instead of returning garbage.

**`AsyncDataFetcher`** gains two small backward-compatible options used here: form-encoded POST via `data=`, and `decode_text=False` for binary payloads.

## Five document categories
`financial_statement` · `form_56_1` · `form_56_2` · `key_financial_ratio` · `mda` (a single `FS` search returns statements + KFR + MD&A together).

## Testing & verification

- **506 tests pass** (447 existing + **59 new** mocked tests with HTML fixtures), **83%** coverage; ruff + mypy clean.
- **Live end-to-end** (CPALL): resolve → **170 documents** across all 5 categories → downloaded the zip containing `FINANCIAL_STATEMENTS.XLSX` → concurrent batch → soft-404 correctly raised.
- Example notebook executed top-to-bottom against the live API (0 errors; outputs stripped).

## Docs
`docs/settfex/services/sec/financial_report.md`, `examples/sec/01_financial_report.ipynb`, plus README / CLAUDE.md (inventory, tree, 4 gotchas) / CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)