### PR TITLE
chore(ci): bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
     name: Lint & Type
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true
@@ -52,9 +53,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true
@@ -67,7 +69,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
           flags: unittests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       is_prerelease: ${{ steps.parse.outputs.is_prerelease }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Parse tag and detect pre-release
         id: parse
@@ -60,9 +60,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true
@@ -83,9 +84,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true
@@ -97,7 +99,7 @@ jobs:
       - name: Verify dist contents
         run: ls -lh dist/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -113,7 +115,7 @@ jobs:
       url: https://pypi.org/project/settfex/${{ needs.validate.outputs.version }}/
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -133,9 +135,9 @@ jobs:
     if: always() && needs.validate.result == 'success' && needs.publish-pypi.result != 'failure'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -155,7 +157,7 @@ jobs:
           PYEOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "settfex v${{ needs.validate.outputs.version }}"
           body_path: release_notes.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,9 +17,10 @@ jobs:
     name: Bandit (static analysis)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true
@@ -34,7 +35,7 @@ jobs:
 
       - name: Upload Bandit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-results
           path: bandit-results.json
@@ -44,9 +45,10 @@ jobs:
     name: pip-audit (dependency CVEs)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      # setup-uv stopped publishing floating major tags at v8 — pin the exact version.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
           enable-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SecDocument.file_id`. The CI gate is narrower (`mypy settfex/`), so this never showed up there.
 - Dev-dependency bumps: mypy 1.18.2 → 2.3.0, matplotlib 3.10.6 → 3.11.1, notebook 7.4.7 → 7.6.0,
   tqdm 4.68.3 → 4.69.0 (lockfile only — no `pyproject.toml` constraint changes).
+- GitHub Actions bumped off the deprecated Node 20 runtime, which the runners had been
+  force-upgrading to Node 24: `actions/checkout` v4 → v7, `astral-sh/setup-uv` v5 → v9.0.0,
+  `codecov/codecov-action` v4 → v7, `actions/upload-artifact` v4 → v7,
+  `actions/download-artifact` v4 → v8, `softprops/action-gh-release` v2 → v3.
+  `pypa/gh-action-pypi-publish` stays on the rolling `release/v1` branch (upstream's
+  recommended pin). `setup-uv` is pinned to an exact version because it stopped publishing
+  floating major tags at v8 — `@v9` does not resolve.
 
 ## [0.15.0] - 2026-07-27
 


### PR DESCRIPTION
## Why

Every CI run has been emitting:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on
> Node.js 24: `actions/checkout@v4`, `astral-sh/setup-uv@v5`, `codecov/codecov-action@v4`

The runners are papering over it for now, but that fallback is temporary. This bumps all six
actions to current majors.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `astral-sh/setup-uv` | v5 | **v9.0.0** |
| `codecov/codecov-action` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `softprops/action-gh-release` | v2 | **v3** |
| `pypa/gh-action-pypi-publish` | `release/v1` | *unchanged* — rolling branch is upstream's recommended pin |

## ⚠️ `setup-uv` is pinned exactly, not floating

`astral-sh/setup-uv` **stopped publishing major/minor tags at v8.0.0**, so `@v9` does not resolve —
only `@v9.0.0` exists. Pinning the exact version is mandatory here, not a style choice. A comment
in each workflow records why, so nobody "tidies" it back to `@v9` later.

This also means Dependabot's `github-actions` ecosystem will propose exact-version bumps for this
one action going forward, rather than the usual major-tag bumps.

## Breaking changes, checked against the inputs we actually pass

- **checkout v7** — blocks checking out fork PRs for `pull_request_target` / `workflow_run`. We use
  neither trigger, and pass no inputs at all.
- **setup-uv v9** — flips the `prune-cache` default to `false` (bigger cache, less load on PyPI
  infra). Fine for a public repo well under the 10 GB cache limit. All three inputs we pass
  (`version`, `enable-cache`, `cache-dependency-glob`) still exist in v9.0.0's `action.yml`.
- **codecov v5** — renamed `file` → `files`. We already use `files`.
- **download-artifact v5** — the breaking path change applies to downloads **by ID**; we download by
  `name`. **v8** additionally makes a digest mismatch a hard error rather than a warning, which is
  what you want in a pipeline that publishes to PyPI.
- **upload-artifact v7** — the new `archive` input is opt-in; our inputs are untouched.
- **action-gh-release v3** — Node 24 runtime move, no input changes.

## Verification

`release.yml` only runs on a **tag push**, so PR CI cannot exercise it — the artifact and
GitHub-Release steps would otherwise go unvalidated until the next release. To close that gap I
checked every `with:` key across all 21 steps against each action's declared inputs at the new ref:

```
OK  release/build:          actions/upload-artifact@v7    with=[if-no-files-found, name, path]
OK  release/publish-pypi:   actions/download-artifact@v8  with=[name, path]
OK  release/publish-pypi:   pypa/gh-action-pypi-publish@release/v1  with=[skip-existing]
OK  release/github-release: softprops/action-gh-release@v3
                            with=[body_path, files, make_latest, name, prerelease]
...  (21/21 OK)
```

All three workflows were also confirmed to still parse with their jobs intact
(`ci`: lint/test · `release`: validate/ci/build/publish-pypi/github-release · `security`:
bandit/pip-audit). The diff itself is version bumps plus one repeated explanatory comment —
no logic, trigger, or input changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
