### PR TITLE
feat(sec): harden document downloads — timeout, concurrency, dedupe, memory (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-20
+
+### Changed
+
+- **SEC downloads are now robust for large files by default.** Form 56‑1/56‑2 "One Reports" run
+  15–25 MB and were timing out under the 30 s default. The download path now:
+  - **Defaults to a 180 s per-file timeout** (`DEFAULT_DOWNLOAD_TIMEOUT`) instead of 30 s, with a
+    new `timeout=` parameter on `download_sec_document(s)` / `DocumentDownloadService` (an explicit
+    `timeout` wins; a caller-supplied `config` is otherwise honored; max 300 s).
+  - **Lowers the default `max_concurrency` from 5 → 3** for `download_all` /
+    `download_sec_documents` / `SecCompany.download_all` (large files share bandwidth, so fewer at
+    once finish more reliably).
+  - **Dedupes by URL:** a statement's *Company* and *Consolidated* rows point to the same zip, so
+    `download_all` now downloads each unique file once and returns one result per unique URL
+    (e.g. an 18‑year all‑category batch drops from 229 fetches to 153).
+- **`download_all` no longer holds every file's bytes in memory when saving to disk.** With
+  `dest_dir` set, each returned `DownloadedFile` has `content` emptied after the file is written
+  (bytes are on disk; `size` and the new `path` field remain), bounding memory on large batches.
+  New `keep_bytes` parameter overrides this (`True` = always keep, default keeps bytes only when
+  not saving). Single-file `download_sec_document` still returns the bytes.
+
+### Added
+
+- **`DownloadedFile.path`** — the on-disk `Path` a file was saved to (set by `.save()` and by
+  `download_all` when `dest_dir` is used).
+
 ## [0.13.0] - 2026-07-20
 
 ### Added

--- a/docs/settfex/services/sec/financial_report.md
+++ b/docs/settfex/services/sec/financial_report.md
@@ -120,15 +120,38 @@ docs.years_by_category()          # -> {'financial_statement': [2026, 2025, ...]
 docs.available_years("form_56_1")  # -> [2025, 2024, 2023, 2022, 2021, 2020]
 
 # 2) Download them all — pass the whole list, or a filtered subset
-await download_sec_documents(docs, dest_dir="./out", max_concurrency=5)              # everything
+await download_sec_documents(docs, dest_dir="./out")                                 # everything
 await download_sec_documents(docs.filter(category="form_56_1"), dest_dir="./out")    # just 56-1
 await download_sec_documents(docs.filter(category="financial_statement", year=2025),
                              dest_dir="./out")                                       # one year
 ```
 
 With the `SecCompany` facade, `await sec.download_all(docs, dest_dir="./out")` does the same.
-`download_all`/`download_sec_documents` run bounded-concurrent downloads and (by default) skip
-any dead links rather than failing the whole batch.
+`download_all`/`download_sec_documents` run bounded-concurrent downloads, **dedupe by URL**
+(a statement's Company & Consolidated rows share one zip — downloaded once), and (by default)
+skip dead links rather than failing the whole batch.
+
+### Tuning downloads (timeout & concurrency)
+
+Form 56‑1/56‑2 "One Reports" are large (**15–25 MB**). Downloads default to a **180 s** per-file
+timeout and **`max_concurrency=3`**; raise the timeout / lower the concurrency for big batches on
+a slow link:
+
+| Batch | `max_concurrency` | `timeout` |
+|---|---|---|
+| Form 56‑1 / 56‑2 (10–25 MB) | **1–2** | **180–300 s** |
+| Financial statements (~0.4–1 MB zips) | 3 (default) | 180 (default) |
+| Slow / shared connection, still timing out | **1** | **300** (max) |
+
+```python
+await download_sec_documents(docs.filter(category="form_56_1"),
+                             dest_dir="./out", max_concurrency=2, timeout=300)
+```
+
+**Memory:** when `dest_dir` is set, each returned `DownloadedFile` has its `content` emptied after
+the file is written (bytes live on disk; `size` and `path` remain) so a big batch doesn't sit in
+RAM. Pass `keep_bytes=True` to keep the bytes in memory too; omit `dest_dir` and the bytes are
+returned (the only way to get them).
 
 ## Models
 
@@ -159,8 +182,10 @@ the symbol's listed company).
 
 ### `DownloadedFile`
 
-`filename`, `content: bytes`, `content_type`, `size`, `file_url`, `document: SecDocument | None`,
-plus `.save(dest)` — writes to `dest/<filename>` if `dest` is a directory, else to `dest`.
+`filename`, `content: bytes` (empty if dropped after saving — see memory note above), `content_type`,
+`size` (always the real byte count), `file_url`, `path: Path | None` (set when saved),
+`document: SecDocument | None`, plus `.save(dest)` — writes to `dest/<filename>` if `dest` is a
+directory (else to `dest`) and records `.path`.
 
 ## Service classes
 
@@ -168,20 +193,22 @@ plus `.save(dest)` — writes to `dest/<filename>` if `dest` is a directory, els
 
 ```python
 fetch_documents(unique_id, *, company_name=None, types=None, from_date=None, to_date=None,
-                lang="en", follow_view_more=True) -> list[SecDocument]
+                lang="en", follow_view_more=True) -> SecDocumentList
 fetch_documents_raw(unique_id, *, code, from_date=None, to_date=None, lang="en") -> list[dict]
 ```
 
-### `DocumentDownloadService`
+### `DocumentDownloadService(config=None, *, timeout=None)`
 
 ```python
