### PR TITLE
fix(sec): accept any Sequence of download targets; restore green `mypy .`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SEC downloads now accept a plain `list[SecDocument]`** — `DocumentDownloadService.download_all`,
+  `SecCompany.download_all` and `download_sec_documents` typed `targets` as
+  `list[SecDocument | str]`, which (because `list` is invariant) rejected the output of
+  `list_documents()` under a type checker — i.e. the documented
+  `docs = await sec.list_documents(...)` → `sec.download_all(docs)` flow was a type error for
+  every typed consumer, despite working fine at runtime. `targets` is now
+  `Sequence[SecDocument | str]`; the parameter only widens, so existing callers are unaffected.
+
+### Internal
+
+- `uv run mypy .` is green again across all 125 files (package, `tests/`, local `scripts/`). It had
+  been failing on stale `CompanyMatch(...)` constructions in `tests/services/sec/` that predate the
+  model's required `company_name` / `unique_id` fields, plus one `in` test against the optional
+  `SecDocument.file_id`. The CI gate is narrower (`mypy settfex/`), so this never showed up there.
+- Dev-dependency bumps: mypy 1.18.2 → 2.3.0, matplotlib 3.10.6 → 3.11.1, notebook 7.4.7 → 7.6.0,
+  tqdm 4.68.3 → 4.69.0 (lockfile only — no `pyproject.toml` constraint changes).
+
 ## [0.15.0] - 2026-07-27
 
 ### Added

--- a/settfex/services/sec/download.py
+++ b/settfex/services/sec/download.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -190,7 +191,7 @@ class DocumentDownloadService:
 
     async def download_all(
         self,
-        targets: list[SecDocument | str],
+        targets: Sequence[SecDocument | str],
         *,
         dest_dir: str | Path | None = None,
         max_concurrency: int = 3,
@@ -205,7 +206,9 @@ class DocumentDownloadService:
         Company and Consolidated rows share one zip), so the result has one entry per unique file.
 
         Args:
-            targets: SecDocuments / URLs / FILEIDs to download (deduped by resolved URL).
+            targets: SecDocuments / URLs / FILEIDs to download (deduped by resolved URL). Any
+                sequence is accepted, so a ``SecDocumentList`` / ``list[SecDocument]`` straight
+                from :meth:`list_documents` can be passed as-is.
             dest_dir: If set, each file is written here (created if needed).
             max_concurrency: Max simultaneous downloads (default 3 — big files share bandwidth).
             continue_on_error: If True (default) a failed item is logged and skipped; if False
