### PR TITLE
feat(set): SET market holiday calendar service (0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-27
+
+### Added
+
+- **SET Market Holiday service** (`settfex.services.set.holiday`) — the official SET market-closure
+  calendar for a year, in English or Thai, via `GET /api/cms/v1/holidays/year/{year}`. Follows the
+  standard three tiers: `get_holidays()` → `HolidayService.fetch_holidays()` →
+  `HolidayService.fetch_holidays_raw()`.
+  - **`Holiday`** — `holiday_date` (timezone-aware, always `+07:00`, `00:00:00` time component;
+    aliased from the API's `date` key) and `description`. Descriptions are preserved **verbatim**:
+    unlike every other SET model, `str_strip_whitespace` is deliberately **off**, because a
+    trailing `" *"` is a SET footnote marker for additional special closures.
+  - **`HolidayCalendar`** — container exposing `count`, `dates`, `is_holiday()`, `get_holiday()`,
+    `filter_by_month()` and `next_holiday()`. Query methods accept `date` or `datetime` (naive
+    datetimes are treated as Bangkok-local, aware ones converted) and do not depend on payload
+    ordering.
+  - `year` defaults to the current year in **Asia/Bangkok**, never system-local time. Client-side
+    validation (`MIN_YEAR` 1975 … `MAX_YEAR` 2100) is a typo guard only.
+  - New constant `SET_HOLIDAY_ENDPOINT`; `get_holidays` and `HolidayCalendar` are re-exported from
+    the top-level `settfex` package.
+  - Docs: `docs/settfex/services/set/holiday.md`; example: `examples/set/17_holiday.ipynb`.
+
+### Fixed
+
+- **The holiday service retries transient HTTP 401s** instead of failing the call. This endpoint
+  uses a bare `401` with an empty body as its *only* failure code — for an unrecognized `lang`, a
+  missing `lang`, an unserved year, **and** transiently on perfectly valid requests — while
+  `AsyncDataFetcher.fetch()` retries exceptions only and never a non-2xx status. `HolidayService`
+  therefore retries `401`/`403`/`429` with exponential backoff driven by the existing
+  `FetcherConfig.max_retries` / `retry_delay` knobs (no new API surface). On exhaustion the
+  `FetchError` message names both possible causes, since the API gives no way to tell them apart.
+
+### Documentation
+
+- Recorded three live-probed limits of the holiday endpoint (2026-07-27), in the module docstring,
+  the docs page and `CLAUDE.md` Known Gotchas:
+  - **Only the current year is served.** With 2026 returning 200 on every interleaved control
+    request, 2024, 2025, 2027 and 2028 all returned HTTP 401 — so this endpoint cannot supply
+    history for backtests or next year's calendar for year-boundary arithmetic.
+  - **Success rate degrades under polling** (~100% cold → ~35% after ~50 requests → ~12% after
+    ~150) and recovers on its own when left idle. Cache the result; holiday data is static.
+  - **`is_holiday()` answers "published holiday", not "market closed"** — weekends are absent from
+    the payload, and only whole-day closures are expressed (no partial sessions or altered hours).
+
 ## [0.14.0] - 2026-07-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ settfex/
 ├── settfex/                    # Main package
 │   ├── services/              # Business logic and API integrations
 │   │   ├── set/              # SET-specific services
-│   │   │   ├── constants.py, list.py, earnings_call.py, news.py
+│   │   │   ├── constants.py, list.py, earnings_call.py, news.py, holiday.py
 │   │   │   ├── index/        # Market index services: list, info (quotation),
 │   │   │   │                 #   composition (constituents), chart_quotation,
 │   │   │   │                 #   index.py (SetIndex facade), utils.py
@@ -33,7 +33,7 @@ settfex/
 │                             #   session_cache.py, logging.py
 ├── tests/                     # Mirror of settfex/ with test_ prefix
 ├── docs/                      # Service docs, guides, solutions
-├── examples/                  # 20 Jupyter notebooks (16 SET + 3 TFEX + 1 SEC)
+├── examples/                  # 21 Jupyter notebooks (17 SET + 3 TFEX + 1 SEC)
 ├── scripts/                   # Verification scripts per service
 ├── .github/                   # CI and agent instructions
 ├── pyproject.toml             # uv-based config
@@ -118,9 +118,9 @@ data = await get_highlight_data("CPALL")   # or convenience function
 all_stocks = await get_stock_list()        # no cookie params needed
 ```
 
-## Services Inventory (20 total)
+## Services Inventory (21 total)
 
-### SET Services (16)
+### SET Services (17)
 
 | # | Service | Module | Endpoint Pattern | Key Data |
 |---|---|---|---|---|
@@ -140,6 +140,7 @@ all_stocks = await get_stock_list()        # no cookie params needed
 | 14 | Latest Historical Trading | `stock/latest_historical_trading.py` | `/api/set/stock/{sym}/latest-historical-trading` | Latest trading-day summary: OHLCV, change/%change, and valuation metrics |
 | 15 | Market Index | `index/{list,info,composition,chart_quotation,index}.py` | `/api/set/index/list`, `/api/set/index/info/list`, `/api/set/index/{sym}/info`, `/api/set/index/{sym}/composition`, `/api/set/index/{sym}/chart-quotation` | 55-index directory (INDEX/INDUSTRY/SECTOR levels; mai industries use `-m` query symbols); page-header quotes (last/chg/%chg/OHLC/vol/value/marketStatus/tz-aware timestamp); constituents w/ full quote rows incl. bid/offer (string prices coerced); `SetIndex` facade + `get_index_latest_price()` (reuses stock ChartQuotation); index symbols keep casing (`sSET`, `AGRO-m`); `SET`/`mai` have no composition (404 w/ helpful error). |
 | 16 | News | `news.py` | `/api/set/news/search` | Company news/disclosures for **all stocks** in one call (default `sourceId=company`, latest-trading-day window); filters: `symbol`, `fromDate`/`toDate` (**dd/MM/yyyy only** — ISO → HTTP 400; validated eagerly via `InvalidDateError`), `keyword`, `source_id` (`None` = all sources; unrecognized values silently ignored by the API), en/th; helpers `count`/`filter_today()`/`filter_by_tag()`/`filter_by_symbol()`; `Stock.get_news()` accessor; no pagination — keep date windows modest |
+| 17 | Market Holidays | `holiday.py` | `/api/cms/v1/holidays/year/{year}` | Official SET market-closure calendar for a year (en/th): tz-aware `+07:00` dates + verbatim descriptions (trailing `" *"` = SET footnote, never stripped). `HolidayCalendar` container with `count`/`dates`/`is_holiday()`/`get_holiday()`/`filter_by_month()`/`next_holiday()`; `year=None` → current **Asia/Bangkok** year. **Only the current year is served** (2024/2025/2027/2028 → HTTP 401); 401 is the endpoint's *only* failure code and also fires transiently, so the service retries 401/403/429 via `FetcherConfig.max_retries`/`retry_delay`. Holidays only — **weekends are not in the payload** |
 
 ### TFEX Services (3)
 
@@ -263,6 +264,11 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full, versioned release history — t
 - **SEC service is a different host + HTML, not JSON:** `services/sec/` targets `market.sec.or.th` (Thai SEC IDISC), an ASP.NET WebForms app — NOT set.or.th. The document search has no JSON list endpoint; it is a form postback returning HTML tables that the service parses (stdlib `html.parser`). It reuses `AsyncDataFetcher` with `use_session=False` (stateless, like `earnings_call.py`); dates are **dd/mm/yyyy** (note: SET news is dd/MM/yyyy — same digits, but the SEC form is its own endpoint). Do not route SEC URLs through SessionManager (its auto-detect would mis-warm them as SET).
 - **SEC VIEWSTATE tokens are mandatory and must be fresh:** the search POST must echo `__VIEWSTATE`/`__VIEWSTATEGENERATOR`/`__EVENTVALIDATION` scraped from a fresh GET of the same page. Omitting them does **not** error — it silently returns a wrong, broader result set (43 vs 7 rows in testing). `FinancialReportService` always GETs tokens immediately before each POST; no cookie/session binding is needed (cross-request works).
 - **SEC downloads can be soft-404s (HTTP 200 + HTML):** a dead `Download?FILEID=` link returns an HTML page `ไม่พบไฟล์ที่ระบุ` ("file not found") under **HTTP 200**, notably for some recent `dat/annual/` (56-2) rows whose file actually lives under `dat/f56/`. `DocumentDownloadService.download` validates the content-type and raises `FetchError` instead of returning the garbage bytes; `download_all(..., continue_on_error=True)` skips such items.
+- **Holiday endpoint lives on a different path prefix:** `/api/cms/v1/holidays/year/{year}` is the **only** `/api/cms/v1/` endpoint in the package — everything else on `www.set.or.th` is under `/api/set/`. It takes `?lang=` (like stock/news), **not** `?language=` (like index).
+- **The holiday endpoint serves ONLY the current year:** live-probed 2026-07-27 — with 2026 returning HTTP 200 on every interleaved control request, **2024, 2025, 2027 and 2028 all returned HTTP 401**. There is no history and no next-year lookahead, so this endpoint alone cannot back a multi-year trading calendar or a backtest.
+- **HTTP 401 is the holiday endpoint's only failure code — and it is ambiguous:** an unrecognized `lang`, a missing `lang`, and an unserved year all return a bare `401` with an **empty body**, and so do valid requests *transiently*. Success degrades the harder you poll (~100% cold → ~35% after ~50 requests → ~12% after ~150), recovering on its own when left idle. `HolidayService` therefore retries 401/403/429 itself with exponential backoff (`FetcherConfig.max_retries`/`retry_delay`) — note `AsyncDataFetcher.fetch()` retries **exceptions only**, never a non-2xx status, so any other service is one flaky response away from a hard failure.
+- **`HolidayCalendar.is_holiday()` is not "is the market open":** the API returns published closures only, so weekends are absent and `is_holiday(saturday)` is `False`. It also expresses whole-day closures only — no field for partial sessions or altered hours. Weekend logic must live in the caller.
+- **Do not enable `str_strip_whitespace` on `Holiday`:** unlike every other SET model, it is deliberately off — a trailing `" *"` in a description is a SET footnote marker for additional special closures and must survive verbatim (a test guards this).
 - **A SEC `FS` search returns three categories at once:** querying `ddlReportType=FS` returns financial statements **+** Key Financial Ratio **+** MD&A sections in one HTML response (each its own table); large sections truncate inline and expose a `ViewMore/{fs-norm|fs-kf|fs-mda}` link the listing follows (`follow_view_more=True`). MD&A rows use different columns (Date/Time/Heading/Link, no Name) — the mapper fills `company_name` from the resolved company as a fallback.
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This includes pandas, matplotlib, and jupyter notebook support.
 - [Stock List](examples/set/01_stock_list.ipynb) → [Highlight Data](examples/set/02_highlight_data.ipynb) → [Price Performance](examples/set/10_price_performance.ipynb) → [Financial Statements](examples/set/11_financial.ipynb)
 
 **Professional Trading :** Master all features for institutional use:
-- All 16 SET notebooks + TFEX notebooks (see below)
+- All 17 SET notebooks + TFEX notebooks (see below)
 
 ### 📊 SET Examples (Stock Exchange of Thailand)
 
@@ -61,6 +61,7 @@ All examples include beginner explanations, professional trading use cases, and 
 14. **[Latest Historical Trading](examples/set/14_latest_historical_trading.ipynb)** - Latest trading-day summary: OHLCV, P/E, P/BV, market cap
 15. **[Market Index](examples/set/15_market_index.ipynb)** - Index directory, SET50/SETESG quotations, constituents, and index membership per stock
 16. **[SET News](examples/set/16_news.ipynb)** - Company news/disclosures for all stocks: symbol/date/keyword filters, Thai headlines
+17. **[Market Holidays](examples/set/17_holiday.ipynb)** - Official market-closure calendar: is the market open, next holiday, long weekends
 
 ### 📈 TFEX Examples (Thailand Futures Exchange)
 
@@ -94,6 +95,7 @@ Want to dig deeper? Check out our detailed guides:
 - **[Earnings Call (Opportunity Day) Service](docs/settfex/services/set/earnings_call.md)** - OPPDAY earnings-call calendar with YouTube links, as models or a DataFrame
 - **[Market Index Service](docs/settfex/services/set/index.md)** - Index directory (SET50/SET100/sSET/SETESG/...), quotations, constituents, and latest index value
 - **[News Service](docs/settfex/services/set/news.md)** - Company news and disclosures for all stocks, with symbol/date/keyword filters
+- **[Market Holiday Service](docs/settfex/services/set/holiday.md)** - Official SET market-closure calendar for the year, in English or Thai
 
 ### TFEX Services
 
@@ -489,6 +491,40 @@ fin = news.filter_by_tag("financial-statement")
 ```
 
 **👉 [Learn more about the News Service](docs/settfex/services/set/news.md)**
+
+---
+
+#### 📅 Check Market Holidays
+
+The official SET market-closure calendar for the year, in English or Thai:
+
+```python
+from datetime import date
+from settfex.services.set import get_holidays
+
+# Defaults to the current year in Asia/Bangkok
+calendar = await get_holidays()
+print(f"{calendar.count} holidays in {calendar.year}")
+
+for holiday in calendar.holidays[:3]:
+    print(f"{holiday.holiday_date:%Y-%m-%d %a}  {holiday.description}")
+# 2026-01-01 Thu  New Year's Day
+# 2026-01-02 Fri  Additional special holiday
+# 2026-03-03 Tue  Makha Bucha Day
+
+calendar.is_holiday(date(2026, 1, 1))   # True
+calendar.next_holiday()                 # the next closure from today
+calendar.filter_by_month(4)             # Songkran cluster
+
+# Thai names
+thai = await get_holidays(lang="th")
+```
+
+> ⚠️ Two limits worth knowing: the API serves **only the current year**, and `is_holiday()` means
+> *"on SET's published holiday list"* — **weekends are not in the payload**, so combine it with a
+> weekday check to answer "is the market open?".
+
+**👉 [Learn more about the Market Holiday Service](docs/settfex/services/set/holiday.md)**
 
 ---
 

--- a/docs/settfex/services/set/holiday.md
+++ b/docs/settfex/services/set/holiday.md
@@ -1,0 +1,251 @@
+# SET Market Holiday Service
+
+## Overview
+
+Fetches the official **SET market holiday calendar** for a calendar year
+(`GET /api/cms/v1/holidays/year/{year}`) in English or Thai. One call returns every published
+market closure for the year, with helpers for answering "is this day a holiday?".
+
+Module: `settfex/services/set/holiday.py` · Three tiers: `get_holidays()` (one-call convenience,
+the LLM tool-calling entry point) → `HolidayService.fetch_holidays()` (validated Pydantic models) →
+`HolidayService.fetch_holidays_raw()` (raw `list[dict]` escape hatch).
+
+> ### ⚠️ Four API gotchas (live-verified 2026-07-27)
+>
+> 1. **Only the current year is served.** With 2026 returning HTTP 200 on every interleaved
+>    control request, **2024, 2025, 2027 and 2028 all returned HTTP 401**. Any year other than the
+>    current one raises `FetchError`. This endpoint cannot supply history for backtests, nor next
+>    year's calendar for year-boundary arithmetic.
+> 2. **HTTP 401 is the only failure code, and it is ambiguous.** An unrecognized `lang`, a missing
+>    `lang`, and an unserved year all return a bare `401` with an **empty body** — and so do
+>    perfectly valid requests, *transiently*. The service therefore retries `401/403/429` with
+>    exponential backoff before raising (see [Reliability](#reliability)).
+> 3. **This is the only `/api/cms/v1/` endpoint**, and it takes `?lang=` (like the stock and news
+>    endpoints), **not** `?language=` (the index endpoints). Passing the wrong one returns 401.
+> 4. **Descriptions are verbatim.** A trailing `" *"` is a SET footnote marker on additional
+>    special closures (e.g. `"Additional special holiday *"` on 2026-10-16) and is deliberately
+>    **not** stripped — unlike other SET models, `Holiday` does not enable `str_strip_whitespace`.
+
+## Quick Start
+
+```python
+import asyncio
+from datetime import date
+from settfex.services.set import get_holidays
+
+async def main() -> None:
+    # Current year in Asia/Bangkok, English descriptions
+    calendar = await get_holidays()
+    print(f"{calendar.count} holidays in {calendar.year}")
+    for holiday in calendar.holidays:
+        print(f"{holiday.holiday_date:%Y-%m-%d}  {holiday.description}")
+
+    print(calendar.is_holiday(date(2026, 1, 1)))  # True
+
+asyncio.run(main())
+```
+
+```python
+# Thai descriptions
+calendar = await get_holidays(lang="th")
+
+# An explicit year (must be the current year — see gotcha 1)
+calendar = await get_holidays(2026)
+
+# Be patient when the endpoint is throwing transient 401s
+from settfex.utils.data_fetcher import FetcherConfig
+calendar = await get_holidays(config=FetcherConfig(max_retries=6, retry_delay=2.0))
+```
+
+## Models
+
+### `Holiday`
+
+One market holiday. Both fields are always present.
+
+| Field | Alias | Type | Notes |
+|---|---|---|---|
+| `holiday_date` | `date` | `datetime` | Timezone-aware, always `+07:00` (Asia/Bangkok); time is always `00:00:00` |
+| `description` | — | `str` | Holiday name in the requested language, **verbatim** — a trailing `" *"` is a SET footnote |
+
+The field is named `holiday_date` rather than `date` so the module can use `datetime.date` freely;
+`populate_by_name=True` means the API's `date` key still round-trips (`model_dump(by_alias=True)`).
+
+### `HolidayCalendar`
+
+Container for one year. Holidays are kept in API order (live-verified ascending, no duplicates);
+none of the helpers depend on that ordering.
+
+| Member | Description |
+|---|---|
+| `year` | `int` — the calendar year |
+| `lang` | `'en'` or `'th'` — language the descriptions were fetched in |
+| `holidays` | `list[Holiday]` — every published holiday, in API order |
+| `count` | *(property)* number of holidays |
+| `dates` | *(property)* `list[date]` — plain Bangkok-local calendar days, ascending |
+| `is_holiday(day)` | `bool` — is this day on SET's published holiday list |
+| `get_holiday(day)` | `Holiday \| None` — the matching entry, or `None` |
+| `filter_by_month(month)` | `list[Holiday]` — holidays in month `1`–`12` (raises `ValueError` otherwise) |
+| `next_holiday(after=None)` | `Holiday \| None` — earliest holiday strictly after `after` (default: today in Bangkok) |
+
+`day` accepts a `date` or a `datetime`. Naive datetimes are treated as Bangkok-local; aware ones
+are converted to the Bangkok calendar day first.
+
+> ### ⚠️ `is_holiday()` is not "is the market open"
+>
+> The API returns **closures only** — Saturdays and Sundays are not in the payload, so
+> `is_holiday(saturday)` returns `False` even though the market is shut. Answering "was the market
+> open on date X?" additionally requires weekend logic (and this endpoint expresses whole-day
+> closures only — it has no field for partial sessions or altered trading hours).
+
+## Service Class
+
+### `HolidayService(config: FetcherConfig | None = None)`
+
+Uses the default `use_session=True`, so `SessionManager` handles the Incapsula cookie warm-up
+automatically. Raise `max_retries` if you hit repeated HTTP 401s.
+
+#### `fetch_holidays(year=None, lang="en") -> HolidayCalendar`
+#### `fetch_holidays_raw(year=None, lang="en") -> list[dict]`
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `year` | `int \| None` | `None` | Defaults to the current year in **Asia/Bangkok**, never system-local time. Only the current year is served by the API. |
+| `lang` | `Language` | `"en"` | `en`/`eng`/`english` or `th`/`tha`/`thai`, normalized via `normalize_language()` |
+
+Client-side, `year` must be an integer between `MIN_YEAR` (1975, when SET began trading) and
+`MAX_YEAR` (2100). That is a **typo guard only**, not a claim about coverage — it stays permissive
+so that if SET starts publishing next year's calendar, the client does not reject it.
+
+## Convenience Function
+
+```python
+async def get_holidays(
+    year: int | None = None,
+    lang: Language = "en",
+    config: FetcherConfig | None = None,
+) -> HolidayCalendar
+```
+
+## Usage Examples
+
+### Is the market closed today?
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+calendar = await get_holidays()
+today = datetime.now(ZoneInfo("Asia/Bangkok")).date()
+
+# Remember: holidays only. Weekends must be checked separately.
+closed = today.weekday() >= 5 or calendar.is_holiday(today)
+```
+
+### What is the next market holiday?
+
+```python
+calendar = await get_holidays()
+upcoming = calendar.next_holiday()
+if upcoming:
+    print(f"{upcoming.holiday_date:%d %b %Y} — {upcoming.description}")
+else:
+    print("No holidays left this year")
+```
+
+### Long weekends and clustered closures
+
+```python
+calendar = await get_holidays(2026)
+for holiday in calendar.filter_by_month(4):      # Songkran
+    print(holiday.holiday_date.date(), holiday.description)
+# 2026-04-06 Chakri Memorial Day
+# 2026-04-13 Songkran Festival
+# 2026-04-14 Songkran Festival
+# 2026-04-15 Songkran Festival
+```
+
+### Both languages side by side
+
+```python
+en = await get_holidays(2026, lang="en")
+th = await get_holidays(2026, lang="th")
+
+for a, b in zip(en.holidays, th.holidays):       # 1:1 aligned, same order
+    print(f"{a.holiday_date.date()}  {a.description:45s} {b.description}")
+```
+
+## Reliability
+
+This endpoint is noticeably less stable than the rest of the SET API, and it degrades the harder
+you poll it. Measured on an unchanged, valid URL:
+
+| Phase | Success rate |
+|---|---|
+| First contact (cold) | ~100% |
+| After ~50 requests | ~35% |
+| After ~150 requests | ~12% |
+
+It recovers on its own after an idle period. Because `AsyncDataFetcher.fetch()` only retries
+*exceptions* — never a non-2xx status — `HolidayService` retries `401`/`403`/`429` itself, using
+the existing `FetcherConfig` knobs:
+
+```python
+# 7 attempts, backing off 2s, 4s, 8s, 16s, 32s, 64s
+calendar = await get_holidays(config=FetcherConfig(max_retries=6, retry_delay=2.0))
+```
+
+Holiday data is static for a whole year, so cache the result in your application rather than
+re-fetching it — and avoid loops that request many years.
+
+## Error Handling
+
+```python
+from settfex.exceptions import FetchError, InvalidLanguageError
+from settfex.services.set import get_holidays
+from settfex.utils.parsing import ResponseParseError
+
+try:
+    calendar = await get_holidays(2026)
+except ValueError as exc:            # year not an int, or outside 1975..2100
+    print(f"Bad year: {exc}")
+except InvalidLanguageError as exc:  # also a ValueError — catch it first
+    print(f"Bad language: {exc}")
+except FetchError as exc:
+    print(f"HTTP {exc.status_code}: {exc}")
+except ResponseParseError as exc:
+    print(f"Malformed response: {exc}")
+```
+
+> `InvalidLanguageError` subclasses `ValueError`, so order the `except` clauses accordingly.
+> A `FetchError` with `status_code == 401` means either *"that year is not served"* or
+> *"the endpoint is saturated, retry later"* — the message spells out both, because the API
+> gives no way to tell them apart.
+
+## API Endpoint
+
+```
+GET https://www.set.or.th/api/cms/v1/holidays/year/{year}?lang={en|th}
+```
+
+Returns a **bare JSON array** (no envelope):
+
+```json
+[
+  {"date": "2026-01-01T00:00:00+07:00", "description": "New Year's Day"},
+  {"date": "2026-10-16T00:00:00+07:00", "description": "Additional special holiday *"}
+]
+```
+
+Requires the full SET API header set (`AsyncDataFetcher.get_set_api_headers()`) — a plain request
+is blocked by Incapsula with HTTP 403. Cookies are *not* required (the same request succeeds with
+`use_session=False`), but the default `use_session=True` is used for consistency with the other
+`www.set.or.th` services.
+
+## Related Services
+
+- [Stock List](list.md) — every SET/mai symbol
+- [News](news.md) — company news and disclosures
+- [Chart Quotation](chart_quotation.md) — latest traded price relative to now
+- [Latest Historical Trading](latest_historical_trading.md) — the latest trading day's summary
+- [Corporate Actions](corporate_action.md) — XD/XM dates per symbol

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Comprehensive, beginner-friendly tutorials for the settfex library.
 
 **Location**: `examples/set/`
 
-Complete tutorial series covering all 11 SET services:
+Complete tutorial series covering all 17 SET services:
 
 1. **Stock List** - Market universe and symbol validation
 2. **Highlight Data** - Key metrics (P/E, P/B, market cap, dividends)
@@ -22,8 +22,13 @@ Complete tutorial series covering all 11 SET services:
 10. **Price Performance** - Stock vs sector vs market comparison
 11. **Financial Statements** - Balance sheet, income, cash flow
 12. **Earnings Call (Opportunity Day)** - OPPDAY calendar with YouTube links → DataFrame → CSV
+13. **Chart Quotation & Latest Price** - Intraday series and the latest traded price relative to now
+14. **Latest Historical Trading** - Latest trading-day summary (OHLCV, P/E, P/BV, market cap)
+15. **Market Index** - Index directory, quotations, constituents, index membership per stock
+16. **SET News** - Company news/disclosures for all stocks, with symbol/date/keyword filters
+17. **Market Holidays** - Official market-closure calendar: is the market open, next holiday
 
-**Total**: 12 notebooks + comprehensive guide
+**Total**: 17 notebooks + comprehensive guide
 
 ## Quick Start
 

--- a/examples/set/17_holiday.ipynb
+++ b/examples/set/17_holiday.ipynb
@@ -1,0 +1,367 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# SET Market Holiday Service — Official Market Closure Calendar\n",
+    "\n",
+    "The authoritative list of days the Stock Exchange of Thailand is closed, in English or Thai.\n",
+    "\n",
+    "**You will learn how to:**\n",
+    "- Fetch the official holiday calendar for the current year\n",
+    "- Ask whether a given day is a market holiday\n",
+    "- Find the next holiday and spot long weekends\n",
+    "- Read Thai holiday names, including SET's `*` footnote marker\n",
+    "- Handle this endpoint's unusually flaky HTTP 401 behaviour\n",
+    "\n",
+    "> ⚠️ **Four API gotchas** (live-verified 2026-07-27):\n",
+    "> 1. **Only the current year is served.** 2024, 2025, 2027 and 2028 all return HTTP 401 while the current year returns 200. No history, no next-year lookahead.\n",
+    "> 2. **HTTP 401 is the only failure code** — and it is also returned *transiently* on valid requests. The service retries automatically.\n",
+    "> 3. `is_holiday()` means *\"on SET's published holiday list\"*, **not** *\"the market is closed\"* — weekends are not in the payload.\n",
+    "> 4. Descriptions are **verbatim**: a trailing `\" *\"` is a SET footnote and is never stripped."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import date, datetime\n",
+    "from zoneinfo import ZoneInfo\n",
+    "\n",
+    "from settfex.services.set import HolidayService, get_holidays\n",
+    "from settfex.utils.data_fetcher import FetcherConfig\n",
+    "\n",
+    "BANGKOK = ZoneInfo(\"Asia/Bangkok\")\n",
+    "\n",
+    "# In Jupyter, await works directly (no asyncio.run needed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 2. Fetch this year's holiday calendar\n",
+    "\n",
+    "With no arguments, `get_holidays()` resolves the year from the **Asia/Bangkok** clock — never your machine's local time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calendar = await get_holidays()\n",
+    "\n",
+    "print(f\"{calendar.count} market holidays in {calendar.year} (lang={calendar.lang})\\n\")\n",
+    "for holiday in calendar.holidays:\n",
+    "    print(f\"{holiday.holiday_date:%Y-%m-%d %a}  {holiday.description}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 3. Is a given day a market holiday?\n",
+    "\n",
+    "`is_holiday()` accepts a `date` or a `datetime`. Naive datetimes are treated as Bangkok-local; aware ones are converted to the Bangkok calendar day first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_year = date(calendar.year, 1, 1)\n",
+    "\n",
+    "print(f\"{new_year} is a holiday? {calendar.is_holiday(new_year)}\")\n",
+    "print(f\"Details: {calendar.get_holiday(new_year)}\")\n",
+    "\n",
+    "# get_holiday() returns None for an ordinary trading day\n",
+    "print(f\"\\n{date(calendar.year, 1, 5)} -> {calendar.get_holiday(date(calendar.year, 1, 5))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 4. ⚠️ Weekends are NOT in the payload\n",
+    "\n",
+    "This is the single easiest way to get a wrong answer. The API publishes **holidays only**, so a Saturday is not a \"holiday\" even though the market is shut. Combine both checks yourself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def market_is_closed(day: date) -> bool:\n",
+    "    \"\"\"Holidays alone are not enough — weekends must be handled separately.\"\"\"\n",
+    "    return day.weekday() >= 5 or calendar.is_holiday(day)\n",
+    "\n",
+    "\n",
+    "for day in [date(calendar.year, 1, 1), date(calendar.year, 1, 3), date(calendar.year, 1, 5)]:\n",
+    "    print(\n",
+    "        f\"{day:%Y-%m-%d %a}  is_holiday={calendar.is_holiday(day)!s:5s} \"\n",
+    "        f\"market_is_closed={market_is_closed(day)}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 5. The next market holiday\n",
+    "\n",
+    "`next_holiday()` is exclusive of the given day and defaults to today in Bangkok. It returns `None` once the year runs out — the calendar only covers its own year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "today = datetime.now(BANGKOK).date()\n",
+    "upcoming = calendar.next_holiday()\n",
+    "\n",
+    "if upcoming:\n",
+    "    days_away = (upcoming.holiday_date.date() - today).days\n",
+    "    print(\n",
+    "        f\"Next holiday: {upcoming.holiday_date:%d %b %Y} ({days_away} days) — {upcoming.description}\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(f\"No holidays left in {calendar.year}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## 6. Filter by month — finding long weekends"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for month in range(1, 13):\n",
+    "    holidays = calendar.filter_by_month(month)\n",
+    "    if holidays:\n",
+    "        names = \", \".join(h.description for h in holidays)\n",
+    "        print(f\"{month:2d}: {len(holidays)} — {names}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## 7. Thai descriptions\n",
+    "\n",
+    "The English and Thai payloads are 1:1 aligned — same dates, same order. Note that Thai parenthetical notes use Buddhist-era years (2569 = 2026)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thai = await get_holidays(calendar.year, lang=\"th\")\n",
+    "\n",
+    "for en, th in zip(calendar.holidays, thai.holidays):\n",
+    "    print(f\"{en.holiday_date:%Y-%m-%d}  {en.description[:42]:45s} {th.description}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## 8. The verbatim `*` footnote marker\n",
+    "\n",
+    "SET marks *additional special closures* with a trailing `\" *\"`. It is part of the published name and is deliberately never stripped — unlike other SET models, `Holiday` does not enable `str_strip_whitespace`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marked = [h for h in calendar.holidays if h.description.endswith(\" *\")]\n",
+    "\n",
+    "print(f\"{len(marked)} description(s) carry the footnote marker:\")\n",
+    "for holiday in marked:\n",
+    "    print(f\"  {holiday.holiday_date:%Y-%m-%d}  {holiday.description!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {},
+   "source": [
+    "## 9. Raw tier — the untouched API response\n",
+    "\n",
+    "`fetch_holidays_raw()` is the escape hatch: a bare list of dicts exactly as the API returned them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8309879909854d7188b41380fd92a7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service = HolidayService()\n",
+    "raw = await service.fetch_holidays_raw(calendar.year)\n",
+    "\n",
+    "print(f\"{len(raw)} entries, keys={set(raw[0])}\")\n",
+    "raw[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ed186c9a28b402fb0bc4494df01f08d",
+   "metadata": {},
+   "source": [
+    "## 10. Only the current year is served\n",
+    "\n",
+    "Requesting any other year returns HTTP 401 — the same code the endpoint uses for transient failures, so the error message spells out both causes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb1e1581032b452c9409d6c6813c49d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from settfex.exceptions import FetchError\n",
+    "\n",
+    "try:\n",
+    "    await get_holidays(calendar.year - 1, config=FetcherConfig(max_retries=1))\n",
+    "except FetchError as exc:\n",
+    "    print(f\"HTTP {exc.status_code}\\n{exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379cbbc1e968416e875cc15c1202d7eb",
+   "metadata": {},
+   "source": [
+    "## 11. Handling the transient 401\n",
+    "\n",
+    "This endpoint degrades the harder you poll it (~100% success cold, ~12% after ~150 requests) and recovers on its own when left alone. `HolidayService` retries `401`/`403`/`429` with exponential backoff, tuned through the normal `FetcherConfig` knobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "277c27b1587741f2af2001be3712ef0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 7 attempts, backing off 2s, 4s, 8s, 16s, 32s, 64s\n",
+    "patient = FetcherConfig(max_retries=6, retry_delay=2.0)\n",
+    "calendar = await get_holidays(config=patient)\n",
+    "\n",
+    "print(f\"Fetched {calendar.count} holidays for {calendar.year}\")\n",
+    "\n",
+    "# Holiday data is static for a whole year — cache it rather than re-fetching."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db7b79bc585a40fcaf58bf750017e135",
+   "metadata": {},
+   "source": [
+    "## 12. Export to pandas (optional: `pip install \"settfex[dataframe]\"`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "916684f9a58a4a2aa5f864670399430d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    df = pd.DataFrame(\n",
+    "        {\n",
+    "            \"date\": [h.holiday_date.date() for h in calendar.holidays],\n",
+    "            \"weekday\": [h.holiday_date.strftime(\"%a\") for h in calendar.holidays],\n",
+    "            \"description\": [h.description for h in calendar.holidays],\n",
+    "        }\n",
+    "    )\n",
+    "    display(df)\n",
+    "except ImportError:\n",
+    "    print(\"pandas not installed — pip install 'settfex[dataframe]'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1671c31a24314836a5b85d7ef7fbf015",
+   "metadata": {},
+   "source": [
+    "## Use Cases\n",
+    "\n",
+    "- **Skip closed days** when iterating a date range for price or news queries\n",
+    "- **Validate a \"latest trading day\"** result against the published calendar\n",
+    "- **Plan around long weekends** (Songkran in April, the December cluster)\n",
+    "- **Surface upcoming closures** in a dashboard or trading UI\n",
+    "\n",
+    "> ⚠️ Two limits to design around: this endpoint serves **only the current year**, and it lists\n",
+    "> **whole-day closures only** — it has no field for partial sessions or altered trading hours.\n",
+    "> Combined with the missing weekends, that means it is not by itself a trading calendar.\n",
+    "\n",
+    "**See also**: `docs/settfex/services/set/holiday.md` · News (16) for disclosures · Chart Quotation (13) for the latest traded price · Latest Historical Trading (14) for the last trading day's summary"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/set/README.md
+++ b/examples/set/README.md
@@ -306,6 +306,26 @@ Complete, beginner-friendly tutorials for all SET (Stock Exchange of Thailand) s
 - Earnings-season tracking via the `financial-statement` tag
 - Event-driven research joined onto price history
 
+---
+
+### 17. Market Holidays (`17_holiday.ipynb`)
+**What it does**: The official SET market-closure calendar for the year, en/th
+
+**Learn how to**:
+- Fetch the calendar for the current year (resolved in Asia/Bangkok, not system-local time)
+- Ask `is_holiday()` / `get_holiday()` for any `date` or `datetime`
+- Find the next closure and spot long weekends with `next_holiday()` / `filter_by_month()`
+- Read Thai holiday names and SET's verbatim `*` footnote marker
+- Handle the endpoint's transient HTTP 401 with a more patient `FetcherConfig`
+
+**Use cases**:
+- Skipping closed days when iterating a date range for price or news queries
+- Validating a "latest trading day" result against the published calendar
+- Surfacing upcoming closures in a dashboard or trading UI
+
+> ⚠️ The API serves **only the current year**, and weekends are **not** in the payload — combine
+> `is_holiday()` with a weekday check to answer "is the market open?".
+
 ## Learning Path
 
 ### Beginners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.14.0"
+version = "0.15.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 __author__ = "batt"
 __license__ = "MIT"
 
@@ -62,6 +62,7 @@ from settfex.services.sec import (
 )
 from settfex.services.set import (
     CompanyProfile,
+    HolidayCalendar,
     IndexCompositionResponse,
     IndexInfo,
     IndexListResponse,
@@ -74,6 +75,7 @@ from settfex.services.set import (
     StockProfile,
     get_company_profile,
     get_highlight_data,
+    get_holidays,
     get_index_composition,
     get_index_info,
     get_index_list,
@@ -102,6 +104,7 @@ __all__ = [
     "get_index_info",
     "get_index_composition",
     "get_news",
+    "get_holidays",
     # SEC IDISC document services (market.sec.or.th)
     "SecCompany",
     "get_sec_documents",
@@ -121,6 +124,7 @@ __all__ = [
     "IndexInfo",
     "IndexCompositionResponse",
     "NewsSearchResponse",
+    "HolidayCalendar",
     # Utilities
     "AsyncDataFetcher",
     "FetcherConfig",

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -11,6 +11,7 @@ from settfex.services.set.constants import (
     SET_FINANCIAL_BALANCE_SHEET_ENDPOINT,
     SET_FINANCIAL_CASH_FLOW_ENDPOINT,
     SET_FINANCIAL_INCOME_STATEMENT_ENDPOINT,
+    SET_HOLIDAY_ENDPOINT,
     SET_INDEX_CHART_QUOTATION_ENDPOINT,
     SET_INDEX_COMPOSITION_ENDPOINT,
     SET_INDEX_INFO_ENDPOINT,
@@ -38,6 +39,12 @@ from settfex.services.set.earnings_call import (
     get_earnings_call_transcript,
     get_earnings_calls,
     get_earnings_calls_dataframe,
+)
+from settfex.services.set.holiday import (
+    Holiday,
+    HolidayCalendar,
+    HolidayService,
+    get_holidays,
 )
 from settfex.services.set.index import (
     BidOffer,
@@ -154,6 +161,7 @@ __all__ = [
     "SET_EARNINGS_CALL_DETAIL_ENDPOINT",
     "SET_EARNINGS_CALL_FILTER_ENDPOINT",
     "SET_NEWS_SEARCH_ENDPOINT",
+    "SET_HOLIDAY_ENDPOINT",
     # Stock List Service
     "StockListService",
     "StockListResponse",
@@ -200,6 +208,11 @@ __all__ = [
     "NewsItem",
     "NewsSearchResponse",
     "get_news",
+    # Holiday Service
+    "HolidayService",
+    "Holiday",
+    "HolidayCalendar",
+    "get_holidays",
     # Stock Class and Services
     "Stock",
     "StockHighlightDataService",

--- a/settfex/services/set/constants.py
+++ b/settfex/services/set/constants.py
@@ -25,6 +25,14 @@ SET_STOCK_LATEST_HISTORICAL_TRADING_ENDPOINT = "/api/set/stock/{symbol}/latest-h
 # dd/MM/yyyy ONLY (ISO dates -> HTTP 400).
 SET_NEWS_SEARCH_ENDPOINT = "/api/set/news/search"
 
+# Market holiday calendar. NOTE: this is the ONLY endpoint on the /api/cms/v1/ prefix — every other
+# www.set.or.th endpoint here lives under /api/set/. It takes ?lang= (like the stock and news
+# endpoints), NOT ?language= (the index endpoints). The API answers anything it does not like —
+# an unrecognized lang value, a missing lang, or a year it does not serve — with a bare HTTP 401
+# and an empty body, and it also returns 401 transiently on perfectly valid requests.
+# Only the CURRENT year is served (live-probed 2026-07-27: 2026 → 200, 2024/2025/2027/2028 → 401).
+SET_HOLIDAY_ENDPOINT = "/api/cms/v1/holidays/year/{year}"
+
 # Market index endpoints (note: the index API uses ?language=, not ?lang= like stock endpoints)
 SET_INDEX_LIST_ENDPOINT = "/api/set/index/list"
 SET_INDEX_INFO_LIST_ENDPOINT = "/api/set/index/info/list"

--- a/settfex/services/set/holiday.py
+++ b/settfex/services/set/holiday.py
@@ -1,0 +1,452 @@
+"""SET Market Holiday Service - Fetch the official SET market holiday calendar for a year.
+
+Wraps the SET CMS holiday endpoint, which returns a bare JSON array of ``{date, description}``
+objects for one calendar year in English or Thai.
+
+Three live-verified quirks drive the shape of this module:
+
+1. The endpoint lives under ``/api/cms/v1/`` — every other ``www.set.or.th`` endpoint in this
+   package is under ``/api/set/`` — and it takes ``?lang=`` (like the stock and news endpoints),
+   not ``?language=`` (the index endpoints).
+2. It answers anything it dislikes with a bare **HTTP 401 and an empty body**: an unrecognized
+   ``lang``, a missing ``lang``, and a year it does not serve all look identical. It also returns
+   401 *transiently* on perfectly valid requests, so :class:`HolidayService` retries before giving
+   up (see ``FetcherConfig.max_retries``).
+3. Descriptions are preserved **verbatim**. A trailing ``" *"`` is a SET footnote marker on
+   additional special closures and is deliberately not stripped.
+
+.. warning::
+    **Only the current year is served.** Live-probed 2026-07-27: with 2026 returning 200 on every
+    interleaved control request, 2024, 2025, 2027 and 2028 all returned HTTP 401. Any year other
+    than the current one raises :class:`~settfex.exceptions.FetchError`. This endpoint therefore
+    cannot supply history for backtests, nor next year's calendar for year-boundary arithmetic.
+
+``MIN_YEAR``/``MAX_YEAR`` are only a client-side typo guard; they deliberately stay permissive
+rather than hard-coding "current year only", since SET may begin publishing the following year's
+calendar at some point and a narrow client-side check would reject it.
+"""
+
+import asyncio
+from datetime import date, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.exceptions import FetchError, raise_for_status
+from settfex.services.set.constants import SET_BASE_URL, SET_HOLIDAY_ENDPOINT
+from settfex.services.set.stock.utils import Language, normalize_language
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig, FetchResponse
+from settfex.utils.parsing import decode_json, validate_list_or_raise
+
+# Thailand observes no DST, so the API's fixed +07:00 offset is equivalent to Asia/Bangkok. Kept as
+# a ZoneInfo rather than a fixed offset so "the current year in Bangkok" comes from the real zone.
+BANGKOK_TZ = ZoneInfo("Asia/Bangkok")
+
+# Client-side bounds on the ``year`` argument. This is a typo guard, NOT a claim about what the API
+# actually serves: the endpoint reports an unsupported year with the same bare HTTP 401 it uses for
+# transient failures, so real coverage cannot be probed reliably and is deliberately not enforced.
+MIN_YEAR = 1975  # SET began trading in 1975
+MAX_YEAR = 2100
+
+# Statuses worth retrying. AsyncDataFetcher.fetch() only retries exceptions, never a non-2xx status,
+# so the transient 401 described in the module docstring has to be handled here.
+_RETRYABLE_STATUS = frozenset({401, 403, 429})
+
+
+def _as_bangkok_day(value: date | datetime) -> date:
+    """
+    Reduce a date or datetime to a Bangkok-local calendar day.
+
+    Naive datetimes are assumed to already be Bangkok-local; aware ones are converted. Plain
+    ``date`` objects pass through untouched.
+
+    Args:
+        value: A ``date`` or ``datetime`` to normalize
+
+    Returns:
+        The corresponding Bangkok-local calendar day
+
+    Example:
+        >>> _as_bangkok_day(datetime(2026, 1, 1, 23, 30, tzinfo=UTC))
+        datetime.date(2026, 1, 2)
+    """
+    # datetime is a subclass of date, so this check must come first.
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=BANGKOK_TZ).date()
+        return value.astimezone(BANGKOK_TZ).date()
+    return value
+
+
+class Holiday(BaseModel):
+    """Model for a single SET market holiday."""
+
+    holiday_date: datetime = Field(
+        alias="date",
+        description=(
+            "Holiday date as published by SET - timezone-aware, always +07:00 (Asia/Bangkok), "
+            "with a 00:00:00 time component"
+        ),
+    )
+    description: str = Field(
+        description=(
+            "Holiday name in the requested language, preserved verbatim. A trailing ' *' is a "
+            "SET footnote marker on additional special closures and is not stripped"
+        )
+    )
+
+    # NOTE: deliberately WITHOUT str_strip_whitespace (which the other SET models enable) - the
+    # trailing ' *' footnote marker in some descriptions must survive verbatim.
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+    )
+
+
+class HolidayCalendar(BaseModel):
+    """
+    The official SET market holiday calendar for one year.
+
+    Holidays are kept in the order the API returned them (live-verified ascending, no duplicates);
+    the query helpers below do not depend on that ordering.
+    """
+
+    year: int = Field(description="Calendar year these holidays belong to")
+    lang: Language = Field(description="Language the descriptions were fetched in ('en' or 'th')")
+    holidays: list[Holiday] = Field(
+        default_factory=list, description="Holidays for the year, in API order"
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+    )
+
+    @property
+    def count(self) -> int:
+        """Get total count of holidays in the calendar."""
+        return len(self.holidays)
+
+    @property
+    def dates(self) -> list[date]:
+        """
+        All holiday dates as plain Bangkok-local calendar days, ascending.
+
+        Returns:
+            Sorted list of ``datetime.date`` objects
+        """
+        return sorted(h.holiday_date.date() for h in self.holidays)
+
+    def is_holiday(self, day: date | datetime) -> bool:
+        """
+        Check whether a day is a SET-published market holiday.
+
+        .. warning::
+            This answers *"is this day on SET's published holiday list"* - **not** *"is the market
+            closed"*. Weekends are not in the payload, so a Saturday returns ``False``. Use a
+            trading-calendar layer for market-open questions.
+
+        Args:
+            day: Day to check, as a ``date`` or ``datetime`` (naive datetimes are treated as
+                Bangkok-local)
+
+        Returns:
+            True if the day appears in this calendar's holiday list
+
+        Example:
+            >>> calendar = await get_holidays(2026)
+            >>> calendar.is_holiday(date(2026, 1, 1))
+            True
+        """
+        return self.get_holiday(day) is not None
+
+    def get_holiday(self, day: date | datetime) -> Holiday | None:
+        """
+        Get the holiday falling on a given day, if any.
+
+        Args:
+            day: Day to look up, as a ``date`` or ``datetime`` (naive datetimes are treated as
+                Bangkok-local)
+
+        Returns:
+            The matching :class:`Holiday`, or None if the day is not a published holiday
+
+        Example:
+            >>> calendar = await get_holidays(2026)
+            >>> holiday = calendar.get_holiday(date(2026, 1, 1))
+            >>> holiday.description
+            "New Year's Day"
+        """
+        target = _as_bangkok_day(day)
+        for holiday in self.holidays:
+            if holiday.holiday_date.date() == target:
+                return holiday
+        return None
+
+    def filter_by_month(self, month: int) -> list[Holiday]:
+        """
+        Filter holidays by calendar month.
+
+        Args:
+            month: Month number, 1 (January) through 12 (December)
+
+        Returns:
+            List of holidays falling in that month, in API order
+
+        Raises:
+            ValueError: If month is outside 1-12.
+
+        Example:
+            >>> calendar = await get_holidays(2026)
+            >>> len(calendar.filter_by_month(4))  # Songkran
+            4
+        """
+        if not 1 <= month <= 12:
+            error_msg = f"Month must be between 1 and 12, got {month}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+        return [h for h in self.holidays if h.holiday_date.month == month]
+
+    def next_holiday(self, after: date | datetime | None = None) -> Holiday | None:
+        """
+        Get the next holiday strictly after a given day.
+
+        Args:
+            after: Day to search from (exclusive). Defaults to today in Asia/Bangkok.
+
+        Returns:
+            The earliest holiday after ``after``, or None if this year has none left. Note the
+            calendar only covers :attr:`year`, so December lookups usually return None.
+
+        Example:
+            >>> calendar = await get_holidays(2026)
+            >>> upcoming = calendar.next_holiday(date(2026, 1, 1))
+            >>> upcoming.description
+            'Additional special holiday'
+        """
+        target = _as_bangkok_day(after) if after is not None else datetime.now(BANGKOK_TZ).date()
+        upcoming = [h for h in self.holidays if h.holiday_date.date() > target]
+        if not upcoming:
+            return None
+        # min() rather than [0] so the result is correct even if the API stops returning sorted data
+        return min(upcoming, key=lambda h: h.holiday_date)
+
+
+class HolidayService:
+    """
+    Service for fetching the official SET market holiday calendar.
+
+    Market-level: takes a year rather than a symbol, and supports English and Thai. Because the
+    endpoint returns HTTP 401 transiently on valid requests, fetches are retried according to
+    ``FetcherConfig.max_retries`` / ``retry_delay``.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """
+        Initialize the holiday service.
+
+        Args:
+            config: Optional fetcher configuration (uses defaults if None). Raise
+                ``max_retries`` if you hit repeated HTTP 401s from the endpoint.
+
+        Example:
+            >>> # Default: Uses SessionManager for automatic cookie handling
+            >>> service = HolidayService()
+            >>> # More patient, for when the endpoint is throwing transient 401s
+            >>> service = HolidayService(FetcherConfig(max_retries=6, retry_delay=2.0))
+        """
+        self.config = config or FetcherConfig()
+        self.base_url = SET_BASE_URL
+        logger.info(f"HolidayService initialized with base_url={self.base_url}")
+
+    @staticmethod
+    def _normalize_year(year: int | None) -> int:
+        """Resolve None to the current Bangkok year and range-check an explicit year."""
+        if year is None:
+            resolved = datetime.now(BANGKOK_TZ).year
+            logger.debug(f"No year supplied; defaulting to the current Bangkok year {resolved}")
+            return resolved
+
+        # bool is a subclass of int, so exclude it explicitly rather than formatting True into a URL
+        if isinstance(year, bool) or not isinstance(year, int):
+            error_msg = f"Year must be an integer, got {type(year).__name__}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        if not MIN_YEAR <= year <= MAX_YEAR:
+            error_msg = f"Year {year} is out of range; must be between {MIN_YEAR} and {MAX_YEAR}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        return year
+
+    async def _fetch_with_retry(
+        self, fetcher: AsyncDataFetcher, url: str, headers: dict[str, str], year: int
+    ) -> FetchResponse:
+        """Fetch ``url``, retrying the endpoint's transient 401/403/429 before raising."""
+        attempts = self.config.max_retries + 1
+
+        for attempt in range(attempts):
+            response = await fetcher.fetch(url, headers=headers)
+
+            if response.status_code == 200:
+                return response
+
+            if response.status_code in _RETRYABLE_STATUS and attempt < self.config.max_retries:
+                delay = self.config.retry_delay * (2**attempt)
+                logger.warning(
+                    f"HTTP {response.status_code} from the holiday API "
+                    f"(attempt {attempt + 1}/{attempts}); retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            error_msg = f"Failed to fetch holidays for {year}: HTTP {response.status_code}"
+            if response.status_code == 401:
+                # 401 is this endpoint's only failure code, so spell out both causes rather than
+                # leaving the caller with a bare status.
+                error_msg += (
+                    " - the API returns 401 both for years it does not serve (live-probed"
+                    " 2026-07-27: only the current year is available) and transiently under"
+                    " load; check the year, or retry later"
+                )
+            logger.error(error_msg)
+            raise_for_status(response.status_code, error_msg, suggest=False)
+
+        # Not reachable: the final attempt above always returns or raises. Present so the function
+        # is total for mypy without an assert.
+        error_msg = f"Failed to fetch holidays for {year} after {attempts} attempts"
+        logger.error(error_msg)
+        raise FetchError(error_msg)
+
+    async def _fetch_payload(self, year: int, lang: Language) -> Any:
+        """Fetch and JSON-decode the holiday payload for a resolved year and language."""
+        endpoint = SET_HOLIDAY_ENDPOINT.format(year=year)
+        url = f"{self.base_url}{endpoint}?lang={lang}"
+
+        logger.info(f"Fetching SET holidays for {year} (lang={lang}) from {url}")
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            # Get optimized headers for SET API (includes all Incapsula bypass headers)
+            headers = AsyncDataFetcher.get_set_api_headers()
+
+            # SessionManager handles cookies automatically - no manual cookie needed
+            response = await self._fetch_with_retry(fetcher, url, headers, year)
+
+            return decode_json(response.text, context=f"set holidays {year} ({lang})")
+
+    async def fetch_holidays(
+        self, year: int | None = None, lang: Language = "en"
+    ) -> HolidayCalendar:
+        """
+        Fetch the SET market holiday calendar for a year.
+
+        Args:
+            year: Calendar year (defaults to the current year in Asia/Bangkok). The API only
+                serves the current year - any other year raises FetchError.
+            lang: Language for response ('en' or 'th', default: 'en')
+
+        Returns:
+            HolidayCalendar containing every published holiday for the year
+
+        Raises:
+            ValueError: If the year is not an integer within MIN_YEAR..MAX_YEAR.
+            InvalidLanguageError: If the language is not recognized.
+            FetchError: On HTTP or transport failures - including the endpoint's bare HTTP 401,
+                which it returns both for unsupported years and transiently for valid requests.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = HolidayService()
+            >>> calendar = await service.fetch_holidays(2026)
+            >>> print(f"{calendar.count} holidays in {calendar.year}")
+            >>> for holiday in calendar.holidays:
+            ...     print(holiday.holiday_date.date(), holiday.description)
+        """
+        resolved_year = self._normalize_year(year)
+        lang = normalize_language(lang)
+
+        data = await self._fetch_payload(resolved_year, lang)
+
+        # The payload is a bare JSON array of holiday entries
+        holidays = validate_list_or_raise(
+            Holiday, data, context=f"set holidays {resolved_year} ({lang})"
+        )
+        calendar = HolidayCalendar(year=resolved_year, lang=lang, holidays=holidays)
+
+        logger.info(f"Successfully fetched {calendar.count} holiday(s) for {resolved_year}")
+
+        return calendar
+
+    async def fetch_holidays_raw(
+        self, year: int | None = None, lang: Language = "en"
+    ) -> list[dict[str, Any]]:
+        """
+        Fetch the holiday calendar as a raw list without Pydantic validation.
+
+        Useful for debugging or when you need the raw API response.
+
+        Args:
+            year: Calendar year (defaults to the current year in Asia/Bangkok). The API only
+                serves the current year - any other year raises FetchError.
+            lang: Language for response ('en' or 'th', default: 'en')
+
+        Returns:
+            Raw list of dictionaries from API
+
+        Raises:
+            ValueError: If the year is not an integer within MIN_YEAR..MAX_YEAR.
+            InvalidLanguageError: If the language is not recognized.
+            FetchError: On HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = HolidayService()
+            >>> raw_data = await service.fetch_holidays_raw(2026)
+            >>> print(raw_data[0])
+            {'date': '2026-01-01T00:00:00+07:00', 'description': "New Year's Day"}
+        """
+        resolved_year = self._normalize_year(year)
+        lang = normalize_language(lang)
+
+        data = await self._fetch_payload(resolved_year, lang)
+        logger.debug(f"Raw response: {len(data) if isinstance(data, list) else type(data)} entries")
+
+        return data  # type: ignore[no-any-return]
+
+
+# Convenience function for quick access
+async def get_holidays(
+    year: int | None = None,
+    lang: Language = "en",
+    config: FetcherConfig | None = None,
+) -> HolidayCalendar:
+    """
+    Convenience function to fetch the SET market holiday calendar for a year.
+
+    Args:
+        year: Calendar year (defaults to the current year in Asia/Bangkok). The API only serves
+            the current year - any other year raises FetchError.
+        lang: Language for response ('en' or 'th', default: 'en')
+        config: Optional fetcher configuration
+
+    Returns:
+        HolidayCalendar containing every published holiday for the year
+
+    Raises:
+        ValueError: If the year is not an integer within MIN_YEAR..MAX_YEAR.
+        InvalidLanguageError: If the language is not recognized.
+        FetchError: On HTTP or transport failures.
+        ResponseParseError: If the response cannot be parsed.
+
+    Example:
+        >>> from settfex.services.set import get_holidays
+        >>> calendar = await get_holidays()  # current year, English
+        >>> calendar.is_holiday(date(2026, 1, 1))
+        True
+        >>> thai = await get_holidays(2026, lang="th")
+        >>> thai.holidays[0].description
+        'วันขึ้นปีใหม่'
+    """
+    service = HolidayService(config=config)
+    return await service.fetch_holidays(year=year, lang=lang)

--- a/tests/services/set/test_holiday.py
+++ b/tests/services/set/test_holiday.py
@@ -1,0 +1,502 @@
+"""Tests for the SET market holiday calendar service.
+
+All HTTP is mocked (the suite runs offline). Fixtures are the real payloads captured live from
+``/api/cms/v1/holidays/year/2026`` on 2026-07-27, including the trailing ``" *"`` footnote marker
+that must survive parsing verbatim.
+"""
+
+import json
+from datetime import UTC, date, datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.exceptions import FetchError, InvalidLanguageError
+from settfex.services.set.holiday import (
+    BANGKOK_TZ,
+    MAX_YEAR,
+    MIN_YEAR,
+    Holiday,
+    HolidayCalendar,
+    HolidayService,
+    get_holidays,
+)
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+from settfex.utils.parsing import ResponseParseError
+
+# Thailand has no DST, so a fixed +07:00 offset is equivalent to Asia/Bangkok.
+BKK = timezone(timedelta(hours=7))
+
+# --- real payloads, captured live 2026-07-27 -------------------------------------------------
+
+# Full English payload for 2026 (20 entries, ascending, no duplicates).
+SAMPLE_EN: list[dict[str, Any]] = [
+    {"date": "2026-01-01T00:00:00+07:00", "description": "New Year's Day"},
+    {"date": "2026-01-02T00:00:00+07:00", "description": "Additional special holiday"},
+    {"date": "2026-03-03T00:00:00+07:00", "description": "Makha Bucha Day"},
+    {"date": "2026-04-06T00:00:00+07:00", "description": "Chakri Memorial Day"},
+    {"date": "2026-04-13T00:00:00+07:00", "description": "Songkran Festival"},
+    {"date": "2026-04-14T00:00:00+07:00", "description": "Songkran Festival"},
+    {"date": "2026-04-15T00:00:00+07:00", "description": "Songkran Festival"},
+    {"date": "2026-05-01T00:00:00+07:00", "description": "National Labor Day"},
+    {"date": "2026-05-04T00:00:00+07:00", "description": "Coronation Day"},
+    {
+        "date": "2026-06-01T00:00:00+07:00",
+        "description": "Substitution for Visakha Bucha Day (Sunday 31st May 2026)",
+    },
+    {
+        "date": "2026-06-03T00:00:00+07:00",
+        "description": "H.M. Queen Suthida Bajrasudhabimalalakshana's Birthday",
+    },
+    {
+        "date": "2026-07-28T00:00:00+07:00",
+        "description": "H.M. King Maha Vajiralongkorn Phra Vajiraklaochaoyuhua's Birthday",
+    },
+    {"date": "2026-07-29T00:00:00+07:00", "description": "Asarnha Bucha Day"},
+    {
+        "date": "2026-08-12T00:00:00+07:00",
+        "description": "H.M. Queen Sirikit The Queen Mother's Birthday / Mother's Day",
+    },
+    {
+        "date": "2026-10-13T00:00:00+07:00",
+        "description": "H.M. King Bhumibol Adulyadej the Great Memorial Day",
+    },
+    # The trailing " *" is a SET footnote marker and must never be stripped.
+    {"date": "2026-10-16T00:00:00+07:00", "description": "Additional special holiday *"},
+    {
+        "date": "2026-10-23T00:00:00+07:00",
+        "description": "H.M. King Chulalongkorn the Great Memorial Day",
+    },
+    {
+        "date": "2026-12-07T00:00:00+07:00",
+        "description": (
+            "Substitution for H.M. King Bhumibol Adulyadej the Great's Birthday / National Day / "
+            "Father's Day (Saturday 5th December 2026)"
+        ),
+    },
+    {"date": "2026-12-10T00:00:00+07:00", "description": "Constitution Day"},
+    {"date": "2026-12-31T00:00:00+07:00", "description": "New Year's Eve"},
+]
+
+# Thai payload subset - same dates and ordering as SAMPLE_EN. Note the parenthetical notes use
+# Buddhist-era years (2569 = 2026) and the " *" marker appears in Thai too.
+SAMPLE_TH: list[dict[str, Any]] = [
+    {"date": "2026-01-01T00:00:00+07:00", "description": "วันขึ้นปีใหม่"},
+    {"date": "2026-01-02T00:00:00+07:00", "description": "วันหยุดทำการเพิ่มเติมเป็นกรณีพิเศษ"},
+    {"date": "2026-03-03T00:00:00+07:00", "description": "วันมาฆบูชา"},
+    {
+        "date": "2026-06-01T00:00:00+07:00",
+        "description": "ชดเชยวันวิสาขบูชา (วันอาทิตย์ที่ 31 พฤษภาคม 2569)",
+    },
+    {"date": "2026-10-16T00:00:00+07:00", "description": "วันหยุดทำการเพิ่มเติมเป็นกรณีพิเศษ *"},
+    {"date": "2026-12-31T00:00:00+07:00", "description": "วันสิ้นปี"},
+]
+
+
+def _response(
+    payload: Any = None,
+    *,
+    status_code: int = 200,
+    text: str | None = None,
+) -> FetchResponse:
+    """Build a FetchResponse whose body is ``payload`` as JSON (or the literal ``text``)."""
+    body = text if text is not None else json.dumps(payload)
+    return FetchResponse(
+        status_code=status_code,
+        content=body.encode("utf-8"),
+        text=body,
+        headers={},
+        url="https://www.set.or.th/api/cms/v1/holidays/year/2026?lang=en",
+        elapsed=0.1,
+    )
+
+
+def _calendar(payload: list[dict[str, Any]] | None = None, year: int = 2026) -> HolidayCalendar:
+    """Build a HolidayCalendar directly from a payload, without going through the service."""
+    holidays = [
+        Holiday.model_validate(item) for item in (payload if payload is not None else SAMPLE_EN)
+    ]
+    return HolidayCalendar(year=year, lang="en", holidays=holidays)
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Patch AsyncDataFetcher inside the holiday module; yield its async instance.
+
+    The patched class mock is attached as ``.cls`` so tests can assert on the header helper.
+    """
+    with patch("settfex.services.set.holiday.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        fetcher_instance.cls = mock
+        yield fetcher_instance
+
+
+@pytest.fixture
+def no_sleep():
+    """Neutralize the retry backoff so retry tests run instantly."""
+    with patch("settfex.services.set.holiday.asyncio.sleep", new=AsyncMock()) as sleeper:
+        yield sleeper
+
+
+# --- models -----------------------------------------------------------------------------------
+
+
+class TestHolidayModel:
+    """Tests for the Holiday Pydantic model."""
+
+    def test_alias_and_timezone(self):
+        """The API's `date` key lands in holiday_date as an aware +07:00 datetime."""
+        holiday = Holiday.model_validate(SAMPLE_EN[0])
+        assert holiday.holiday_date == datetime(2026, 1, 1, 0, 0, tzinfo=BKK)
+        assert holiday.holiday_date.utcoffset() == timedelta(hours=7)
+        assert holiday.description == "New Year's Day"
+
+    def test_footnote_marker_preserved_verbatim(self):
+        """The trailing ' *' footnote marker must survive parsing untouched."""
+        holiday = Holiday.model_validate(SAMPLE_EN[15])
+        assert holiday.description == "Additional special holiday *"
+        assert holiday.description.endswith(" *")
+
+    def test_thai_footnote_marker_preserved(self):
+        """Same guard for the Thai payload."""
+        holiday = Holiday.model_validate(SAMPLE_TH[4])
+        assert holiday.description.endswith(" *")
+        assert "วันหยุดทำการเพิ่มเติมเป็นกรณีพิเศษ" in holiday.description
+
+    def test_populate_by_name(self):
+        """The model accepts the snake_case field name as well as the API alias."""
+        holiday = Holiday(
+            holiday_date=datetime(2026, 1, 1, tzinfo=BKK), description="New Year's Day"
+        )
+        assert holiday.holiday_date.year == 2026
+
+    def test_round_trips_to_api_alias(self):
+        """Dumping by alias reproduces the API's key name."""
+        holiday = Holiday.model_validate(SAMPLE_EN[0])
+        assert "date" in holiday.model_dump(by_alias=True)
+
+
+class TestHolidayCalendar:
+    """Tests for the HolidayCalendar container and its query helpers."""
+
+    def test_count_and_dates(self):
+        """count reflects the payload; dates are plain ascending calendar days."""
+        calendar = _calendar()
+        assert calendar.count == 20
+        assert calendar.dates[0] == date(2026, 1, 1)
+        assert calendar.dates[-1] == date(2026, 12, 31)
+        assert calendar.dates == sorted(calendar.dates)
+
+    def test_is_holiday(self):
+        """A published holiday is recognized; an ordinary trading day is not."""
+        calendar = _calendar()
+        assert calendar.is_holiday(date(2026, 1, 1)) is True
+        assert calendar.is_holiday(date(2026, 1, 5)) is False
+
+    def test_is_holiday_returns_false_for_weekend(self):
+        """Weekends are absent from the payload - this is the documented sharp edge."""
+        calendar = _calendar()
+        saturday = date(2026, 1, 3)
+        assert saturday.weekday() == 5
+        assert calendar.is_holiday(saturday) is False
+
+    def test_is_holiday_accepts_naive_datetime(self):
+        """A naive datetime is treated as Bangkok-local."""
+        calendar = _calendar()
+        assert calendar.is_holiday(datetime(2026, 1, 1, 15, 30)) is True
+
+    def test_is_holiday_converts_aware_datetime(self):
+        """An aware datetime is converted to the Bangkok calendar day before matching."""
+        calendar = _calendar()
+        # 2025-12-31 18:00 UTC is 2026-01-01 01:00 in Bangkok.
+        moment = datetime(2025, 12, 31, 18, 0, tzinfo=UTC)
+        assert calendar.is_holiday(moment) is True
+
+    def test_get_holiday(self):
+        """get_holiday returns the matching entry, or None."""
+        calendar = _calendar()
+        holiday = calendar.get_holiday(date(2026, 4, 13))
+        assert holiday is not None
+        assert holiday.description == "Songkran Festival"
+        assert calendar.get_holiday(date(2026, 4, 16)) is None
+
+    def test_filter_by_month(self):
+        """Songkran gives April four entries (6th, 13th, 14th, 15th)."""
+        calendar = _calendar()
+        april = calendar.filter_by_month(4)
+        assert len(april) == 4
+        assert all(h.holiday_date.month == 4 for h in april)
+
+    def test_filter_by_month_rejects_out_of_range(self):
+        """An impossible month is a caller error, not an empty result."""
+        calendar = _calendar()
+        with pytest.raises(ValueError, match="between 1 and 12"):
+            calendar.filter_by_month(13)
+
+    def test_next_holiday(self):
+        """next_holiday is exclusive of the given day."""
+        calendar = _calendar()
+        upcoming = calendar.next_holiday(date(2026, 1, 1))
+        assert upcoming is not None
+        assert upcoming.holiday_date.date() == date(2026, 1, 2)
+
+    def test_next_holiday_returns_none_past_year_end(self):
+        """The calendar only covers its own year."""
+        calendar = _calendar()
+        assert calendar.next_holiday(date(2026, 12, 31)) is None
+
+    def test_next_holiday_is_order_independent(self):
+        """Correct even if the API stops returning sorted data."""
+        shuffled = list(reversed(SAMPLE_EN))
+        calendar = _calendar(shuffled)
+        upcoming = calendar.next_holiday(date(2026, 1, 1))
+        assert upcoming is not None
+        assert upcoming.holiday_date.date() == date(2026, 1, 2)
+
+    def test_empty_calendar(self):
+        """An empty holiday list is valid and answers everything negatively."""
+        calendar = HolidayCalendar(year=2026, lang="en", holidays=[])
+        assert calendar.count == 0
+        assert calendar.dates == []
+        assert calendar.is_holiday(date(2026, 1, 1)) is False
+        assert calendar.next_holiday(date(2026, 1, 1)) is None
+
+
+# --- service ----------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHolidayService:
+    """Tests for HolidayService."""
+
+    async def test_init_default_config(self):
+        """Default config keeps use_session=True (this host is behind Incapsula)."""
+        service = HolidayService()
+        assert service.config.use_session is True
+        assert service.base_url == "https://www.set.or.th"
+
+    async def test_init_custom_config(self):
+        """A caller-supplied config is honored."""
+        config = FetcherConfig(max_retries=6, retry_delay=2.0)
+        service = HolidayService(config=config)
+        assert service.config.max_retries == 6
+
+    async def test_fetch_holidays_success(self, mock_fetcher):
+        """A successful fetch parses into a HolidayCalendar."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        calendar = await HolidayService().fetch_holidays(2026)
+
+        assert isinstance(calendar, HolidayCalendar)
+        assert calendar.year == 2026
+        assert calendar.lang == "en"
+        assert calendar.count == 20
+        assert calendar.holidays[0].description == "New Year's Day"
+
+    async def test_fetch_holidays_builds_expected_url(self, mock_fetcher):
+        """URL uses the /api/cms/v1/ prefix and ?lang= (not ?language=)."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        await HolidayService().fetch_holidays(2026, lang="th")
+
+        url = mock_fetcher.fetch.call_args.args[0]
+        assert url == "https://www.set.or.th/api/cms/v1/holidays/year/2026?lang=th"
+        assert "language=" not in url
+
+    async def test_fetch_holidays_uses_set_api_headers(self, mock_fetcher):
+        """Market-level services call the header helper with no arguments."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        await HolidayService().fetch_holidays(2026)
+
+        mock_fetcher.cls.get_set_api_headers.assert_called_once_with()
+
+    async def test_language_normalization(self, mock_fetcher):
+        """Language aliases are normalized before hitting the wire."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_TH)
+
+        calendar = await HolidayService().fetch_holidays(2026, lang="thai")  # type: ignore[arg-type]
+
+        assert calendar.lang == "th"
+        assert mock_fetcher.fetch.call_args.args[0].endswith("?lang=th")
+
+    async def test_invalid_language(self, mock_fetcher):
+        """An unrecognized language is rejected before any request is made."""
+        with pytest.raises(InvalidLanguageError):
+            await HolidayService().fetch_holidays(2026, lang="de")  # type: ignore[arg-type]
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_year_defaults_to_current_bangkok_year(self, mock_fetcher):
+        """Omitting the year resolves it from Asia/Bangkok, never system-local time."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        await HolidayService().fetch_holidays()
+
+        expected = datetime.now(BANGKOK_TZ).year
+        assert f"/holidays/year/{expected}?" in mock_fetcher.fetch.call_args.args[0]
+
+    async def test_normalize_year_resolves_none(self):
+        """_normalize_year(None) matches the Bangkok clock."""
+        assert HolidayService._normalize_year(None) == datetime.now(BANGKOK_TZ).year
+
+    @pytest.mark.parametrize("bad_year", [MIN_YEAR - 1, MAX_YEAR + 1, 0, -2026])
+    async def test_year_out_of_range(self, bad_year, mock_fetcher):
+        """Out-of-range years are a typo guard and never reach the network."""
+        with pytest.raises(ValueError, match="out of range"):
+            await HolidayService().fetch_holidays(bad_year)
+        mock_fetcher.fetch.assert_not_called()
+
+    @pytest.mark.parametrize("bad_year", [True, False, "2026", 2026.0])
+    async def test_year_must_be_int(self, bad_year, mock_fetcher):
+        """Non-int years (including bools, which are ints in Python) are rejected."""
+        with pytest.raises(ValueError, match="must be an integer"):
+            await HolidayService().fetch_holidays(bad_year)
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_fetch_holidays_raw(self, mock_fetcher):
+        """The raw tier returns the untouched list of dicts."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        data = await HolidayService().fetch_holidays_raw(2026)
+
+        assert isinstance(data, list)
+        assert data[0] == {"date": "2026-01-01T00:00:00+07:00", "description": "New Year's Day"}
+
+    async def test_empty_list_response(self, mock_fetcher):
+        """An empty array is a valid, empty calendar - not an error."""
+        mock_fetcher.fetch.return_value = _response([])
+
+        calendar = await HolidayService().fetch_holidays(2026)
+
+        assert calendar.count == 0
+
+
+@pytest.mark.asyncio
+class TestRetryBehaviour:
+    """The endpoint returns a bare 401 transiently, so the service retries."""
+
+    async def test_retries_transient_401_then_succeeds(self, mock_fetcher, no_sleep):
+        """A 401 followed by a 200 yields data rather than an exception."""
+        mock_fetcher.fetch.side_effect = [
+            _response(status_code=401, text=""),
+            _response(status_code=401, text=""),
+            _response(SAMPLE_EN),
+        ]
+        service = HolidayService(FetcherConfig(max_retries=3, retry_delay=0.1))
+
+        calendar = await service.fetch_holidays(2026)
+
+        assert calendar.count == 20
+        assert mock_fetcher.fetch.call_count == 3
+        assert no_sleep.await_count == 2
+
+    async def test_backoff_is_exponential(self, mock_fetcher, no_sleep):
+        """Successive retries wait retry_delay * 2**attempt."""
+        mock_fetcher.fetch.side_effect = [
+            _response(status_code=401, text=""),
+            _response(status_code=401, text=""),
+            _response(SAMPLE_EN),
+        ]
+        service = HolidayService(FetcherConfig(max_retries=3, retry_delay=1.0))
+
+        await service.fetch_holidays(2026)
+
+        assert [call.args[0] for call in no_sleep.await_args_list] == [1.0, 2.0]
+
+    async def test_retries_exhausted_raises_fetch_error(self, mock_fetcher, no_sleep):
+        """Persistent 401s surface as FetchError carrying the status code."""
+        mock_fetcher.fetch.return_value = _response(status_code=401, text="")
+        service = HolidayService(FetcherConfig(max_retries=2, retry_delay=0.1))
+
+        with pytest.raises(FetchError) as exc_info:
+            await service.fetch_holidays(2026)
+
+        assert exc_info.value.status_code == 401
+        assert mock_fetcher.fetch.call_count == 3
+        # 401 is the endpoint's only failure code, so the message must name both causes.
+        message = str(exc_info.value)
+        assert "only the current year is available" in message
+        assert "retry later" in message
+
+    async def test_non_retryable_status_raises_immediately(self, mock_fetcher, no_sleep):
+        """A 500 is not retried - it fails on the first attempt."""
+        mock_fetcher.fetch.return_value = _response(status_code=500, text="")
+        service = HolidayService(FetcherConfig(max_retries=3, retry_delay=0.1))
+
+        with pytest.raises(FetchError) as exc_info:
+            await service.fetch_holidays(2026)
+
+        assert exc_info.value.status_code == 500
+        assert mock_fetcher.fetch.call_count == 1
+        no_sleep.assert_not_awaited()
+        # The 401-specific hint must not be attached to unrelated statuses.
+        assert "current year" not in str(exc_info.value)
+
+    async def test_no_retry_when_max_retries_is_zero(self, mock_fetcher, no_sleep):
+        """max_retries=0 means exactly one attempt."""
+        mock_fetcher.fetch.return_value = _response(status_code=401, text="")
+        service = HolidayService(FetcherConfig(max_retries=0))
+
+        with pytest.raises(FetchError):
+            await service.fetch_holidays(2026)
+
+        assert mock_fetcher.fetch.call_count == 1
+        no_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestParseErrors:
+    """Malformed payloads surface as ResponseParseError."""
+
+    async def test_invalid_json(self, mock_fetcher):
+        """A non-JSON body is a parse error, not a crash."""
+        mock_fetcher.fetch.return_value = _response(text="<html>nope</html>")
+
+        with pytest.raises(ResponseParseError, match="2026"):
+            await HolidayService().fetch_holidays(2026)
+
+    async def test_non_list_payload(self, mock_fetcher):
+        """A dict where an array was expected is rejected by validate_list_or_raise."""
+        mock_fetcher.fetch.return_value = _response({"holidays": []})
+
+        with pytest.raises(ResponseParseError, match="Expected a JSON array"):
+            await HolidayService().fetch_holidays(2026)
+
+
+# --- convenience function ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestConvenienceFunction:
+    """Tests for the get_holidays convenience function."""
+
+    async def test_get_holidays(self, mock_fetcher):
+        """The one-liner returns the same HolidayCalendar."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+
+        calendar = await get_holidays(2026)
+
+        assert isinstance(calendar, HolidayCalendar)
+        assert calendar.count == 20
+
+    async def test_get_holidays_thai(self, mock_fetcher):
+        """Thai descriptions survive the round trip."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_TH)
+
+        calendar = await get_holidays(2026, lang="th")
+
+        assert calendar.lang == "th"
+        assert calendar.holidays[0].description == "วันขึ้นปีใหม่"
+
+    async def test_get_holidays_honors_config(self, mock_fetcher):
+        """A custom config reaches the underlying fetcher."""
+        mock_fetcher.fetch.return_value = _response(SAMPLE_EN)
+        config = FetcherConfig(timeout=99)
+
+        await get_holidays(2026, config=config)
+
+        assert mock_fetcher.cls.call_args.kwargs["config"].timeout == 99

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

Adds the **21st service**: the official **SET market holiday calendar** for a year, in English or
Thai (`GET /api/cms/v1/holidays/year/{year}?lang=`). It answers *"is the market closed on date X?"*
without downstream code hardcoding Thai public holidays. Ships as **v0.15.0**.

Purely **additive** — no existing signature, model field, exception type, or behaviour changed.

```python
from datetime import date
from settfex.services.set import get_holidays

calendar = await get_holidays()          # current year, resolved in Asia/Bangkok
calendar.count                           # 20
calendar.is_holiday(date(2026, 1, 1))    # True
calendar.next_holiday()                  # next closure from today
calendar.filter_by_month(4)              # the Songkran cluster
```

## Changes

| # | Change |
|---|---|
| 1 | **`settfex/services/set/holiday.py`** — standard three tiers: `get_holidays()` → `HolidayService.fetch_holidays()` → `fetch_holidays_raw()`. Template was `index/list.py` (market-level, bare JSON array → container model). |
| 2 | **`Holiday`** — `holiday_date` (tz-aware, always `+07:00`, `00:00:00` time component, aliased from the API's `date` key) and `description`. |
| 3 | **`HolidayCalendar`** — container with `count`, `dates`, `is_holiday()`, `get_holiday()`, `filter_by_month()`, `next_holiday()`. Query methods accept a `date` or `datetime` (naive = Bangkok-local, aware = converted) and don't depend on payload ordering. |
| 4 | `year` defaults to the current year in **Asia/Bangkok**, never system-local time. The client-side range (1975–2100) is a **typo guard only**, kept permissive so a future next-year calendar wouldn't be rejected locally. |
| 5 | New `SET_HOLIDAY_ENDPOINT`; `get_holidays` + `HolidayCalendar` re-exported from the top-level package. |
| 6 | Docs page, notebook `17_holiday.ipynb`, `CLAUDE.md` inventory (20→21 / SET 16→17, table row, project tree, 5 new Known Gotchas), CHANGELOG, README. Also fixes `examples/README.md`, which was **stale by five notebooks** ("all 11 SET services", "Total: 12"). |

## ⚠️ Live-probed API limits (2026-07-27)

These are the non-obvious part, and are recorded in the module docstring, the docs page and
`CLAUDE.md` Known Gotchas:

| Limit | Evidence |
|---|---|
| **Only the current year is served** | With 2026 returning HTTP 200 on **all 3** interleaved control requests, **2024, 2025, 2027 and 2028 all returned 401**. No history for backtests, no next-year lookahead. |
| **HTTP 401 is the only failure code, and it's ambiguous** | An unrecognized `lang`, a missing `lang`, and an unserved year all return a bare 401 with an *empty body* — and so do valid requests, *transiently*. Success degrades under polling (~100% cold → ~35% after ~50 requests → ~12% after ~150) and recovers when idle. The `FetchError` message names both causes. |
| **`is_holiday()` ≠ "market open"** | The API returns published closures only — weekends are absent, and only whole-day closures are expressed (no partial sessions or altered hours). |

## Two deliberate deviations from repo convention

Both are commented in place, because each looks like a mistake otherwise:

1. **`Holiday` does not enable `str_strip_whitespace`** (every other SET model does). A trailing
   `" *"` is a SET footnote marker on additional special closures and must survive verbatim — e.g.
   `"Additional special holiday *"` on 2026-10-16. A test guards this.
2. **The service retries `401`/`403`/`429` itself** with exponential backoff, driven by the
   *existing* `FetcherConfig.max_retries`/`retry_delay` rather than a new knob.
   `AsyncDataFetcher.fetch()` retries **exceptions only, never a non-2xx status**
   (`data_fetcher.py:328-394`), so without this a transient 401 became a hard `FetchError`.
   Deliberately kept local to `holiday.py` — fixing it centrally would change behaviour for all 20
   existing services and is filed as a follow-up instead.

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy settfex/` passes
- [x] `uv run pytest` passes — **571 tests** (46 new), coverage **83.8%** overall / **97%** on `holiday.py`
- [x] New behavior covered by tests, all external API calls mocked (suite runs offline)
- [x] Docs / docstrings / `CHANGELOG.md` updated

Fixtures are the **real captured 2026 payloads** (en + th, 20 entries each, 1:1 aligned), including
the `" *"` footnote marker and the Buddhist-era parenthetical notes
(`"ชดเชยวันวิสาขบูชา (วันอาทิตย์ที่ 31 พฤษภาคม 2569)"`).

Retry behaviour is covered explicitly: retry-then-succeed, retries-exhausted → `FetchError`,
non-retryable status (500) failing on the first attempt without sleeping, and `max_retries=0`.

## Verification (live)

Local verification script green **5/5** against the real API in both languages — English and Thai
fetches, the container query helpers, the raw tier, the Bangkok-year default, and the year typo
guard. Top-level import smoke:

```
version: 0.15.0
top-level get_holidays -> HolidayCalendar, 20 holidays, year=2026
is_holiday(2026-01-01): True
verbatim * marker preserved: ['Additional special holiday *']
```

## Compatibility

Fully backward-compatible: new module, new exports, new constant only. Nothing existing is
modified. Version bumped to 0.15.0 across `pyproject.toml`, `settfex/__init__.py` and `uv.lock`
(`uv lock --check` passes, so CI's `uv sync --frozen` gate is satisfied).

## Follow-ups (not in this PR)

- **A trading-calendar layer (`is_trading_day`, `next_trading_day`, …) is blocked by the API**, not
  by effort: with only the current year served there's no history and no year-boundary lookahead,
  so `next_trading_day(2026-12-31)` is unanswerable. Needs a decision on where other years come
  from first.
- Central status-aware retry in `AsyncDataFetcher` (affects all services).
- Payload caching — `SessionCache` could back it, but no data service caches payloads today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