-download(target, *, referer=...) -> DownloadedFile          # target: SecDocument | URL | FILEID
-download_all(targets, *, dest_dir=None, max_concurrency=5,
-             continue_on_error=True, progress=False) -> list[DownloadedFile]
+download(target, *, fetcher=None, referer=...) -> DownloadedFile   # target: SecDocument|URL|FILEID
+download_all(targets, *, dest_dir=None, max_concurrency=3, continue_on_error=True,
+             keep_bytes=None, progress=False) -> list[DownloadedFile]
 ```
 
-`download_all` runs bounded-concurrent downloads; with `continue_on_error=True` (default) a
-failed item (e.g. a soft-404 dead link) is logged and skipped rather than failing the batch.
+`download_all` dedupes by URL, runs bounded-concurrent downloads (default `timeout=180 s` per
+file, set on the service), and with `continue_on_error=True` (default) logs and skips a failed
+item (e.g. a soft-404 dead link) rather than failing the batch. `keep_bytes` controls whether
+returned objects retain `content` (default: drop when saving to `dest_dir`).
 
 ## Convenience functions
 
@@ -189,9 +216,9 @@ failed item (e.g. a soft-404 dead link) is logged and skipped rather than failin
 resolve_company(query, lang="en") -> CompanyMatch | None
 get_sec_documents(query, *, types=None, from_date=None, to_date=None,
                   lang="en", follow_view_more=True) -> SecDocumentList
-download_sec_document(target, *, dest_dir=None) -> DownloadedFile
-download_sec_documents(targets, *, dest_dir=None, max_concurrency=5,
-                       continue_on_error=True, progress=False) -> list[DownloadedFile]
+download_sec_document(target, *, dest_dir=None, timeout=None) -> DownloadedFile
+download_sec_documents(targets, *, dest_dir=None, max_concurrency=3, continue_on_error=True,
+                       keep_bytes=None, timeout=None, progress=False) -> list[DownloadedFile]
 ```
 
 ## Unified facade — `SecCompany`

--- a/examples/sec/01_financial_report.ipynb
+++ b/examples/sec/01_financial_report.ipynb
@@ -38,10 +38,10 @@
    "id": "c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:04.826374Z",
-     "iopub.status.busy": "2026-07-20T13:25:04.825871Z",
-     "iopub.status.idle": "2026-07-20T13:25:05.329435Z",
-     "shell.execute_reply": "2026-07-20T13:25:05.328006Z"
+     "iopub.execute_input": "2026-07-20T15:06:23.636340Z",
+     "iopub.status.busy": "2026-07-20T15:06:23.635497Z",
+     "iopub.status.idle": "2026-07-20T15:06:24.176706Z",
+     "shell.execute_reply": "2026-07-20T15:06:24.175333Z"
     }
    },
    "outputs": [],
@@ -49,7 +49,6 @@
     "import io\n",
     "import tempfile\n",
     "import zipfile\n",
-    "from pathlib import Path\n",
     "\n",
     "from settfex.services.sec import (\n",
     "    DocumentCategory,\n",
@@ -80,10 +79,10 @@
    "id": "c05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:05.336116Z",