@@ -305,7 +308,7 @@ async def download_sec_document(
 
 
 async def download_sec_documents(
-    targets: list[SecDocument | str],
+    targets: Sequence[SecDocument | str],
     *,
     dest_dir: str | Path | None = None,
     max_concurrency: int = 3,

--- a/settfex/services/sec/sec.py
+++ b/settfex/services/sec/sec.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
 
@@ -112,7 +113,7 @@ class SecCompany:
 
     async def download_all(
         self,
-        targets: list[SecDocument | str],
+        targets: Sequence[SecDocument | str],
         *,
         dest_dir: str | Path | None = None,
         max_concurrency: int = 3,

--- a/tests/services/sec/test_company.py
+++ b/tests/services/sec/test_company.py
@@ -20,13 +20,16 @@ def _patch_company_fetcher(payload):
 
 class TestCompanyMatchModel:
     def test_aliases(self) -> None:
-        m = CompanyMatch(Text="CP ALL", Value="0000003875", Flag=True)
+        # Constructed by alias (as the API payload arrives) — model_validate rather than
+        # CompanyMatch(Text=...) so the alias path stays exercised AND type-checks: the
+        # pydantic mypy plugin types __init__ by field name, not by alias.
+        m = CompanyMatch.model_validate({"Text": "CP ALL", "Value": "0000003875", "Flag": True})
         assert m.company_name == "CP ALL"
         assert m.unique_id == "0000003875"
         assert m.is_primary is True
 
     def test_flag_defaults_false(self) -> None:
-        m = CompanyMatch(Text="X", Value="1")
+        m = CompanyMatch.model_validate({"Text": "X", "Value": "1"})
         assert m.is_primary is False
 
 

--- a/tests/services/sec/test_financial_report.py
+++ b/tests/services/sec/test_financial_report.py
@@ -214,7 +214,7 @@ class TestFinancialReportService:
             )
         assert len(full) == 3  # ViewMore replaces the single truncated inline row
         assert len(trunc) == 1
-        assert all("full_" in d.file_id for d in full)
+        assert all(d.file_id and "full_" in d.file_id for d in full)
 
     @pytest.mark.asyncio
     async def test_missing_viewstate_raises(self) -> None:
@@ -273,7 +273,9 @@ class TestGetSecDocuments:
             patch(
                 "settfex.services.sec.financial_report.resolve_company",
                 new=AsyncMock(
-                    return_value=CompanyMatch(Text="CP ALL", Value="0000003875", Flag=True)
+                    return_value=CompanyMatch(
+                        company_name="CP ALL", unique_id="0000003875", is_primary=True
+                    )
                 ),
             ),
             patch("settfex.services.sec.financial_report.AsyncDataFetcher") as cls,

--- a/tests/services/sec/test_sec.py
+++ b/tests/services/sec/test_sec.py
@@ -11,7 +11,9 @@ from settfex.services.sec.sec import SecCompany
 
 pytestmark = pytest.mark.asyncio
 
-_MATCH = CompanyMatch(Text="CP ALL PUBLIC COMPANY LIMITED", Value="0000003875", Flag=True)
+_MATCH = CompanyMatch(
+    company_name="CP ALL PUBLIC COMPANY LIMITED", unique_id="0000003875", is_primary=True
+)
 
 
 class TestResolve:


### PR DESCRIPTION
## Why

Two independent problems, both invisible to CI because the lint gate is
`mypy settfex/` (package only) while `CLAUDE.md` tells developers to run `uv run mypy .`.
That broader command had been **failing on `main`** — 10 errors across 4 files.

### 1. `list` invariance made the documented download flow a type error

`DocumentDownloadService.download_all`, `SecCompany.download_all` and
`download_sec_documents` all typed `targets` as `list[SecDocument | str]`. Since `list`
is invariant, a `list[SecDocument]` is **not** an acceptable argument — and
`list_documents()` returns exactly that (`SecDocumentList`, a `list[SecDocument]` subclass).

So the flow in `sec.py`'s own module docstring, and in the `CLAUDE.md` usage example,
did not type-check for any typed consumer:

```python
docs = await sec.list_documents(types="financial_statement", from_date="01/01/2025")
files = await sec.download_all(docs, dest_dir="./out")   # error: arg-type
```

It worked fine at runtime — this was purely a signature that was narrower than the
implementation. `targets` is now `Sequence[SecDocument | str]`, which is what mypy
itself suggested. The body only iterates and calls `len()`, both satisfied by
`Sequence`, and **the parameter only widens** — every existing caller, including ones
passing `list[SecDocument | str]`, still checks.

### 2. Stale test constructions

- `CompanyMatch(Text=..., Value=...)` predates the model's now-required `company_name` /
  `unique_id` fields. The pydantic mypy plugin types `__init__` by field name, not by
  alias, so alias-kwarg construction can never type-check.
  - In `test_company.py`, where alias mapping **is** the thing under test, switched to
    `CompanyMatch.model_validate({"Text": ...})` — same alias code path, still type-clean.
    Using field names there would have gutted the test.
  - In `test_financial_report.py` / `test_sec.py`, where the alias is incidental to
    building a mock return value, switched to field names.
- `"full_" in d.file_id` is now None-safe, since `SecDocument.file_id` is `str | None`.

## Note on scope

The `scripts/` error is fixed in `settfex/` source rather than in the script.
`scripts/` is gitignored and untracked (`.gitignore:205`), so a fix there would be
local-only, and the error was a real public-API bug rather than a script bug.

## Verification

```
uv run ruff check .          # All checks passed!
uv run ruff format --check . # 123 files already formatted
uv run mypy settfex/         # Success: 52 source files  (the CI gate)
uv run mypy .                # Success: 125 source files (was: 10 errors in 4 files)
uv run pytest                # 571 passed, 84% coverage
```

Backward compatibility of the widened signature was checked explicitly against four
call shapes — `SecDocumentList`, `list[SecDocument]`, `list[str]` and the original
`list[SecDocument | str]` — all type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