-     "iopub.status.busy": "2026-07-20T13:25:05.335711Z",
-     "iopub.status.idle": "2026-07-20T13:25:05.624699Z",
-     "shell.execute_reply": "2026-07-20T13:25:05.622423Z"
+     "iopub.execute_input": "2026-07-20T15:06:24.185235Z",
+     "iopub.status.busy": "2026-07-20T15:06:24.184594Z",
+     "iopub.status.idle": "2026-07-20T15:06:24.486172Z",
+     "shell.execute_reply": "2026-07-20T15:06:24.483609Z"
     }
    },
    "outputs": [],
@@ -109,10 +108,10 @@
    "id": "c07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:05.631165Z",
-     "iopub.status.busy": "2026-07-20T13:25:05.630495Z",
-     "iopub.status.idle": "2026-07-20T13:25:10.835619Z",
-     "shell.execute_reply": "2026-07-20T13:25:10.833581Z"
+     "iopub.execute_input": "2026-07-20T15:06:24.493301Z",
+     "iopub.status.busy": "2026-07-20T15:06:24.492654Z",
+     "iopub.status.idle": "2026-07-20T15:06:29.477535Z",
+     "shell.execute_reply": "2026-07-20T15:06:29.475936Z"
     }
    },
    "outputs": [],
@@ -138,10 +137,10 @@
    "id": "c09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:10.842418Z",
-     "iopub.status.busy": "2026-07-20T13:25:10.841851Z",
-     "iopub.status.idle": "2026-07-20T13:25:10.852668Z",
-     "shell.execute_reply": "2026-07-20T13:25:10.850823Z"
+     "iopub.execute_input": "2026-07-20T15:06:29.485200Z",
+     "iopub.status.busy": "2026-07-20T15:06:29.484336Z",
+     "iopub.status.idle": "2026-07-20T15:06:29.498967Z",
+     "shell.execute_reply": "2026-07-20T15:06:29.496467Z"
     }
    },
    "outputs": [],
@@ -169,10 +168,10 @@
    "id": "c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:10.858715Z",
-     "iopub.status.busy": "2026-07-20T13:25:10.858180Z",
-     "iopub.status.idle": "2026-07-20T13:25:10.868231Z",
-     "shell.execute_reply": "2026-07-20T13:25:10.866340Z"
+     "iopub.execute_input": "2026-07-20T15:06:29.505424Z",
+     "iopub.status.busy": "2026-07-20T15:06:29.504724Z",
+     "iopub.status.idle": "2026-07-20T15:06:29.514870Z",
+     "shell.execute_reply": "2026-07-20T15:06:29.512933Z"
     }
    },
    "outputs": [],
@@ -198,10 +197,10 @@
    "id": "c13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:10.874651Z",
-     "iopub.status.busy": "2026-07-20T13:25:10.874054Z",
-     "iopub.status.idle": "2026-07-20T13:25:10.884457Z",
-     "shell.execute_reply": "2026-07-20T13:25:10.882318Z"
+     "iopub.execute_input": "2026-07-20T15:06:29.521784Z",
+     "iopub.status.busy": "2026-07-20T15:06:29.520953Z",
+     "iopub.status.idle": "2026-07-20T15:06:29.533358Z",
+     "shell.execute_reply": "2026-07-20T15:06:29.531157Z"
     }
    },
    "outputs": [],
@@ -230,10 +229,10 @@
    "id": "c15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:10.891683Z",
-     "iopub.status.busy": "2026-07-20T13:25:10.890710Z",
-     "iopub.status.idle": "2026-07-20T13:25:11.342687Z",
-     "shell.execute_reply": "2026-07-20T13:25:11.340838Z"
+     "iopub.execute_input": "2026-07-20T15:06:29.540951Z",
+     "iopub.status.busy": "2026-07-20T15:06:29.540142Z",
+     "iopub.status.idle": "2026-07-20T15:06:29.958831Z",
+     "shell.execute_reply": "2026-07-20T15:06:29.956904Z"
     }
    },
    "outputs": [],
@@ -252,7 +251,13 @@
     "## 8. Download them all — or a filtered subset\n",
     "\n",
     "Pass the whole `SecDocumentList` to download everything, or a `filter(...)` subset. Downloads run\n",
-    "concurrently (bounded), and dead links are skipped by default (`continue_on_error=True`)."
+    "concurrently (bounded), **dedupe by URL** (a statement's Company & Consolidated rows share one zip),\n",
+    "and skip dead links by default (`continue_on_error=True`).\n",
+    "\n",
+    "**Tuning:** Form 56‑1/56‑2 are large (15–25 MB). Downloads default to `timeout=180`s and\n",
+    "`max_concurrency=3`; for big batches on a slow link use `max_concurrency=1–2` and `timeout` up to\n",
+    "300. When `dest_dir` is set, each result's bytes are dropped after saving (see `.path`); pass\n",
+    "`keep_bytes=True` to keep them in memory too."
    ]
   },
   {
@@ -261,18 +266,25 @@
    "id": "c17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:11.349068Z",
-     "iopub.status.busy": "2026-07-20T13:25:11.348418Z",
-     "iopub.status.idle": "2026-07-20T13:25:16.112513Z",
-     "shell.execute_reply": "2026-07-20T13:25:16.109658Z"
+     "iopub.execute_input": "2026-07-20T15:06:29.966853Z",
+     "iopub.status.busy": "2026-07-20T15:06:29.966300Z",
+     "iopub.status.idle": "2026-07-20T15:06:37.863368Z",
+     "shell.execute_reply": "2026-07-20T15:06:37.859425Z"
     }
    },
    "outputs": [],
    "source": [
     "subset = docs.filter(category=\"form_56_1\")  # or: docs (everything), docs.filter(year=2025), ...\n",
     "with tempfile.TemporaryDirectory() as tmp:\n",
-    "    got = await download_sec_documents(subset, dest_dir=tmp, max_concurrency=5)\n",
-    "    print(f\"downloaded {len(got)} file(s); on disk: {[p.name for p in Path(tmp).glob('*')]}\")"
+    "    got = await download_sec_documents(\n",
+    "        subset,\n",
+    "        dest_dir=tmp,\n",
+    "        max_concurrency=2,\n",
+    "        timeout=300,  # big files: fewer at once, longer timeout\n",
+    "    )\n",
+    "    for f in got:\n",
+    "        print(f\"{f.filename:40} {f.size / 1e6:5.1f} MB  saved -> {f.path.name}\")\n",
+    "    print(f\"downloaded {len(got)} file(s)\")"
    ]
   },
   {
@@ -292,10 +304,10 @@
    "id": "c19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:16.121533Z",
-     "iopub.status.busy": "2026-07-20T13:25:16.120631Z",
-     "iopub.status.idle": "2026-07-20T13:25:18.318757Z",
-     "shell.execute_reply": "2026-07-20T13:25:18.316972Z"
+     "iopub.execute_input": "2026-07-20T15:06:37.874204Z",
+     "iopub.status.busy": "2026-07-20T15:06:37.872804Z",
+     "iopub.status.idle": "2026-07-20T15:06:39.917446Z",
+     "shell.execute_reply": "2026-07-20T15:06:39.915511Z"
     }
    },
    "outputs": [],
@@ -329,10 +341,10 @@
    "id": "c21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T13:25:18.324988Z",
-     "iopub.status.busy": "2026-07-20T13:25:18.324170Z",
-     "iopub.status.idle": "2026-07-20T13:25:20.727502Z",
-     "shell.execute_reply": "2026-07-20T13:25:20.725339Z"
+     "iopub.execute_input": "2026-07-20T15:06:39.923940Z",
+     "iopub.status.busy": "2026-07-20T15:06:39.923354Z",
+     "iopub.status.idle": "2026-07-20T15:06:42.139717Z",
+     "shell.execute_reply": "2026-07-20T15:06:42.137310Z"
     }
    },
    "outputs": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.13.0"
+version = "0.14.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/settfex/services/sec/download.py
+++ b/settfex/services/sec/download.py
@@ -30,13 +30,19 @@ from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
 
 
 class DownloadedFile(BaseModel):
-    """A downloaded SEC document: filename + raw bytes, with optional source metadata."""
+    """A downloaded SEC document: filename + raw bytes, with optional source metadata.
+
+    ``size`` is always the real byte count. When a bulk download saves to disk without keeping
+    bytes (see ``download_all(keep_bytes=...)``), ``content`` is emptied to save memory and
+    ``path`` records where the file was written.
+    """
 
     filename: str = Field(description="Filename (from Content-Disposition, or a sensible fallback)")
-    content: bytes = Field(description="Raw file bytes (e.g. a zip of the original XLSX/PDF)")
+    content: bytes = Field(description="Raw file bytes (empty if dropped after saving to disk)")
     content_type: str = Field(default="", description="Response Content-Type header")
-    size: int = Field(description="Number of bytes")
+    size: int = Field(description="Number of bytes downloaded (real size, even if content dropped)")
     file_url: str = Field(description="URL the bytes were fetched from")
+    path: Path | None = Field(default=None, description="On-disk path, if the file was saved")
     document: SecDocument | None = Field(
         default=None, description="The source SecDocument, when downloaded from a listing"
     )
@@ -47,13 +53,14 @@ class DownloadedFile(BaseModel):
         """
         Write the bytes to disk. If ``dest`` is a directory (existing or trailing-slash), the
         file is written as ``dest/<filename>``; otherwise ``dest`` is treated as the full path.
-        Parent directories are created. Returns the path written.
+        Parent directories are created. Records and returns the path written.
         """
         path = Path(dest)
         if path.is_dir() or str(dest).endswith(("/", "\\")):
             path = path / self.filename
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(self.content)
+        self.path = path
         logger.info(f"Saved {self.size} bytes -> {path}")
         return path
 
@@ -80,13 +87,37 @@ def _fallback_filename(file_url: str, document: SecDocument | None) -> str:
     return base or "sec_download"
 
 
+# SEC documents are large binaries (56-1/56-2 One Reports run 15-25 MB), so downloads default
+# to a much longer per-file timeout than the 30 s used for JSON/listing calls.
+DEFAULT_DOWNLOAD_TIMEOUT = 180
+
+
+def _effective_download_config(config: FetcherConfig | None, timeout: int | None) -> FetcherConfig:
+    """
+    Resolve the fetcher config for a download (stateless host).
+
+    Precedence: an explicit ``timeout`` wins; otherwise a caller-supplied ``config`` is honored
+    as-is; otherwise the document default (:data:`DEFAULT_DOWNLOAD_TIMEOUT`) applies instead of
+    the 30 s ``FetcherConfig`` default. ``use_session`` is always forced off.
+    """
+    if config is None:
+        base = FetcherConfig(timeout=timeout if timeout is not None else DEFAULT_DOWNLOAD_TIMEOUT)
+    elif timeout is not None:
+        base = config.model_copy(update={"timeout": timeout})
+    else:
+        base = config
+    return base.model_copy(update={"use_session": False})
+
+
 class DocumentDownloadService:
     """Download SEC documents to bytes (and optionally disk). Stateless host — no SessionManager."""
 
-    def __init__(self, config: FetcherConfig | None = None) -> None:
-        base = config or FetcherConfig()
-        self.config = base.model_copy(update={"use_session": False})
-        logger.info("DocumentDownloadService initialized (host=market.sec.or.th)")
+    def __init__(self, config: FetcherConfig | None = None, *, timeout: int | None = None) -> None:
+        self.config = _effective_download_config(config, timeout)
+        logger.info(
+            f"DocumentDownloadService initialized (host=market.sec.or.th, "
+            f"timeout={self.config.timeout}s)"
+        )
 
     @staticmethod
     def _resolve_url(target: SecDocument | str) -> tuple[str, SecDocument | None]:
@@ -162,27 +193,50 @@ class DocumentDownloadService:
         targets: list[SecDocument | str],
         *,
         dest_dir: str | Path | None = None,
-        max_concurrency: int = 5,
+        max_concurrency: int = 3,
         continue_on_error: bool = True,
+        keep_bytes: bool | None = None,
         progress: bool = False,
     ) -> list[DownloadedFile]:
         """
         Download many documents concurrently (bounded), optionally saving each to ``dest_dir``.
 
+        Duplicate targets that resolve to the **same URL** are downloaded once (a statement's
+        Company and Consolidated rows share one zip), so the result has one entry per unique file.
+
         Args:
-            targets: SecDocuments / URLs / FILEIDs to download.
-            dest_dir: If set, each file is also written here (created if needed).
-            max_concurrency: Max simultaneous downloads (default 5).
+            targets: SecDocuments / URLs / FILEIDs to download (deduped by resolved URL).
+            dest_dir: If set, each file is written here (created if needed).
+            max_concurrency: Max simultaneous downloads (default 3 — big files share bandwidth).
             continue_on_error: If True (default) a failed item is logged and skipped; if False
                 the first failure propagates.
+            keep_bytes: Whether to keep each file's bytes on the returned ``DownloadedFile``.
+                Default (``None``) keeps bytes only when NOT saving to disk; when ``dest_dir`` is
+                set the bytes are dropped after saving (``content=b""``, ``path`` set) to bound
+                memory. Pass ``True`` to always keep bytes, ``False`` to always drop them.
             progress: Show a tqdm progress bar if the optional ``progress`` extra is installed.
 
         Returns:
-            The successfully downloaded files (order not guaranteed under concurrency).
+            The successfully downloaded files (one per unique URL; order not guaranteed).
         """
+        # Dedupe by resolved URL, preserving first-seen order.
+        unique: list[SecDocument | str] = []
+        seen: set[str] = set()
+        for target in targets:
+            url, _ = self._resolve_url(target)
+            if url and url not in seen:
+                seen.add(url)
+                unique.append(target)
+        if len(unique) != len(targets):
+            logger.info(
+                f"download_all: {len(targets)} targets -> {len(unique)} unique files "
+                f"({len(targets) - len(unique)} duplicate(s) skipped)"
+            )
+
+        keep = keep_bytes if keep_bytes is not None else (dest_dir is None)
         semaphore = asyncio.Semaphore(max(1, max_concurrency))
         results: list[DownloadedFile] = []
-        bar = _make_progress_bar(len(targets)) if progress else None
+        bar = _make_progress_bar(len(unique)) if progress else None
 
         async with AsyncDataFetcher(config=self.config) as fetcher:
 
@@ -198,9 +252,11 @@ class DocumentDownloadService:
                         return None
                     if dest_dir is not None:
                         dl.save(dest_dir)
+                    if not keep:
+                        dl.content = b""  # bytes are on disk (or unwanted); free the memory
                     return dl
 
-            tasks = [asyncio.create_task(one(t)) for t in targets]
+            tasks = [asyncio.create_task(one(t)) for t in unique]
             for coro in asyncio.as_completed(tasks):
                 dl = await coro
                 if bar is not None:
@@ -210,7 +266,7 @@ class DocumentDownloadService:
 
         if bar is not None:
             bar.close()
-        logger.info(f"Downloaded {len(results)}/{len(targets)} document(s)")
+        logger.info(f"Downloaded {len(results)}/{len(unique)} document(s)")
         return results
 
 
@@ -228,6 +284,7 @@ async def download_sec_document(
     target: SecDocument | str,
     *,
     dest_dir: str | Path | None = None,
+    timeout: int | None = None,
     config: FetcherConfig | None = None,
 ) -> DownloadedFile:
     """
@@ -235,10 +292,12 @@ async def download_sec_document(
 
     Args:
         target: A :class:`SecDocument`, an absolute URL, or a bare FILEID path.
-        dest_dir: If set, also write the file here.
+        dest_dir: If set, also write the file here (``.path`` is recorded).
+        timeout: Per-file timeout in seconds (default 180 — documents are large). Bump for very
+            large files on a slow link (max 300).
         config: Optional fetcher configuration.
     """
-    service = DocumentDownloadService(config=config)
+    service = DocumentDownloadService(config=config, timeout=timeout)
     dl = await service.download(target)
     if dest_dir is not None:
         dl.save(dest_dir)
@@ -249,21 +308,25 @@ async def download_sec_documents(
     targets: list[SecDocument | str],
     *,
     dest_dir: str | Path | None = None,
-    max_concurrency: int = 5,
+    max_concurrency: int = 3,
     continue_on_error: bool = True,
+    keep_bytes: bool | None = None,
+    timeout: int | None = None,
     progress: bool = False,
     config: FetcherConfig | None = None,
 ) -> list[DownloadedFile]:
     """
     Convenience: download many SEC documents concurrently (optionally saving to ``dest_dir``).
 
-    See :meth:`DocumentDownloadService.download_all` for argument semantics.
+    Duplicate targets sharing a URL are downloaded once. ``timeout`` sets the per-file timeout
+    (default 180s). See :meth:`DocumentDownloadService.download_all` for the rest.
     """
-    service = DocumentDownloadService(config=config)
+    service = DocumentDownloadService(config=config, timeout=timeout)
     return await service.download_all(
         targets,
         dest_dir=dest_dir,
         max_concurrency=max_concurrency,
         continue_on_error=continue_on_error,
+        keep_bytes=keep_bytes,
         progress=progress,
     )

--- a/settfex/services/sec/sec.py
+++ b/settfex/services/sec/sec.py
@@ -115,15 +115,17 @@ class SecCompany:
         targets: list[SecDocument | str],
         *,
         dest_dir: str | Path | None = None,
-        max_concurrency: int = 5,
+        max_concurrency: int = 3,
         continue_on_error: bool = True,
+        keep_bytes: bool | None = None,
         progress: bool = False,
     ) -> list[DownloadedFile]:
-        """Download many documents concurrently (optionally saving to ``dest_dir``)."""
+        """Download many documents concurrently (deduped by URL; optionally saved to disk)."""
         return await self.download_service.download_all(
             targets,
             dest_dir=dest_dir,
             max_concurrency=max_concurrency,
             continue_on_error=continue_on_error,
+            keep_bytes=keep_bytes,
             progress=progress,
         )

--- a/tests/services/sec/test_download.py
+++ b/tests/services/sec/test_download.py
@@ -7,12 +7,13 @@ import pytest
 
 from settfex.exceptions import FetchError
 from settfex.services.sec.download import (
+    DEFAULT_DOWNLOAD_TIMEOUT,
     DocumentDownloadService,
     DownloadedFile,
     _filename_from_disposition,
 )
 from settfex.services.sec.financial_report import DocumentCategory, SecDocument
-from settfex.utils.data_fetcher import FetchResponse
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
 from tests.services.sec.fixtures import FILE_NOT_FOUND_HTML
 
 ZIP_BYTES = b"PK\x03\x04\x14\x00\x00\x08" + b"\x00" * 32
@@ -197,3 +198,117 @@ class TestDownloadAll:
                 await svc.download_all([bad], continue_on_error=False)
         finally:
             patch.stopall()
+
+
+class TestTimeoutConfig:
+    def test_default_download_timeout_is_180(self) -> None:
+        svc = DocumentDownloadService()
+        assert svc.config.timeout == DEFAULT_DOWNLOAD_TIMEOUT == 180
+        assert svc.config.use_session is False
+
+    def test_timeout_param_overrides(self) -> None:
+        assert DocumentDownloadService(timeout=250).config.timeout == 250
+
+    def test_passed_config_timeout_is_honored(self) -> None:
+        svc = DocumentDownloadService(config=FetcherConfig(timeout=45))
+        assert svc.config.timeout == 45  # explicit config respected (no 180 default)
+
+    def test_timeout_param_wins_over_config(self) -> None:
+        svc = DocumentDownloadService(config=FetcherConfig(timeout=45), timeout=300)
+        assert svc.config.timeout == 300
+
+
+class TestDedupeAndMemory:
+    @pytest.mark.asyncio
+    async def test_download_all_dedupes_by_url(self) -> None:
+        # Company + Consolidated rows share one zip -> same file_url.
+        url = "https://market.sec.or.th/public/idisc/Download?FILEID=dat/news/shared.zip"
+        company = _doc(url, "dat/news/shared.zip")
+        consolidated = _doc(url, "dat/news/shared.zip")
+
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
+            return _dl_resp(ZIP_BYTES, "application/zip", "shared.zip")
+
+        _, instance = _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            got = await svc.download_all([company, consolidated])
+        finally:
+            patch.stopall()
+        assert len(got) == 1  # one result per unique URL
+        assert instance.fetch.await_count == 1  # downloaded once, not twice
+
+    @pytest.mark.asyncio
+    async def test_keep_bytes_default_drops_content_when_saving(self, tmp_path: Path) -> None:
+        doc = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=a.zip", "a.zip")
+
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
+            return _dl_resp(ZIP_BYTES, "application/zip", "a.zip")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            got = await svc.download_all([doc], dest_dir=tmp_path)
+        finally:
+            patch.stopall()
+        dl = got[0]
+        assert dl.content == b""  # bytes dropped to save memory
+        assert dl.size == len(ZIP_BYTES)  # real size still reported
+        assert dl.path == tmp_path / "a.zip" and dl.path.exists()  # on disk + path recorded
+
+    @pytest.mark.asyncio
+    async def test_keep_bytes_true_retains_content(self, tmp_path: Path) -> None:
+        doc = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=a.zip", "a.zip")
+
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
+            return _dl_resp(ZIP_BYTES, "application/zip", "a.zip")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            got = await svc.download_all([doc], dest_dir=tmp_path, keep_bytes=True)
+        finally:
+            patch.stopall()
+        assert got[0].content == ZIP_BYTES  # retained despite saving
+
+    @pytest.mark.asyncio
+    async def test_no_dest_dir_keeps_bytes_by_default(self) -> None:
+        doc = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=a.zip", "a.zip")
+
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
+            return _dl_resp(ZIP_BYTES, "application/zip", "a.zip")
+
+        _patch_download(router)
+        try:
+            svc = DocumentDownloadService()
+            got = await svc.download_all([doc])  # no dest_dir -> must keep bytes
+        finally:
+            patch.stopall()
+        assert got[0].content == ZIP_BYTES and got[0].path is None
+
+    @pytest.mark.asyncio
+    async def test_single_download_records_path_and_keeps_bytes(self, tmp_path: Path) -> None:
+        from settfex.services.sec.download import download_sec_document
+
+        doc = _doc("https://market.sec.or.th/public/idisc/Download?FILEID=a.zip", "a.zip")
+
+        async def router(
+            url, headers=None, *, method="GET", json_body=None, data=None, decode_text=True
+        ):
+            return _dl_resp(ZIP_BYTES, "application/zip", "a.zip")
+
+        _patch_download(router)
+        try:
+            dl = await download_sec_document(doc, dest_dir=tmp_path)
+        finally:
+            patch.stopall()
+        assert dl.content == ZIP_BYTES  # single download keeps bytes
+        assert dl.path == tmp_path / "a.zip" and dl.path.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Fixes the large-file **"download all" timeout** a user hit on Form 56‑1/56‑2 One Reports
(`curl: (28) Operation timed out after 30000 ms`), and two scalability issues a live **18‑year /
229‑document** stress test surfaced. Ships as **v0.14.0**.

Root cause was **not** a bug: `FetcherConfig.timeout` defaults to **30 s** (a *total* per-request
timeout), too short for **15–25 MB** documents, made worse by `max_concurrency=5` splitting
bandwidth.

## Changes

| # | Change |
|---|---|
| 1 | **Default per-file timeout 30 s → 180 s** (`DEFAULT_DOWNLOAD_TIMEOUT`); new `timeout=` param on `download_sec_document(s)` / `DocumentDownloadService` (explicit `timeout` wins, else a passed `config` is honored; max 300 s). |
| 2 | **Default `max_concurrency` 5 → 3** for `download_all` / `download_sec_documents` / `SecCompany.download_all`. |
| 3 | **`download_all` dedupes by URL** — a statement's *Company* & *Consolidated* rows share one zip, so each unique file is fetched once (18 y/all categories: **229 → 153**). |
| 4 | **No longer holds all bytes in RAM when saving.** With `dest_dir` set, each returned `DownloadedFile` has `content` emptied after writing (bytes on disk; `size` + new **`path`** field remain). `keep_bytes=True` to keep; single `download_sec_document` still returns bytes. |
| 5 | Doc **tuning table** (timeout/concurrency), notebook bulk-download cell updated, CHANGELOG + version bump. |

## Immediate workaround (already available on 0.13.0)

```python
from settfex import FetcherConfig
await download_sec_documents(subset, dest_dir="./out", max_concurrency=2,
                             config=FetcherConfig(timeout=300))
```
0.14.0 makes robust behavior the default (no `FetcherConfig` needed).

## Verification (live, 18 years, CPALL, all categories)

| Metric | Before | After |
|---|---|---|
| Files downloaded (229 docs) | 229 (76 redundant) | **150** (deduped, −3 dead links) |
| Bytes held in RAM | ~286 MB | **0 MB** (`.path` set on all) |
| Peak RSS | ~316 MB | **94 MB** |
| Timeouts at defaults | would time out | **none** |

- **525 tests** pass (+9 new: dedupe, `keep_bytes` default/override, `path`, timeout threading);
  `ruff check` + `ruff format --check` + `mypy` clean.
- Example notebook re-executed top-to-bottom (0 errors; outputs stripped).

## Compatibility

Backward-compatible in the common case (returned type is still `list[DownloadedFile]`, still a
list). Two intentional, documented behavior changes: default concurrency (5→3) and — when
`dest_dir` is set — `content` is dropped in favor of `path` (opt back in with `keep_bytes=True`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)