### PR TITLE
feat(set): add asset types and DR TradingView indicative price (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-03
+
+### Added
+
+- **Asset-type classification** — new `AssetType` StrEnum (`stock`, `stock_foreign`,
+  `preferred_stock`, `preferred_stock_foreign`, `warrant`, `dw`, `etf`, `unit_trust`, `dr`,
+  `unknown`) mapping SET's `securityType` codes (`S/F/P/Q/W/V/L/U/X`, live-probed
+  2026-08-03), exposed as `StockProfile.asset_type` and `StockSymbol.asset_type` properties,
+  a `StockListResponse.filter_by_asset_type()` helper (accepts the enum, its value, or a raw
+  SET code), and a cached `Stock.get_asset_type()` accessor. Unrecognized codes degrade to
+  `AssetType.UNKNOWN` (never raises). There is deliberately no `BOND` member — bonds do not
+  appear in SET's stock APIs at all.
+- **DR profile service** (`stock/profile_dr.py`) — `GET /api/set/dr/{symbol}/profile` for
+  Depositary Receipts (GOOG80, MICRON01, …): issuer/underlying details, verbatim conversion
+  ratio, DRx `fractionalTrade` flag, and the TradingView **"Indicative Price"** link
+  (`indicativePriceSymbol` expression + `indicativePriceUrl`). `DrProfile.indicative_expression`
+  parses the expression and recovers it from the URL's `symbol` query param when the symbol
+  field is null (observed for HERMES80/BYDCOM80/NDX01). New `Stock.get_dr_profile()` (cached
+  per language) and `Stock.get_tradingview_url()` (`None` for non-DRs). Non-DR symbols get
+  HTTP 404 `Invalid DR` → `SymbolNotFoundError` without a "did you mean?" suggestion (the
+  endpoint 404s for valid non-DR symbols, so a suggestion would echo the symbol back).
+- **DR indicative price from TradingView** (`stock/dr_indicative_price.py`) — evaluates the
+  DR's fair-value expression (`underlying × FX ÷ ratio`, in THB) with ONE batch
+  `POST scanner.tradingview.com/global/scan` for all legs. The `close` column is the last
+  price (~15-min delayed for exchange legs, streaming for FX); the host is stateless and is
+  never routed through SessionManager. New models `TradingViewQuote`, `DrIndicativePrice`
+  (legs, ratio, `is_delayed`, aware-Bangkok `as_of`) and `DrIndicativeQuotation` (a
+  `Quotation` subclass carrying `.indicative` provenance); `get_dr_indicative_price()`
+  convenience and `Stock.get_indicative_price()`.
+
 ### Changed
 
+- **`Stock.get_latest_price()` is now DR-aware** — for DR symbols it returns the TradingView
+  indicative price as a `DrIndicativeQuotation` (its `price` is the fair value; `volume`,
+  `value`, `change`, `percent_change` are `None` since nothing traded), falling back to SET
+  chart data on any TradingView failure. Non-DR symbols are unchanged (first call per `Stock`
+  instance adds one cached DR-profile probe). Opt out per call with
+  `prefer_dr_indicative=False`; passing an explicit `as_of` always uses the SET chart path
+  (TradingView cannot answer historical instants).
 - **`DocumentCategory` is now an `enum.StrEnum`** (was `class DocumentCategory(str, Enum)`).
   The observable difference is string coercion: `str(cat)` and `f"{cat}"` now render the bare
   value (`"financial_statement"`) instead of `"DocumentCategory.FINANCIAL_STATEMENT"`, and a
@@ -28,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A non-DR symbol no longer logs an `ERROR` on its first `get_latest_price()`** — the DR probe
+  behind the auto-switch asks `/api/set/dr/{symbol}/profile`, which answers every non-DR symbol
+  with HTTP 404. That 404 is routine control flow ("not a DR"), so it is now logged at `debug`;
+  other non-2xx statuses still log at `error`. Without this, every ordinary stock cried wolf in
+  the logs once per `Stock` instance.
 - **SEC downloads now accept a plain `list[SecDocument]`** — `DocumentDownloadService.download_all`,
   `SecCompany.download_all` and `download_sec_documents` typed `targets` as
   `list[SecDocument | str]`, which (because `list` is invariant) rejected the output of
@@ -55,6 +97,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pypa/gh-action-pypi-publish` stays on the rolling `release/v1` branch (upstream's
   recommended pin). `setup-uv` is pinned to an exact version because it stopped publishing
   floating major tags at v8 — `@v9` does not resolve.
+
+### Documentation
+
+- New service docs `docs/settfex/services/set/profile_dr.md` and `dr_indicative_price.md`, plus a
+  new executed example notebook `examples/set/18_dr_and_asset_type.ipynb` (asset-type
+  classification, DR profiles, the TradingView URL, and the indicative-price arithmetic).
+  README, `examples/README.md`, `examples/set/README.md` and `13_chart_quotation.ipynb` now cover
+  the new services and the DR behavior of `Stock.get_latest_price()`.
+- Corrected two pre-existing doc errors found while auditing: the README chart-quotation snippet
+  called `Quotation.close`, which does not exist (the field is `price`), and `CLAUDE.md` advertised
+  `stock.get_balance_sheet()`, a method the `Stock` class has never had.
 
 ## [0.15.0] - 2026-07-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ settfex/
 ├── settfex/                    # Main package
 │   ├── services/              # Business logic and API integrations
 │   │   ├── set/              # SET-specific services
-│   │   │   ├── constants.py, list.py, earnings_call.py, news.py, holiday.py
+│   │   │   ├── constants.py, list.py, earnings_call.py, news.py, holiday.py,
+│   │   │   │   asset_type.py (AssetType StrEnum ← securityType codes)
 │   │   │   ├── index/        # Market index services: list, info (quotation),
 │   │   │   │                 #   composition (constituents), chart_quotation,
 │   │   │   │                 #   index.py (SetIndex facade), utils.py
@@ -25,7 +26,9 @@ settfex/
 │   │   │                     #   profile_company, corporate_action, shareholder,
 │   │   │                     #   nvdr_holder, board_of_director, trading_stat,
 │   │   │                     #   price_performance, chart_quotation,
-│   │   │                     #   latest_historical_trading, financial/, stock.py, utils.py
+│   │   │                     #   latest_historical_trading, profile_dr,
+│   │   │                     #   dr_indicative_price (TradingView), financial/,
+│   │   │                     #   stock.py, utils.py
 │   │   ├── tfex/             # TFEX services: list.py, trading_statistics.py, underlying_price.py
 │   │   └── sec/              # SEC IDISC (market.sec.or.th) document services: constants.py,
 │   │                         #   company.py, financial_report.py, download.py, sec.py, utils.py
@@ -118,9 +121,9 @@ data = await get_highlight_data("CPALL")   # or convenience function
 all_stocks = await get_stock_list()        # no cookie params needed
 ```
 
-## Services Inventory (21 total)
+## Services Inventory (23 total)
 
-### SET Services (17)
+### SET Services (19)
 
 | # | Service | Module | Endpoint Pattern | Key Data |
 |---|---|---|---|---|
@@ -141,6 +144,13 @@ all_stocks = await get_stock_list()        # no cookie params needed
 | 15 | Market Index | `index/{list,info,composition,chart_quotation,index}.py` | `/api/set/index/list`, `/api/set/index/info/list`, `/api/set/index/{sym}/info`, `/api/set/index/{sym}/composition`, `/api/set/index/{sym}/chart-quotation` | 55-index directory (INDEX/INDUSTRY/SECTOR levels; mai industries use `-m` query symbols); page-header quotes (last/chg/%chg/OHLC/vol/value/marketStatus/tz-aware timestamp); constituents w/ full quote rows incl. bid/offer (string prices coerced); `SetIndex` facade + `get_index_latest_price()` (reuses stock ChartQuotation); index symbols keep casing (`sSET`, `AGRO-m`); `SET`/`mai` have no composition (404 w/ helpful error). |
 | 16 | News | `news.py` | `/api/set/news/search` | Company news/disclosures for **all stocks** in one call (default `sourceId=company`, latest-trading-day window); filters: `symbol`, `fromDate`/`toDate` (**dd/MM/yyyy only** — ISO → HTTP 400; validated eagerly via `InvalidDateError`), `keyword`, `source_id` (`None` = all sources; unrecognized values silently ignored by the API), en/th; helpers `count`/`filter_today()`/`filter_by_tag()`/`filter_by_symbol()`; `Stock.get_news()` accessor; no pagination — keep date windows modest |
 | 17 | Market Holidays | `holiday.py` | `/api/cms/v1/holidays/year/{year}` | Official SET market-closure calendar for a year (en/th): tz-aware `+07:00` dates + verbatim descriptions (trailing `" *"` = SET footnote, never stripped). `HolidayCalendar` container with `count`/`dates`/`is_holiday()`/`get_holiday()`/`filter_by_month()`/`next_holiday()`; `year=None` → current **Asia/Bangkok** year. **Only the current year is served** (2024/2025/2027/2028 → HTTP 401); 401 is the endpoint's *only* failure code and also fires transiently, so the service retries 401/403/429 via `FetcherConfig.max_retries`/`retry_delay`. Holidays only — **weekends are not in the payload** |
+
+| 18 | DR Profile | `stock/profile_dr.py` | `/api/set/dr/{sym}/profile` | Depositary Receipt details: issuer, underlying (symbol/name/exchange/url), conversion ratio (verbatim `"2,000 : 1"`), `fractionalTrade` (DRx), trading session, and the **TradingView "Indicative Price" link** — `indicativePriceSymbol` expression (e.g. `NASDAQ:GOOG*FX_IDC:USDTHB/2000.0`; sometimes null) + `indicativePriceUrl` (always present; expression recoverable from its `symbol` query param via `DrProfile.indicative_expression`). Non-DR symbols → 404 `Invalid DR` → `SymbolNotFoundError` w/ **no** suggestion. `Stock.get_dr_profile()` (cached per lang) / `get_tradingview_url()` (None for non-DR) |
+| 19 | DR Indicative Price | `stock/dr_indicative_price.py` | `POST scanner.tradingview.com/global/scan` (stateless foreign host) | DR fair value in THB: evaluates the expression (`product of leg closes ÷ ratio`) with ONE batch scan for all legs; `close` column = last price (~15-min delayed for exchange legs, streaming FX); `DrIndicativePrice` (legs/ratio/`is_delayed`/aware-Bangkok `as_of`) + `DrIndicativeQuotation` (a `Quotation` subclass, `volume=None`); **`Stock.get_latest_price()` auto-returns this for DRs** (opt-out `prefer_dr_indicative=False`; explicit `as_of` forces SET path; any failure falls back to SET chart data); `get_dr_indicative_price()` |
+
+### AssetType classification (`asset_type.py`)
+
+`AssetType` StrEnum + `AssetType.from_security_type(code)` map SET's `securityType` codes to friendly types (live-probed 2026-08-03): `S`→stock (930), `F`→stock_foreign (864), `P`→preferred_stock (8), `Q`→preferred_stock_foreign (8), `W`→warrant (85), `V`→dw (1651), `L`→etf (13), `U`→unit_trust (2), `X`→dr (493); anything else → `unknown` (never raises). Exposed as `StockProfile.asset_type` / `StockSymbol.asset_type` properties, `StockListResponse.filter_by_asset_type()`, and `Stock.get_asset_type()` (one profile fetch, cached per instance). **No `BOND` member** — bonds do not appear in SET's stock APIs.
 
 ### TFEX Services (3)
 
@@ -164,11 +174,17 @@ Single entry point for SET stock data — initialize with symbol, access all ser
 stock = Stock("CPALL")
 highlight = await stock.get_highlight_data()
 profile = await stock.get_profile()
-financials = await stock.get_balance_sheet()
-latest = await stock.get_latest_price()    # latest traded price vs now
+latest = await stock.get_latest_price()    # latest traded price vs now (DRs: TradingView indicative)
 news = await stock.get_news()              # company news/disclosures for this symbol
-# ... all stock services accessible
+asset = await stock.get_asset_type()       # AssetType: stock/etf/dr/dw/warrant/... (cached)
+# DR symbols only (e.g. Stock("GOOG80")):
+dr = await stock.get_dr_profile()          # issuer/underlying/ratio + TradingView link (cached)
+url = await stock.get_tradingview_url()    # "Indicative Price" chart URL (None for non-DR)
+ind = await stock.get_indicative_price()   # underlying x FX / ratio via TradingView
 ```
+Not every service has a `Stock` accessor yet — financial statements, trading stats, price
+performance, corporate actions, NVDR holders and the board list are reached through their
+module-level `get_*()` functions (e.g. `await get_balance_sheet("CPALL")`).
 
 ### Unified SetIndex Class (`index/index.py`)
 Same pattern for market indices:
@@ -273,6 +289,11 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full, versioned release history — t
 - **`DocumentCategory` is a `StrEnum`, deliberately — do not "restore" `(str, Enum)`:** ruff 0.15+ rejects the `(str, Enum)` pattern via `UP042`. As a `StrEnum`, `str(cat)` / `f"{cat}"` give the bare value (`"financial_statement"`), **not** `"DocumentCategory.FINANCIAL_STATEMENT"` — use `cat.name` or `repr(cat)` if you need the qualified form. Equality with the plain string, `.value`, JSON output and all `SecDocumentList` helpers are unaffected (tests guard this). Note `years_by_category()` keys on `.value` on purpose, which is why `summary()` never depended on the enum's `__str__`.
 - **The uv version in CI is pinned by hand — Dependabot will not bump it:** all six `astral-sh/setup-uv` steps pass `version: "0.11.33"` instead of `"latest"`, so a uv release cannot silently change a build (this matters most in `release.yml`, which builds the published artifact). Dependabot's `github-actions` ecosystem bumps the *action ref*, never an action *input*, so this pin only moves when someone edits it. Note pinning does **not** make setup-uv network-free: on a GitHub-hosted runner uv is not in the tool cache, so `getArtifact` still fetches `raw.githubusercontent.com/astral-sh/versions` for the download URL — a fetch that has been observed to fail transiently. Re-run the job when it does.
 - **Ruff 0.16+ formats Python code blocks inside Markdown by default:** upgrading the pinned ruff past 0.16.0 will want to reformat ~32 `.md` files (`CLAUDE.md`, `docs/`, `.github/instructions/`), collapsing the intentionally column-aligned inline comments in the code samples. Decide deliberately: either accept the churn or set `extend-exclude = ["*.md"]` under `[tool.ruff]`. The pin is currently below that (0.13.2).
+- **Classify asset types by `securityType` CODE, never by `securityTypeName`:** the API's own display name for code `Q` carries a typo ("Prefered Foreign Stocks"), and names are localizable. `AssetType.from_security_type()` maps codes case-insensitively and returns `UNKNOWN` for anything new (never raises). There is deliberately no `AssetType.BOND` — bonds appear nowhere in SET's stock APIs (no `/api/set/bond/list`, none in the stock list; live-probed 2026-08-03).
+- **The DR-profile endpoint 404s for perfectly valid non-DR symbols:** `/api/set/dr/{sym}/profile` answers ANY non-DR (even `CPALL`) with HTTP 404 `{"message":"Invalid DR"}` — so the service raises `SymbolNotFoundError` with `suggest=False`; letting the symbol suggester run would produce the absurd "'CPALL' not found — did you mean 'CPALL'?". A 404 here means "not a DR", not "unknown symbol".
+- **`indicativePriceSymbol` is sometimes null while `indicativePriceUrl` is not:** several DRs (HERMES80, BYDCOM80, NDX01 in live probes) return `indicativePriceSymbol: null` but still carry the full expression URL-encoded in `indicativePriceUrl`'s `symbol` query param. `DrProfile.indicative_expression` recovers it from the URL automatically — don't treat a null symbol field as "no expression".
+- **TradingView scanner is a stateless foreign host — and `lp` is a websocket-only column:** never route `scanner.tradingview.com` through SessionManager (auto-detect would mis-warm it as SET, and the batch scan is a POST, which persistent sessions don't support) — `DrIndicativePriceService` forces `use_session=False` for TV calls only. Over plain HTTP request the `close` column for the last price (~15-min delayed for exchange legs, `update_mode: delayed_streaming_900`; FX_IDC legs stream); `lp`/`lp_time`/`last_price` come back null. Unknown tickers return HTTP 200 with the row simply missing (the service raises `FetchError` for missing rows). Remember `AsyncDataFetcher.fetch()` retries exceptions only — the service checks the status explicitly.
+- **`Stock.get_latest_price()` is DR-aware by default:** for DRs it returns a `DrIndicativeQuotation` (TradingView indicative price; `volume`/`change` are `None` — it's a fair value, not a SET trade) and falls back to SET chart data on ANY TradingView failure. The switch only applies when `as_of is None` (TV can't answer historical instants); opt out per-call with `prefer_dr_indicative=False`. DR-ness is detected by one cached DR-profile probe per `Stock` instance (a 404 marks non-DR permanently for that instance; transient errors are never cached). Indicative vs SET-close divergence is EXPECTED (probe: 5.94 indicative vs 5.75 SET close after a US-session move) — not a bug.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ settfex/
 │                             #   session_cache.py, logging.py
 ├── tests/                     # Mirror of settfex/ with test_ prefix
 ├── docs/                      # Service docs, guides, solutions
-├── examples/                  # 21 Jupyter notebooks (17 SET + 3 TFEX + 1 SEC)
+├── examples/                  # 22 Jupyter notebooks (18 SET + 3 TFEX + 1 SEC)
 ├── scripts/                   # Verification scripts per service
 ├── .github/                   # CI and agent instructions
 ├── pyproject.toml             # uv-based config

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This includes pandas, matplotlib, and jupyter notebook support.
 - [Stock List](examples/set/01_stock_list.ipynb) → [Highlight Data](examples/set/02_highlight_data.ipynb) → [Price Performance](examples/set/10_price_performance.ipynb) → [Financial Statements](examples/set/11_financial.ipynb)
 
 **Professional Trading :** Master all features for institutional use:
-- All 17 SET notebooks + TFEX notebooks (see below)
+- All 18 SET notebooks + TFEX notebooks (see below)
 
 ### 📊 SET Examples (Stock Exchange of Thailand)
 
@@ -62,6 +62,7 @@ All examples include beginner explanations, professional trading use cases, and 
 15. **[Market Index](examples/set/15_market_index.ipynb)** - Index directory, SET50/SETESG quotations, constituents, and index membership per stock
 16. **[SET News](examples/set/16_news.ipynb)** - Company news/disclosures for all stocks: symbol/date/keyword filters, Thai headlines
 17. **[Market Holidays](examples/set/17_holiday.ipynb)** - Official market-closure calendar: is the market open, next holiday, long weekends
+18. **[Asset Types & Depositary Receipts](examples/set/18_dr_and_asset_type.ipynb)** - Tell stocks/ETFs/DRs/DWs apart, DR profiles, and TradingView indicative prices
 
 ### 📈 TFEX Examples (Thailand Futures Exchange)
 
@@ -90,12 +91,14 @@ Want to dig deeper? Check out our detailed guides:
 - **[Trading Statistics Service](docs/settfex/services/set/trading_stat.md)** - Historical trading performance and metrics
 - **[Price Performance Service](docs/settfex/services/set/price_performance.md)** - Stock, sector, and market price performance comparison
 - **[Financial Service](docs/settfex/services/set/financial.md)** - Balance sheet, income statement, and cash flow data
-- **[Chart Quotation Service](docs/settfex/services/set/chart_quotation.md)** - Intraday/historical price chart series, plus the latest *traded* price relative to now
+- **[Chart Quotation Service](docs/settfex/services/set/chart_quotation.md)** - Intraday/historical price chart series, plus the latest *traded* price relative to now (DRs answer with the indicative price — see below)
 - **[Latest Historical Trading Service](docs/settfex/services/set/latest_historical_trading.md)** - Latest trading day summary with OHLCV and valuation metrics
 - **[Earnings Call (Opportunity Day) Service](docs/settfex/services/set/earnings_call.md)** - OPPDAY earnings-call calendar with YouTube links, as models or a DataFrame
 - **[Market Index Service](docs/settfex/services/set/index.md)** - Index directory (SET50/SET100/sSET/SETESG/...), quotations, constituents, and latest index value
 - **[News Service](docs/settfex/services/set/news.md)** - Company news and disclosures for all stocks, with symbol/date/keyword filters
 - **[Market Holiday Service](docs/settfex/services/set/holiday.md)** - Official SET market-closure calendar for the year, in English or Thai
+- **[DR Profile Service](docs/settfex/services/set/profile_dr.md)** - Depositary Receipt details: issuer, underlying, conversion ratio, and the TradingView "Indicative Price" link
+- **[DR Indicative Price Service](docs/settfex/services/set/dr_indicative_price.md)** - A DR's fair value in THB (underlying × FX ÷ ratio) from TradingView
 
 ### TFEX Services
 
@@ -132,6 +135,10 @@ mai_stocks = stock_list.filter_by_market("mai")
 # Index memberships are included by default
 print(stock_list.get_symbol("CPALL").indices)   # ['SET50', 'SET100', 'SETESG', ...]
 set50_members = stock_list.filter_by_index("SET50")
+
+# Filter by asset type (stock, ETF, DR, DW, warrant, ...)
+drs = stock_list.filter_by_asset_type("dr")     # GOOG80, MICRON01, ...
+etfs = stock_list.filter_by_asset_type("etf")
 ```
 
 **👉 [Learn more about Stock Lists](docs/settfex/services/set/list.md)**
@@ -370,13 +377,50 @@ if quote:
 # Or work with the full series — intraday (1-minute) or historical (daily)
 chart = await get_chart_quotation("CPALL", period="1D")
 print(f"Prior close: {chart.prior}, data points: {len(chart.quotations)}")
-print(f"Latest: {chart.quotations[-1].close:.2f} THB")
+print(f"Latest price (with prior fallback): {chart.get_latest_price()}")
 
 chart_1y = await get_chart_quotation("CPALL", period="1Y")
 print(f"1Y data points: {len(chart_1y.quotations)}")
 ```
 
+> **Depositary Receipts differ:** `Stock("GOOG80").get_latest_price()` returns the TradingView
+> **indicative** price instead of SET chart data (see the next section). The top-level
+> `get_latest_price()` function shown here is always SET chart data.
+
 **👉 [Learn more about Chart Quotation & Latest Price](docs/settfex/services/set/chart_quotation.md)**
+
+---
+
+#### 🌏 Get Asset Types & Depositary Receipt Prices
+
+SET lists more than common stocks — ETFs, DRs, DWs, warrants, preferred shares and unit trusts all
+share the same APIs. Find out what a symbol actually *is*, and price DRs against their underlying:
+
+```python
+from settfex.services.set import AssetType, Stock, get_dr_indicative_price
+
+# What kind of instrument is this?
+await Stock("CPALL").get_asset_type()      # AssetType.STOCK              ('stock')
+await Stock("1DIV").get_asset_type()       # AssetType.ETF                ('etf')
+await Stock("GOOG80").get_asset_type()     # AssetType.DEPOSITARY_RECEIPT ('dr')
+
+# DRs: issuer/underlying details + the "Indicative Price" TradingView chart
+dr = Stock("GOOG80")
+profile = await dr.get_dr_profile()
+print(profile.underlying, profile.conversion_ratio)   # GOOG  "2,000 : 1"
+print(await dr.get_tradingview_url())                 # https://th.tradingview.com/chart/?symbol=...
+
+# Fair value in THB = underlying price × FX ÷ conversion ratio (live from TradingView)
+price = await get_dr_indicative_price("GOOG80")
+print(f"{price.indicative_price:.2f} THB "
+      f"({price.underlying.close} {price.underlying.currency} × {price.fx.close} ÷ {price.ratio:.0f})")
+
+# ...and get_latest_price() uses it automatically for DRs
+quote = await dr.get_latest_price()                   # DrIndicativeQuotation
+quote = await dr.get_latest_price(prefer_dr_indicative=False)  # SET traded price instead
+```
+
+**👉 [Learn more about DR Profiles](docs/settfex/services/set/profile_dr.md)** · **[DR Indicative Price](docs/settfex/services/set/dr_indicative_price.md)**
 
 ---
 

--- a/docs/settfex/services/set/chart_quotation.md
+++ b/docs/settfex/services/set/chart_quotation.md
@@ -15,6 +15,9 @@ Endpoint: `GET /api/set/stock/{symbol}/chart-quotation?period=1D&accumulated=fal
 - **Intraday + historical** — `period` of `1D`, `5D`, `1M`, `3M`, `6M`, `1Y`, `3Y`, `5Y`, `MAX`.
 - **Latest traded price vs. now** — `get_latest_price()` returns the most recent quotation that
   actually traded (non-null `volume`), skipping future / lunch-break / no-trade buckets.
+  (`Stock.get_latest_price()` answers **DR** symbols with the TradingView indicative price
+  instead — see [dr_indicative_price.md](dr_indicative_price.md); the top-level
+  `get_latest_price()` function in this module is always SET chart data.)
 - **Timezone-correct** — quotation timestamps are tz-aware (`+07:00`); `as_of` inputs (naive or any
   zone) are normalized to Asia/Bangkok before comparison.
 - **Hyphen-safe symbols** — warrant symbols like `JAS-W4` are preserved (only upper-cased/trimmed).
@@ -55,6 +58,12 @@ stock = Stock("CPALL")
 data = await stock.get_chart_quotation(period="1D")    # full ChartQuotation series
 latest = await stock.get_latest_price()                # latest traded Quotation (or None)
 ```
+
+> **DR symbols behave differently:** for Depositary Receipts (e.g. `GOOG80`),
+> `Stock.get_latest_price()` returns the **TradingView indicative price** (a
+> `DrIndicativeQuotation` — `volume` is `None`) instead of SET chart data, falling back to
+> the SET path on any failure. Opt out with `prefer_dr_indicative=False`. See
+> [dr_indicative_price.md](dr_indicative_price.md).
 
 ### Using the convenience function
 

--- a/docs/settfex/services/set/dr_indicative_price.md
+++ b/docs/settfex/services/set/dr_indicative_price.md
@@ -1,0 +1,119 @@
+# DR Indicative Price Service (TradingView)
+
+Compute a DR's **indicative (fair value) price** — `underlying price × FX rate ÷ conversion
+ratio` in THB — by evaluating the TradingView expression SET publishes per DR (see
+[profile_dr.md](profile_dr.md)). This is the number behind the "Indicative Price" menu on
+SET's DR pages, and it keeps moving while SET is closed because the underlying market trades
+on its own hours.
+
+## Overview
+
+- **Endpoint:** `POST https://scanner.tradingview.com/global/scan` — one batch request
+  fetches every expression leg (underlying + FX) together
+- **Host:** `scanner.tradingview.com` — foreign, unauthenticated, **stateless**: the service
+  forces `use_session=False` for TradingView calls (never SessionManager; the scan is a POST,
+  which the persistent-session path does not support anyway). The SET-host DR-profile fetch
+  keeps the caller's config untouched.
+- **Freshness:** the `close` column is the last price — **~15-minute delayed** for exchange
+  legs (`update_mode: "delayed_streaming_900"`), streaming for `FX_IDC` legs. The `lp` /
+  `lp_time` columns are null over plain HTTP (websocket-only) and are deliberately not used.
+- Verified live 2026-08-03: GOOG80 → `356.65 USD × 33.33 THB/USD ÷ 2000 ≈ 5.94 THB` vs the
+  DR's own SET close of 5.75 — **divergence is expected** (the US session moved after SET
+  closed), not a bug.
+
+## Quick Start
+
+```python
+from settfex.services.set import get_dr_indicative_price
+
+price = await get_dr_indicative_price("GOOG80")
+print(price.indicative_price)    # 5.9454 (THB)
+print(price.underlying.close)    # 356.65 (USD, ~15-min delayed)
+print(price.fx.close)            # 33.34 (USDTHB, streaming)
+print(price.ratio)               # 2000.0
+print(price.is_delayed)          # True
+```
+
+### `Stock.get_latest_price()` auto-switch (DRs)
+
+For DR symbols, `Stock.get_latest_price()` returns the TradingView indicative price by
+default, falling back to SET chart data on **any** TradingView failure:
+
+```python
+from settfex.services.set import DrIndicativeQuotation, Stock
+
+stock = Stock("GOOG80")
+q = await stock.get_latest_price()                # DrIndicativeQuotation (indicative)
+q.price                                            # 5.9454 THB
+q.volume                                           # None — fair value, not a SET trade
+q.indicative.expression                            # 'NASDAQ:GOOG*FX_IDC:USDTHB/2000.0'
+isinstance(q, DrIndicativeQuotation)               # True — provenance check
+
+q = await stock.get_latest_price(prefer_dr_indicative=False)   # SET traded price instead
+```
+
+Rules of the switch:
+
+- Applies only to DRs (detected via one cached DR-profile probe per `Stock` instance; the
+  probe's 404 marks a non-DR permanently for that instance — zero overhead afterwards).
+- Skipped when an explicit `as_of` is passed — TradingView serves only "now" and cannot
+  answer a historical instant; the SET chart path is used instead.
+- `period` / `accumulated` only affect the SET chart path.
+- Any TradingView/profile failure logs a warning and falls back to SET chart data.
+
+## Models
+
+### `TradingViewQuote`
+
+One leg quote: `ticker`, `name`, `close` (the delayed last price), `change` (percent),
+`currency`, `update_mode`.
+
+### `DrIndicativePrice`
+
+| Field | Notes |
+|---|---|
+| `symbol` | DR symbol |
+| `indicative_price` | THB: `product(leg closes) / ratio` |
+| `ratio` / `expression` | From the parsed expression |
+| `tradingview_url` | SET's chart link |
+| `legs` | `list[TradingViewQuote]`, in expression order |
+| `as_of` | Computation instant, aware Asia/Bangkok (TradingView provides no usable timestamp over HTTP) |
+
+Properties: `underlying` (first non-`FX_IDC:` leg), `fx` (first `FX_IDC:` leg), `is_delayed`;
+`to_quotation()` → `DrIndicativeQuotation`.
+
+### `DrIndicativeQuotation(Quotation)`
+
+A `Quotation` subclass: `price` = indicative price, `quote_datetime` = `as_of`,
+`volume`/`value`/`change`/`percent_change` = `None`, plus `.indicative` carrying the full
+`DrIndicativePrice`. Use `isinstance(...)` or `.indicative` to tell it apart from a real SET
+quotation.
+
+## Service Class
+
+### `DrIndicativePriceService(config: FetcherConfig | None = None)`
+
+- `fetch_quotes(tickers) -> dict[str, TradingViewQuote]` — one batch scan; result keyed by
+  UPPERCASED ticker; duplicates deduped. TradingView answers **unknown tickers with HTTP 200
+  and the row simply missing** — missing rows raise `FetchError` explicitly.
+- `fetch_quotes_raw(tickers) -> dict` — the raw scan response
+- `fetch_indicative_price(symbol, *, profile=None) -> DrIndicativePrice` — pass a pre-fetched
+  `DrProfile` to skip the profile request (the `Stock` class does this)
+
+## Error Handling
+
+| Case | Raised |
+|---|---|
+| Empty tickers | `ValueError` |
+| Empty symbol | `InvalidSymbolError` |
+| Non-DR symbol | `SymbolNotFoundError` (from the profile fetch; no suggestion) |
+| TradingView non-2xx / transport | `FetchError` (explicit status check — `AsyncDataFetcher` retries exceptions only, never a non-2xx status) |
+| Requested ticker missing from scan / null `close` leg | `FetchError` naming the leg(s) |
+| No usable expression (both `indicativePriceSymbol` and URL unusable) | `FetchError` |
+| Malformed body | `ResponseParseError` |
+
+## Related Services
+
+- [profile_dr.md](profile_dr.md) — the expression source
+- [chart_quotation.md](chart_quotation.md) — the SET fallback path used by
+  `Stock.get_latest_price()`

--- a/docs/settfex/services/set/list.md
+++ b/docs/settfex/services/set/list.md
@@ -9,7 +9,8 @@ The Stock List Service provides async methods to fetch the complete list of stoc
 - **Async-First Design**: Built on `AsyncDataFetcher` for optimal performance
 - **Full Type Safety**: Complete Pydantic models with runtime validation
 - **Thai/Unicode Support**: Proper handling of Thai company names
-- **Filtering Capabilities**: Filter stocks by market, industry, index membership, or lookup by symbol
+- **Filtering Capabilities**: Filter stocks by market, industry, index membership, or asset type
+  (stock/ETF/DR/DW/warrant/...), or look up by symbol
 - **Index Memberships**: Each stock lists its headline sub-index memberships (SET50, SET100,
   sSET, SETESG, ...) by default — see `include_indices`
 - **Browser Impersonation**: Bypasses bot detection using realistic browser headers
@@ -118,6 +119,11 @@ Model representing individual stock information.
 - `indices: list[str]` - Market index memberships (e.g. `['SET50', 'SET100', 'SETESG']`);
   populated when fetching with `include_indices=True` (the default), empty otherwise
 
+**Derived property:**
+- `asset_type: AssetType` - `security_type` mapped to a friendly type
+  (`stock`/`stock_foreign`/`preferred_stock`/`preferred_stock_foreign`/`warrant`/`dw`/`etf`/
+  `unit_trust`/`dr`; unrecognized codes → `unknown`)
+
 **Example:**
 ```python
 stock = stock_list.get_symbol("PTT")
@@ -127,6 +133,7 @@ print(f"Thai: {stock.name_th}")
 print(f"Market: {stock.market}")
 print(f"Industry: {stock.industry}")
 print(f"Indices: {stock.indices}")
+print(f"Asset type: {stock.asset_type}")   # 'stock'
 ```
 
 #### StockListResponse
@@ -189,6 +196,29 @@ empty and this returns nothing.
 ```python
 set50_stocks = response.filter_by_index("SET50")    # 50 stocks
 esg_stocks = response.filter_by_index("SETESG")
+```
+
+##### `filter_by_asset_type(asset_type: AssetType | str) -> list[StockSymbol]`
+
+Filter securities by asset type (stock, ETF, DR, DW, warrant, preferred, unit trust). Each
+`StockSymbol` also exposes an `asset_type` property derived from its `security_type` code
+(`S`/`F`/`P`/`Q`/`W`/`V`/`L`/`U`/`X` → `AssetType`; unrecognized codes → `AssetType.UNKNOWN`).
+There is no `BOND` type — bonds do not appear in SET's stock APIs at all.
+
+**Parameters:**
+- `asset_type` - An `AssetType`, its value (e.g. `"dr"`, `"etf"` — case-insensitive), or a
+  raw SET `securityType` code (e.g. `"X"`). Unknown values raise `ValueError`.
+
+**Returns:**
+- `list[StockSymbol]` - Securities of the specified asset type
+
+**Example:**
+```python
+from settfex.services.set import AssetType
+
+drs = response.filter_by_asset_type(AssetType.DEPOSITARY_RECEIPT)   # GOOG80, MICRON01, ...
+etfs = response.filter_by_asset_type("etf")                         # 1DIV, ...
+dws = response.filter_by_asset_type("V")                            # raw SET code works too
 ```
 
 ##### `get_symbol(symbol: str) -> StockSymbol | None`
@@ -669,6 +699,7 @@ enrichment is skipped) with a warning; the stock list itself is never affected. 
 ## See Also
 
 - [Market Index Service](index.md) - Index directory, quotations, and constituents
+- [DR Profile Service](profile_dr.md) - Depositary Receipt details for the `dr` asset type
 - [AsyncDataFetcher](../../utils/data_fetcher.md) - Underlying HTTP client
 - [Logging Utilities](../../utils/logging.md) - Logging configuration
 - [FetcherConfig](../../utils/data_fetcher.md#fetcherconfig) - Configuration options

--- a/docs/settfex/services/set/profile_dr.md
+++ b/docs/settfex/services/set/profile_dr.md
@@ -1,0 +1,100 @@
+# DR Profile Service
+
+Fetch Depositary Receipt (DR) details from the SET API — issuer and underlying information,
+the conversion ratio, and the **TradingView "Indicative Price" chart link** shown on SET's DR
+pages (e.g. GOOG80, MICRON01).
+
+## Overview
+
+- **Endpoint:** `GET https://www.set.or.th/api/set/dr/{symbol}/profile?lang={en|th}`
+- **Host:** `www.set.or.th` (SessionManager/Incapsula handling applies, like every SET service)
+- **Scope:** DR symbols only — the endpoint answers **every** non-DR symbol (including valid
+  listed stocks like `CPALL`) with HTTP 404 body `{"message": "Invalid DR"}`
+- Backs `Stock.get_dr_profile()`, `Stock.get_tradingview_url()`, and the DR indicative price
+  service (see [dr_indicative_price.md](dr_indicative_price.md))
+
+## Quick Start
+
+```python
+from settfex.services.set import get_dr_profile
+
+profile = await get_dr_profile("GOOG80")
+print(profile.underlying)              # "GOOG"
+print(profile.underlying_exchange)     # "The Nasdaq Global Select Market"
+print(profile.conversion_ratio)        # "2,000 : 1" (verbatim string)
+print(profile.tradingview_url)         # https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0
+
+expr = profile.indicative_expression   # parsed IndicativePriceExpression
+print(expr.tickers, expr.ratio)        # ['NASDAQ:GOOG', 'FX_IDC:USDTHB'] 2000.0
+```
+
+Via the unified `Stock` class (cached per language on the instance):
+
+```python
+from settfex.services.set import Stock
+
+stock = Stock("GOOG80")
+dr = await stock.get_dr_profile()
+url = await stock.get_tradingview_url()   # None for non-DR symbols
+```
+
+## Models
+
+### `DrProfile`
+
+Every field except `symbol` is optional (`| None`) — the payload is live-probed, not
+documented by SET. Key fields:
+
+| Field | Alias | Notes |
+|---|---|---|
+| `symbol` | — | DR symbol, e.g. `GOOG80` |
+| `issuer` / `issuer_name` | `issuerName` | e.g. `KTB` / KRUNG THAI BANK |
+| `security_type` / `security_type_name` | `securityType` / `securityTypeName` | `"X"` / `"Depositary Receipts"` |
+| `conversion_ratio` | `conversionRatio` | **Verbatim string** (`"2,000 : 1"`) — the numeric ratio used for pricing comes from the expression instead |
+| `underlying` / `underlying_name` | — / `underlyingName` | e.g. `GOOG` / ALPHABET INC. |
+| `underlying_exchange` / `underlying_url` | `underlyingExchange` / `underlyingUrl` | Home exchange + info link |
+| `fractional_trade` | `fractionalTrade` | `True` for fractional (DRx) trading |
+| `trading_session` | `tradingSession` | e.g. `"Day & Night Session"` |
+| `indicative_price_symbol` | `indicativePriceSymbol` | TradingView expression, e.g. `NASDAQ:GOOG*FX_IDC:USDTHB/2000.0` — **sometimes null** (HERMES80, BYDCOM80, NDX01) |
+| `indicative_price_url` | `indicativePriceUrl` | TradingView chart URL — always present in probes |
+
+Derived properties:
+
+- `tradingview_url` → the `indicative_price_url` (the "Indicative Price" menu link)
+- `indicative_expression` → parsed `IndicativePriceExpression | None`; prefers
+  `indicative_price_symbol`, and **recovers the expression from the URL's `symbol` query
+  parameter when that field is null**. Logs and returns `None` on parse failure — never raises.
+- `asset_type` → `AssetType.DEPOSITARY_RECEIPT` for a normal DR payload
+
+### `IndicativePriceExpression` / `parse_indicative_price_expression()`
+
+Observed grammar: `{EXCHANGE}:{TICKER}*FX_IDC:{CCY}THB/{ratio}` (NASDAQ, EURONEXT, HKEX seen;
+HKEX tickers are numeric like `HKEX:1211`). Parsing is defensive:
+
+- trailing `/<float>` → `ratio` (must be > 0); absent → `1.0`
+- `*`-separated TradingView tickers (1..n) → `tickers`
+- raises `ValueError` on empty input, no tickers, or a bad/non-positive ratio
+
+## Service Class
+
+### `DrProfileService(config: FetcherConfig | None = None)`
+
+- `fetch_dr_profile(symbol, lang="en") -> DrProfile`
+- `fetch_dr_profile_raw(symbol, lang="en") -> dict[str, Any]` — the raw tier **also** checks
+  HTTP status first, so a non-DR symbol raises `SymbolNotFoundError` instead of a parse error
+
+## Error Handling
+
+| Case | Raised |
+|---|---|
+| Empty symbol | `InvalidSymbolError` |
+| Non-DR symbol (HTTP 404 `Invalid DR`) | `SymbolNotFoundError` with **no suggestion** — the 404 fires for perfectly valid non-DR symbols, so a "did you mean?" would suggest the symbol back to you |
+| Other non-2xx | `FetchError` (with `status_code`) |
+| Malformed body | `ResponseParseError` |
+
+## Related Services
+
+- [dr_indicative_price.md](dr_indicative_price.md) — evaluates the expression via TradingView
+- [profile_stock.md](profile_stock.md) — the generic stock profile (works for DRs too;
+  source of `securityType` → `AssetType`)
+- [list.md](list.md) — `filter_by_asset_type(AssetType.DEPOSITARY_RECEIPT)` lists all DRs

--- a/docs/settfex/services/set/profile_stock.md
+++ b/docs/settfex/services/set/profile_stock.md
@@ -196,6 +196,13 @@ Pydantic model representing stock profile data.
 | `fiscal_year_end` | `str \| None` | Fiscal year end (DD/MM) |
 | `account_form` | `str \| None` | Accounting form type |
 
+> **Derived property — `profile.asset_type`:** maps the `security_type` code to a friendly
+> `AssetType` StrEnum (`stock`/`stock_foreign`/`preferred_stock`/`preferred_stock_foreign`/
+> `warrant`/`dw`/`etf`/`unit_trust`/`dr`; unrecognized → `unknown`). `Stock.get_asset_type()`
+> uses exactly this, fetching the profile once and caching the result on the instance.
+> Classify by **code**, never by `security_type_name` — the API's own display name for `Q`
+> carries a typo ("Prefered Foreign Stocks").
+
 ### `StockProfileService`
 
 Service class for fetching stock profile data.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Comprehensive, beginner-friendly tutorials for the settfex library.
 
 **Location**: `examples/set/`
 
-Complete tutorial series covering all 17 SET services:
+Complete tutorial series covering the SET services:
 
 1. **Stock List** - Market universe and symbol validation
 2. **Highlight Data** - Key metrics (P/E, P/B, market cap, dividends)
@@ -27,8 +27,9 @@ Complete tutorial series covering all 17 SET services:
 15. **Market Index** - Index directory, quotations, constituents, index membership per stock
 16. **SET News** - Company news/disclosures for all stocks, with symbol/date/keyword filters
 17. **Market Holidays** - Official market-closure calendar: is the market open, next holiday
+18. **Asset Types & Depositary Receipts** - Classify stocks/ETFs/DRs/DWs, DR profiles, TradingView indicative prices
 
-**Total**: 17 notebooks + comprehensive guide
+**Total**: 18 notebooks + comprehensive guide
 
 ## Quick Start
 
@@ -159,7 +160,7 @@ Learn to fetch basic data and track dividends.
 Build complete fundamental analysis system.
 
 ### Path 3: Portfolio Management (3 hours)
-All 11 notebooks in sequence.
+All 18 SET notebooks in sequence.
 
 Master complete SET data ecosystem.
 

--- a/examples/set/13_chart_quotation.ipynb
+++ b/examples/set/13_chart_quotation.ipynb
@@ -123,7 +123,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 5. Using the unified `Stock` class\n\nEvery accessor is also available on `Stock`."
+   "source": "## 5. Using the unified `Stock` class\n\nEvery accessor is also available on `Stock`.\n\n> **Depositary Receipts are special:** for a DR (e.g. `GOOG80`), `Stock.get_latest_price()`\n> returns the TradingView **indicative** price — `underlying × FX ÷ conversion ratio` — instead of\n> SET chart data, because the underlying keeps trading after SET closes. Pass\n> `prefer_dr_indicative=False` for the SET traded price. See notebook\n> [18_dr_and_asset_type.ipynb](18_dr_and_asset_type.ipynb). The module-level\n> `get_latest_price()` used above is always SET chart data."
   },
   {
    "cell_type": "code",
@@ -194,7 +194,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\n- `get_latest_price(symbol)` → the latest **traded** `Quotation` relative to now (or `None`).\n- `as_of` lets you ask the same question for any instant; naive = Asia/Bangkok.\n- The model's `get_latest_price(as_of)` is a scalar with a `prior` fallback.\n- Null future/lunch/no-trade buckets are excluded automatically.\n\nSee `docs/settfex/services/set/chart_quotation.md` for the full reference."
+   "source": "## Summary\n\n- `get_latest_price(symbol)` → the latest **traded** `Quotation` relative to now (or `None`).\n- `as_of` lets you ask the same question for any instant; naive = Asia/Bangkok.\n- The model's `get_latest_price(as_of)` is a scalar with a `prior` fallback.\n- Null future/lunch/no-trade buckets are excluded automatically.\n- `Stock.get_latest_price()` answers **DR** symbols with the TradingView indicative price\n  (opt out with `prefer_dr_indicative=False`) — see `18_dr_and_asset_type.ipynb`.\n\nSee `docs/settfex/services/set/chart_quotation.md` for the full reference."
   }
  ],
  "metadata": {

--- a/examples/set/18_dr_and_asset_type.ipynb
+++ b/examples/set/18_dr_and_asset_type.ipynb
@@ -1,0 +1,613 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Asset Types & Depositary Receipts\n",
+    "\n",
+    "SET lists far more than common stocks. The same APIs serve **ETFs**, **Depositary Receipts (DRs)**,\n",
+    "**derivative warrants (DWs)**, warrants, preferred shares and unit trusts — all mixed together, told\n",
+    "apart only by a single-letter `securityType` code.\n",
+    "\n",
+    "This notebook covers two things:\n",
+    "\n",
+    "1. **Asset types** — classify any symbol (`AssetType`), and slice the whole universe by type.\n",
+    "2. **Depositary Receipts** — the issuer/underlying details behind a DR like `GOOG80`, the\n",
+    "   TradingView **\"Indicative Price\"** chart SET links to, and how to compute that indicative price\n",
+    "   (`underlying price × FX ÷ conversion ratio`) yourself.\n",
+    "\n",
+    "Endpoints: `GET /api/set/stock/{symbol}/profile` · `GET /api/set/dr/{symbol}/profile` ·\n",
+    "`POST scanner.tradingview.com/global/scan`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the library (uncomment if needed), then import the helpers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:26.243976Z",
+     "iopub.status.busy": "2026-08-03T04:55:26.243241Z",
+     "iopub.status.idle": "2026-08-03T04:55:26.767928Z",
+     "shell.execute_reply": "2026-08-03T04:55:26.766222Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install settfex\n",
+    "\n",
+    "from settfex.services.set import (\n",
+    "    AssetType,\n",
+    "    Stock,\n",
+    "    get_dr_indicative_price,\n",
+    "    get_dr_profile,\n",
+    "    get_stock_list,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. What kind of instrument is this?\n",
+    "\n",
+    "`Stock.get_asset_type()` reads the symbol's profile once, caches it on the instance, and maps SET's\n",
+    "`securityType` code to a friendly `AssetType`. It never raises on an unknown code — a code SET adds\n",
+    "tomorrow simply comes back as `AssetType.UNKNOWN`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:26.773669Z",
+     "iopub.status.busy": "2026-08-03T04:55:26.773353Z",
+     "iopub.status.idle": "2026-08-03T04:55:26.923563Z",
+     "shell.execute_reply": "2026-08-03T04:55:26.921500Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPALL          stock\n",
+      "1DIV           etf\n",
+      "GOOG80         dr\n",
+      "AAV01C2609T    dw\n",
+      "SCBSET         unit_trust\n"
+     ]
+    }
+   ],
+   "source": [
+    "symbols = [\"CPALL\", \"1DIV\", \"GOOG80\", \"AAV01C2609T\", \"SCBSET\"]\n",
+    "\n",
+    "for symbol in symbols:\n",
+    "    asset_type = await Stock(symbol).get_asset_type()\n",
+    "    print(f\"{symbol:<14} {asset_type}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`AssetType` is a `StrEnum`, so it prints as its bare value and compares equal to a plain string —\n",
+    "handy in f-strings, JSON, and `if` checks alike."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.039541Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.038818Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.257654Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.255453Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "repr:            <AssetType.DEPOSITARY_RECEIPT: 'dr'>\n",
+      "str:             dr\n",
+      "== 'dr':         True\n",
+      "is DR:           True\n"
+     ]
+    }
+   ],
+   "source": [
+    "asset_type = await Stock(\"GOOG80\").get_asset_type()\n",
+    "\n",
+    "print(f\"repr:            {asset_type!r}\")\n",
+    "print(f\"str:             {asset_type}\")\n",
+    "print(f\"== 'dr':         {asset_type == 'dr'}\")\n",
+    "print(f\"is DR:           {asset_type is AssetType.DEPOSITARY_RECEIPT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Slice the whole universe by type\n",
+    "\n",
+    "Every `StockSymbol` in the stock list exposes the same `asset_type` property, and\n",
+    "`filter_by_asset_type()` accepts an `AssetType`, its value (`\"dr\"`), or the raw SET code (`\"X\"`).\n",
+    "\n",
+    "Fetching with `include_indices=False` skips the index-membership enrichment — we don't need it here,\n",
+    "and it makes the call noticeably faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.264108Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.263544Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.460043Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.458193Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4,054 listed securities\n",
+      "\n",
+      "  dw                         1,651\n",
+      "  stock                        930\n",
+      "  stock_foreign                864\n",
+      "  dr                           493\n",
+      "  warrant                       85\n",
+      "  etf                           13\n",
+      "  preferred_stock                8\n",
+      "  preferred_stock_foreign        8\n",
+      "  unit_trust                     2\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "stock_list = await get_stock_list(include_indices=False)\n",
+    "counts = Counter(s.asset_type for s in stock_list.security_symbols)\n",
+    "\n",
+    "print(f\"{stock_list.count:,} listed securities\\n\")\n",
+    "for asset_type, count in counts.most_common():\n",
+    "    print(f\"  {asset_type:<26} {count:>5,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.466569Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.466021Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.494654Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.493227Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DRs:   493   e.g. ['AAOI03', 'AAPL01', 'AAPL03', 'AAPL19', 'AAPL80', 'ABBV19']\n",
+      "ETFs:   13   e.g. ['1DIV', '1I01BSET50', '2I01BSET50', '2X01BSET50', 'ABFTH', 'BMSCG']\n",
+      "DWs:  1651   e.g. ['AAV01C2609T', 'AAV01C2703T', 'AAV13C2608A', 'AAV13C2608B']\n"
+     ]
+    }
+   ],
+   "source": [
+    "drs = stock_list.filter_by_asset_type(AssetType.DEPOSITARY_RECEIPT)\n",
+    "etfs = stock_list.filter_by_asset_type(\"etf\")  # by value\n",
+    "dws = stock_list.filter_by_asset_type(\"V\")  # by raw SET securityType code\n",
+    "\n",
+    "print(f\"DRs:  {len(drs):>4}   e.g. {[s.symbol for s in drs[:6]]}\")\n",
+    "print(f\"ETFs: {len(etfs):>4}   e.g. {[s.symbol for s in etfs[:6]]}\")\n",
+    "print(f\"DWs:  {len(dws):>4}   e.g. {[s.symbol for s in dws[:4]]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the practical way to build a *tradable stock* universe — DWs alone outnumber ordinary\n",
+    "listed companies, so a naive \"all symbols\" screen is mostly derivatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.500701Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.500004Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.520372Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.518656Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1,794 common stocks out of 4,054 listed securities\n"
+     ]
+    }
+   ],
+   "source": [
+    "tradable = [\n",
+    "    s\n",
+    "    for s in stock_list.security_symbols\n",
+    "    if s.asset_type in (AssetType.STOCK, AssetType.STOCK_FOREIGN)\n",
+    "]\n",
+    "print(f\"{len(tradable):,} common stocks out of {stock_list.count:,} listed securities\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Inside a Depositary Receipt\n",
+    "\n",
+    "A DR is a Thai-listed wrapper around a foreign security. `get_dr_profile()` returns who issued it,\n",
+    "what it tracks, on which exchange, and — crucially — the **conversion ratio**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.527861Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.527025Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.568951Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.567240Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Symbol:       GOOG80\n",
+      "Name:         Depositary Receipt on GOOG Issued by KTB\n",
+      "Issuer:       KTB — KRUNG THAI BANK PUBLIC COMPANY LIMITED\n",
+      "Underlying:   GOOG (ALPHABET INC. (GOOG))\n",
+      "Exchange:     The Nasdaq Global Select Market\n",
+      "Ratio:        2,000 : 1\n",
+      "Session:      Day & Night Session\n",
+      "Fractional:   False\n"
+     ]
+    }
+   ],
+   "source": [
+    "profile = await get_dr_profile(\"GOOG80\")\n",
+    "\n",
+    "print(f\"Symbol:       {profile.symbol}\")\n",
+    "print(f\"Name:         {profile.name}\")\n",
+    "print(f\"Issuer:       {profile.issuer} — {profile.issuer_name}\")\n",
+    "print(f\"Underlying:   {profile.underlying} ({profile.underlying_name})\")\n",
+    "print(f\"Exchange:     {profile.underlying_exchange}\")\n",
+    "print(f\"Ratio:        {profile.conversion_ratio}\")\n",
+    "print(f\"Session:      {profile.trading_session}\")\n",
+    "print(f\"Fractional:   {profile.fractional_trade}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The \"Indicative Price\" link\n",
+    "\n",
+    "On SET's DR pages there is an **Indicative Price** menu item pointing at a TradingView chart. The\n",
+    "profile carries both that URL and the expression it charts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.575754Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.574886Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.586950Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.585274Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0\n",
+      "\n",
+      "expression: NASDAQ:GOOG*FX_IDC:USDTHB/2000.0\n",
+      "tickers:    ['NASDAQ:GOOG', 'FX_IDC:USDTHB']\n",
+      "ratio:      2000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(profile.tradingview_url)\n",
+    "\n",
+    "expression = profile.indicative_expression\n",
+    "print(f\"\\nexpression: {expression.expression}\")\n",
+    "print(f\"tickers:    {expression.tickers}\")\n",
+    "print(f\"ratio:      {expression.ratio}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the expression as arithmetic: **`NASDAQ:GOOG` × `FX_IDC:USDTHB` ÷ `2000`** — the underlying's\n",
+    "price in USD, converted to THB, divided by how many DR units represent one share.\n",
+    "\n",
+    "> Some DRs return a `null` `indicativePriceSymbol` (HERMES80, BYDCOM80, NDX01 among them). The\n",
+    "> library recovers the expression from the URL's `symbol` query parameter, so\n",
+    "> `indicative_expression` still works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.593610Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.593050Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.667191Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.664780Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indicative_price_symbol: None\n",
+      "recovered from URL:      EURONEXT:RMS*FX_IDC:EURTHB/10000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "hermes = await get_dr_profile(\"HERMES80\")\n",
+    "\n",
+    "print(f\"indicative_price_symbol: {hermes.indicative_price_symbol}\")\n",
+    "print(f\"recovered from URL:      {hermes.indicative_expression.expression}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. The indicative price\n",
+    "\n",
+    "`get_dr_indicative_price()` fetches every leg of the expression from TradingView in **one** batch\n",
+    "request and evaluates it, returning the fair value in THB plus each leg's quote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.674661Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.673718Z",
+     "iopub.status.idle": "2026-08-03T04:55:27.993266Z",
+     "shell.execute_reply": "2026-08-03T04:55:27.991271Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  NASDAQ:GOOG        356.6500 USD   (delayed_streaming_900)\n",
+      "  FX_IDC:USDTHB       33.3300 THB   (streaming)\n",
+      "\n",
+      "  ÷ ratio             2,000.0\n",
+      "  = indicative         5.9436 THB\n",
+      "\n",
+      "as of 2026-08-03 11:55:27 +07 · delayed=True\n"
+     ]
+    }
+   ],
+   "source": [
+    "price = await get_dr_indicative_price(\"GOOG80\")\n",
+    "\n",
+    "for leg in price.legs:\n",
+    "    print(f\"  {leg.ticker:<16} {leg.close:>10,.4f} {leg.currency}   ({leg.update_mode})\")\n",
+    "\n",
+    "print(f\"\\n  {'÷ ratio':<16} {price.ratio:>10,.1f}\")\n",
+    "print(f\"  {'= indicative':<16} {price.indicative_price:>10,.4f} THB\")\n",
+    "print(f\"\\nas of {price.as_of:%Y-%m-%d %H:%M:%S %Z} · delayed={price.is_delayed}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `underlying` and `fx` helpers pick out the legs, so you can show the arithmetic explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:27.999954Z",
+     "iopub.status.busy": "2026-08-03T04:55:27.999260Z",
+     "iopub.status.idle": "2026-08-03T04:55:28.010124Z",
+     "shell.execute_reply": "2026-08-03T04:55:28.007984Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "356.65 USD × 33.3300 THB/USD ÷ 2,000 = 5.9436 THB\n"
+     ]
+    }
+   ],
+   "source": [
+    "underlying, fx = price.underlying, price.fx\n",
+    "\n",
+    "print(\n",
+    "    f\"{underlying.close:,.2f} {underlying.currency} \"\n",
+    "    f\"× {fx.close:,.4f} THB/{underlying.currency} \"\n",
+    "    f\"÷ {price.ratio:,.0f} \"\n",
+    "    f\"= {price.indicative_price:,.4f} THB\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. `get_latest_price()` is DR-aware\n",
+    "\n",
+    "For a DR, \"the last price\" is ambiguous: the DR's own last trade on SET, or what it is *worth* right\n",
+    "now given where the underlying is trading? `Stock.get_latest_price()` answers with the **indicative**\n",
+    "price for DRs, because the underlying keeps moving long after SET closes.\n",
+    "\n",
+    "The result is a `DrIndicativeQuotation` — a `Quotation` subclass whose `volume`/`change` are `None`\n",
+    "(it is a fair value, not a trade) and whose `.indicative` field carries the full computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:28.015680Z",
+     "iopub.status.busy": "2026-08-03T04:55:28.015140Z",
+     "iopub.status.idle": "2026-08-03T04:55:28.398987Z",
+     "shell.execute_reply": "2026-08-03T04:55:28.397000Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indicative :   5.9436 THB   (DrIndicativeQuotation)\n",
+      "SET traded :   6.0000 THB   (Quotation)\n",
+      "gap        :  -0.0564 THB\n"
+     ]
+    }
+   ],
+   "source": [
+    "dr = Stock(\"GOOG80\")\n",
+    "\n",
+    "indicative = await dr.get_latest_price()\n",
+    "traded = await dr.get_latest_price(prefer_dr_indicative=False)\n",
+    "\n",
+    "print(f\"indicative : {indicative.price:>8,.4f} THB   ({type(indicative).__name__})\")\n",
+    "print(f\"SET traded : {traded.price:>8,.4f} THB   ({type(traded).__name__})\")\n",
+    "print(f\"gap        : {indicative.price - traded.price:>+8,.4f} THB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A gap between the two is **normal**, not an error: the exchange leg is ~15 minutes delayed, and US\n",
+    "or European hours barely overlap SET's. That spread is exactly what a DR arbitrage screen looks for.\n",
+    "\n",
+    "Non-DR symbols are unaffected — they go straight to SET chart data as before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-03T04:55:28.405784Z",
+     "iopub.status.busy": "2026-08-03T04:55:28.405061Z",
+     "iopub.status.idle": "2026-08-03T04:55:28.465448Z",
+     "shell.execute_reply": "2026-08-03T04:55:28.463102Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPALL: 48.25 THB at 2026-08-03 11:54:00 (Quotation)\n",
+      "volume: 8,800   <- a real SET trade, so volume is populated\n"
+     ]
+    }
+   ],
+   "source": [
+    "quote = await Stock(\"CPALL\").get_latest_price()\n",
+    "\n",
+    "print(f\"CPALL: {quote.price} THB at {quote.local_datetime} ({type(quote).__name__})\")\n",
+    "print(f\"volume: {quote.volume:,.0f}   <- a real SET trade, so volume is populated\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- `Stock.get_asset_type()` → `AssetType` (`stock`, `stock_foreign`, `preferred_stock`,\n",
+    "  `preferred_stock_foreign`, `warrant`, `dw`, `etf`, `unit_trust`, `dr`, `unknown`); cached per\n",
+    "  instance, never raises on a new code.\n",
+    "- `StockSymbol.asset_type` and `stock_list.filter_by_asset_type(...)` slice the whole universe —\n",
+    "  accepting an enum, its value, or the raw SET `securityType` code.\n",
+    "- `get_dr_profile(symbol)` → issuer, underlying, exchange, conversion ratio, and the TradingView\n",
+    "  `tradingview_url`; `indicative_expression` parses the pricing formula (recovering it from the URL\n",
+    "  when the symbol field is null).\n",
+    "- `get_dr_indicative_price(symbol)` → THB fair value = product of leg prices ÷ ratio, with each\n",
+    "  leg's quote and delay status.\n",
+    "- `Stock.get_latest_price()` returns the indicative price for DRs (opt out with\n",
+    "  `prefer_dr_indicative=False`); on any TradingView failure it falls back to SET chart data.\n",
+    "\n",
+    "Bonds are **not** covered by these APIs at all — there is deliberately no `AssetType.BOND`.\n",
+    "\n",
+    "See `docs/settfex/services/set/profile_dr.md` and\n",
+    "`docs/settfex/services/set/dr_indicative_price.md` for the full reference."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "settfex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/set/README.md
+++ b/examples/set/README.md
@@ -326,6 +326,29 @@ Complete, beginner-friendly tutorials for all SET (Stock Exchange of Thailand) s
 > ⚠️ The API serves **only the current year**, and weekends are **not** in the payload — combine
 > `is_holiday()` with a weekday check to answer "is the market open?".
 
+---
+
+### 18. Asset Types & Depositary Receipts (`18_dr_and_asset_type.ipynb`)
+**What it does**: Tells SET instruments apart (stock / ETF / DR / DW / warrant / preferred / unit
+trust) and prices Depositary Receipts against their underlying via TradingView
+
+**Learn how to**:
+- Classify any symbol with `Stock.get_asset_type()` and the `AssetType` enum
+- Count and filter the whole universe by type with `filter_by_asset_type()`
+- Read a DR's issuer, underlying, exchange and conversion ratio from `get_dr_profile()`
+- Get the SET "Indicative Price" TradingView chart URL with `get_tradingview_url()`
+- Compute a DR's THB fair value (underlying × FX ÷ ratio) with `get_dr_indicative_price()`
+- Understand why `Stock.get_latest_price()` returns the indicative price for DRs, and how to
+  opt out with `prefer_dr_indicative=False`
+
+**Use cases**:
+- Excluding DWs/DRs (or isolating them) when building a tradable stock universe
+- Spotting the arbitrage gap between a DR's SET price and its underlying's fair value
+- Valuing DR positions outside SET hours, while the underlying market is still trading
+
+> ⚠️ The indicative price is ~15 minutes delayed for the underlying exchange leg and keeps moving
+> while SET is closed — divergence from the DR's own SET close is expected, not an error.
+
 ## Learning Path
 
 ### Beginners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.15.0"
+version = "0.16.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 __author__ = "batt"
 __license__ = "MIT"
 
@@ -61,7 +61,10 @@ from settfex.services.sec import (
     resolve_company,
 )
 from settfex.services.set import (
+    AssetType,
     CompanyProfile,
+    DrIndicativePrice,
+    DrProfile,
     HolidayCalendar,
     IndexCompositionResponse,
     IndexInfo,
@@ -74,6 +77,8 @@ from settfex.services.set import (
     StockListResponse,
     StockProfile,
     get_company_profile,
+    get_dr_indicative_price,
+    get_dr_profile,
     get_highlight_data,
     get_holidays,
     get_index_composition,
@@ -105,6 +110,8 @@ __all__ = [
     "get_index_composition",
     "get_news",
     "get_holidays",
+    "get_dr_profile",
+    "get_dr_indicative_price",
     # SEC IDISC document services (market.sec.or.th)
     "SecCompany",
     "get_sec_documents",
@@ -120,6 +127,9 @@ __all__ = [
     "StockHighlightData",
     "StockProfile",
     "CompanyProfile",
+    "AssetType",
+    "DrProfile",
+    "DrIndicativePrice",
     "IndexListResponse",
     "IndexInfo",
     "IndexCompositionResponse",

--- a/settfex/services/set/__init__.py
+++ b/settfex/services/set/__init__.py
@@ -1,10 +1,12 @@
 """SET (Stock Exchange of Thailand) services."""
 
+from settfex.services.set.asset_type import SECURITY_TYPE_TO_ASSET_TYPE, AssetType
 from settfex.services.set.constants import (
     SET_BASE_URL,
     SET_BOARD_OF_DIRECTOR_ENDPOINT,
     SET_COMPANY_PROFILE_ENDPOINT,
     SET_CORPORATE_ACTION_ENDPOINT,
+    SET_DR_PROFILE_ENDPOINT,
     SET_EARNINGS_CALL_DETAIL_ENDPOINT,
     SET_EARNINGS_CALL_FILTER_ENDPOINT,
     SET_EARNINGS_CALL_SEARCH_ENDPOINT,
@@ -26,6 +28,8 @@ from settfex.services.set.constants import (
     SET_STOCK_PROFILE_ENDPOINT,
     SET_STOCK_SHAREHOLDER_ENDPOINT,
     SET_TRADING_STAT_ENDPOINT,
+    TRADINGVIEW_SCAN_ENDPOINT,
+    TRADINGVIEW_SCANNER_BASE_URL,
 )
 from settfex.services.set.earnings_call import (
     EarningsCallDetail,
@@ -94,9 +98,15 @@ from settfex.services.set.stock import (
     CorporateAction,
     CorporateActionService,
     Director,
+    DrIndicativePrice,
+    DrIndicativePriceService,
+    DrIndicativeQuotation,
+    DrProfile,
+    DrProfileService,
     FinancialService,
     FinancialStatement,
     IncomeStatement,
+    IndicativePriceExpression,
     Intermission,
     Language,
     LatestHistoricalTrading,
@@ -115,12 +125,15 @@ from settfex.services.set.stock import (
     StockProfileService,
     TradingStat,
     TradingStatService,
+    TradingViewQuote,
     get_balance_sheet,
     get_board_of_directors,
     get_cash_flow,
     get_chart_quotation,
     get_company_profile,
     get_corporate_actions,
+    get_dr_indicative_price,
+    get_dr_profile,
     get_highlight_data,
     get_income_statement,
     get_latest_historical_trading,
@@ -132,6 +145,7 @@ from settfex.services.set.stock import (
     get_trading_stats,
     normalize_language,
     normalize_symbol,
+    parse_indicative_price_expression,
 )
 from settfex.utils.youtube_transcript import fetch_youtube_transcript
 
@@ -162,6 +176,12 @@ __all__ = [
     "SET_EARNINGS_CALL_FILTER_ENDPOINT",
     "SET_NEWS_SEARCH_ENDPOINT",
     "SET_HOLIDAY_ENDPOINT",
+    "SET_DR_PROFILE_ENDPOINT",
+    "TRADINGVIEW_SCANNER_BASE_URL",
+    "TRADINGVIEW_SCAN_ENDPOINT",
+    # Asset Type Classification
+    "AssetType",
+    "SECURITY_TYPE_TO_ASSET_TYPE",
     # Stock List Service
     "StockListService",
     "StockListResponse",
@@ -224,6 +244,16 @@ __all__ = [
     "CompanyProfileService",
     "CompanyProfile",
     "get_company_profile",
+    "DrProfileService",
+    "DrProfile",
+    "IndicativePriceExpression",
+    "parse_indicative_price_expression",
+    "get_dr_profile",
+    "DrIndicativePriceService",
+    "DrIndicativePrice",
+    "DrIndicativeQuotation",
+    "TradingViewQuote",
+    "get_dr_indicative_price",
     "CorporateActionService",
     "CorporateAction",
     "get_corporate_actions",

--- a/settfex/services/set/asset_type.py
+++ b/settfex/services/set/asset_type.py
@@ -1,0 +1,78 @@
+"""Asset-type classification for SET-listed instruments.
+
+Maps the SET API's single-letter ``securityType`` codes (as served by ``/api/set/stock/list``
+and the per-symbol profile endpoints) to a friendly :class:`AssetType` enum, so callers can
+tell common stocks apart from ETFs, DRs, DWs, warrants, preferred shares, and unit trusts.
+
+This module is a dependency-free leaf (stdlib only) so that both ``services/set/list.py`` and
+the ``services/set/stock`` package can import it without any import-cycle risk.
+
+Note:
+    Bonds do not appear anywhere in these APIs (there is no ``/api/set/bond/list`` and no bond
+    rows in the stock list — SET-listed debt is served elsewhere), so there is deliberately no
+    ``BOND`` member.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["AssetType", "SECURITY_TYPE_TO_ASSET_TYPE"]
+
+
+class AssetType(StrEnum):
+    """Friendly classification of a SET-listed instrument.
+
+    As a ``StrEnum``, ``str(AssetType.DEPOSITARY_RECEIPT)`` and f-strings render the bare
+    value (``"dr"``), and members compare equal to their plain string values.
+    """
+
+    STOCK = "stock"  # S - Common Stocks
+    STOCK_FOREIGN = "stock_foreign"  # F - Common Foreign Stocks (e.g. 2S-F)
+    PREFERRED_STOCK = "preferred_stock"  # P - Preferred Stocks (e.g. BH-P)
+    PREFERRED_STOCK_FOREIGN = "preferred_stock_foreign"  # Q - Preferred Foreign Stocks (BH-Q)
+    WARRANT = "warrant"  # W - Warrants (e.g. A5-W4)
+    DERIVATIVE_WARRANT = "dw"  # V - Derivative Warrants (e.g. AAV01C2609T)
+    ETF = "etf"  # L - ETFs (e.g. 1DIV)
+    UNIT_TRUST = "unit_trust"  # U - Unit Trusts (e.g. SCBSET)
+    DEPOSITARY_RECEIPT = "dr"  # X - Depositary Receipts (e.g. GOOG80)
+    UNKNOWN = "unknown"  # unrecognized or missing securityType code
+
+    @classmethod
+    def from_security_type(cls, code: str | None) -> AssetType:
+        """Map a SET ``securityType`` code (e.g. ``"X"``) to an :class:`AssetType`.
+
+        Case- and whitespace-insensitive. ``None``, empty, and unrecognized codes map to
+        :attr:`UNKNOWN` — never raises, so a new SET code degrades gracefully instead of
+        breaking every caller.
+
+        Args:
+            code: The raw ``securityType`` value from a SET API payload.
+
+        Returns:
+            The matching :class:`AssetType`, or :attr:`UNKNOWN`.
+
+        Example:
+            >>> AssetType.from_security_type("X")
+            <AssetType.DEPOSITARY_RECEIPT: 'dr'>
+        """
+        if not code:
+            return cls.UNKNOWN
+        return SECURITY_TYPE_TO_ASSET_TYPE.get(code.strip().upper(), cls.UNKNOWN)
+
+
+# securityType code -> AssetType. All nine codes observed live in /api/set/stock/list
+# (2026-08-03: S=930, F=864, P=8, Q=8, U=2, V=1651, W=85, L=13, X=493 symbols). Classify by
+# CODE, never by securityTypeName — the API's own display name for Q carries a typo
+# ("Prefered Foreign Stocks").
+SECURITY_TYPE_TO_ASSET_TYPE: dict[str, AssetType] = {
+    "S": AssetType.STOCK,
+    "F": AssetType.STOCK_FOREIGN,
+    "P": AssetType.PREFERRED_STOCK,
+    "Q": AssetType.PREFERRED_STOCK_FOREIGN,
+    "W": AssetType.WARRANT,
+    "V": AssetType.DERIVATIVE_WARRANT,
+    "L": AssetType.ETF,
+    "U": AssetType.UNIT_TRUST,
+    "X": AssetType.DEPOSITARY_RECEIPT,
+}

--- a/settfex/services/set/constants.py
+++ b/settfex/services/set/constants.py
@@ -20,6 +20,11 @@ SET_FINANCIAL_CASH_FLOW_ENDPOINT = "/api/set/factsheet/{symbol}/financialstateme
 SET_STOCK_CHART_QUOTATION_ENDPOINT = "/api/set/stock/{symbol}/chart-quotation"
 SET_STOCK_LATEST_HISTORICAL_TRADING_ENDPOINT = "/api/set/stock/{symbol}/latest-historical-trading"
 
+# DR (Depositary Receipt) profile — issuer/underlying/conversion-ratio details plus the
+# "Indicative Price" TradingView chart link shown on the DR quote page. Answers non-DR
+# symbols (even valid ones like CPALL) with HTTP 404 {"message": "Invalid DR"}.
+SET_DR_PROFILE_ENDPOINT = "/api/set/dr/{symbol}/profile"
+
 # News search API (market-wide; uses ?lang=). sourceId=company filters to company disclosures —
 # unrecognized sourceId values are silently ignored (returns ALL sources). fromDate/toDate are
 # dd/MM/yyyy ONLY (ISO dates -> HTTP 400).
@@ -49,3 +54,14 @@ SET_EARNINGS_CALL_DETAIL_ENDPOINT = "/investor/vdo/{id}"
 SET_EARNINGS_CALL_FILTER_ENDPOINT = "/investor/filter/{name}"
 SET_OPPDAY_ORIGIN = "https://opportunity-day.setgroup.or.th"
 SET_OPPDAY_REFERER = "https://opportunity-day.setgroup.or.th/"
+
+# TradingView scanner — quotes for the legs of a DR's indicative-price expression (the
+# "Indicative Price" link on SET DR pages points at th.tradingview.com). Foreign,
+# unauthenticated, STATELESS host: never route through SessionManager (its auto-detect would
+# mis-warm it as SET, and the batch scan is a POST, which the persistent session path does
+# not support anyway). Over plain HTTP the `close` column is the last price (~15-min delayed
+# for exchange legs); `lp`/`lp_time` come back null (websocket-only) — do not request them.
+TRADINGVIEW_SCANNER_BASE_URL = "https://scanner.tradingview.com"
+TRADINGVIEW_SCAN_ENDPOINT = "/global/scan"
+TRADINGVIEW_ORIGIN = "https://th.tradingview.com"
+TRADINGVIEW_REFERER = "https://th.tradingview.com/"

--- a/settfex/services/set/list.py
+++ b/settfex/services/set/list.py
@@ -8,6 +8,7 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
 from settfex.exceptions import register_symbol_suggester
+from settfex.services.set.asset_type import SECURITY_TYPE_TO_ASSET_TYPE, AssetType
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_LIST_ENDPOINT
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
 from settfex.utils.parsing import validate_or_raise
@@ -46,6 +47,11 @@ class StockSymbol(BaseModel):
         populate_by_name=True,  # Allow both field name and alias
         str_strip_whitespace=True,  # Strip whitespace from strings
     )
+
+    @property
+    def asset_type(self) -> AssetType:
+        """Asset type derived from ``security_type`` (e.g. ``"X"`` → depositary receipt)."""
+        return AssetType.from_security_type(self.security_type)
 
 
 class StockListResponse(BaseModel):
@@ -103,6 +109,43 @@ class StockListResponse(BaseModel):
         """
         target = index.strip().upper()
         return [s for s in self.security_symbols if any(ix.upper() == target for ix in s.indices)]
+
+    def filter_by_asset_type(self, asset_type: AssetType | str) -> list[StockSymbol]:
+        """
+        Filter securities by asset type (stock, ETF, DR, DW, warrant, ...).
+
+        Args:
+            asset_type: An :class:`AssetType`, its value (e.g. ``'dr'``, ``'etf'`` —
+                case-insensitive), or a raw SET ``securityType`` code (e.g. ``'X'``)
+
+        Returns:
+            List of stock symbols of the specified asset type
+
+        Raises:
+            ValueError: If the value matches neither an AssetType nor a SET securityType code.
+
+        Example:
+            >>> stock_list = await get_stock_list(include_indices=False)
+            >>> drs = stock_list.filter_by_asset_type(AssetType.DEPOSITARY_RECEIPT)
+            >>> etfs = stock_list.filter_by_asset_type("etf")
+        """
+        if isinstance(asset_type, AssetType):
+            target = asset_type
+        else:
+            text = asset_type.strip()
+            try:
+                target = AssetType(text.lower())
+            except ValueError:
+                code_match = SECURITY_TYPE_TO_ASSET_TYPE.get(text.upper())
+                if code_match is None:
+                    valid_values = ", ".join(t.value for t in AssetType)
+                    valid_codes = ", ".join(SECURITY_TYPE_TO_ASSET_TYPE)
+                    raise ValueError(
+                        f"Unknown asset type {asset_type!r}; expected one of: {valid_values} "
+                        f"(or a SET securityType code: {valid_codes})"
+                    ) from None
+                target = code_match
+        return [s for s in self.security_symbols if s.asset_type is target]
 
     def get_symbol(self, symbol: str) -> StockSymbol | None:
         """

--- a/settfex/services/set/stock/__init__.py
+++ b/settfex/services/set/stock/__init__.py
@@ -18,6 +18,13 @@ from settfex.services.set.stock.corporate_action import (
     CorporateActionService,
     get_corporate_actions,
 )
+from settfex.services.set.stock.dr_indicative_price import (
+    DrIndicativePrice,
+    DrIndicativePriceService,
+    DrIndicativeQuotation,
+    TradingViewQuote,
+    get_dr_indicative_price,
+)
 from settfex.services.set.stock.financial import (
     Account,
     BalanceSheet,
@@ -53,6 +60,13 @@ from settfex.services.set.stock.profile_company import (
     CompanyProfile,
     CompanyProfileService,
     get_company_profile,
+)
+from settfex.services.set.stock.profile_dr import (
+    DrProfile,
+    DrProfileService,
+    IndicativePriceExpression,
+    get_dr_profile,
+    parse_indicative_price_expression,
 )
 from settfex.services.set.stock.profile_stock import (
     StockProfile,
@@ -102,6 +116,18 @@ __all__ = [
     "CompanyProfileService",
     "CompanyProfile",
     "get_company_profile",
+    # DR Profile Service
+    "DrProfileService",
+    "DrProfile",
+    "IndicativePriceExpression",
+    "parse_indicative_price_expression",
+    "get_dr_profile",
+    # DR Indicative Price Service (TradingView)
+    "DrIndicativePriceService",
+    "DrIndicativePrice",
+    "DrIndicativeQuotation",
+    "TradingViewQuote",
+    "get_dr_indicative_price",
     # Corporate Action Service
     "CorporateActionService",
     "CorporateAction",

--- a/settfex/services/set/stock/dr_indicative_price.py
+++ b/settfex/services/set/stock/dr_indicative_price.py
@@ -1,0 +1,397 @@
+"""DR Indicative Price Service - Compute a DR's fair value from TradingView quotes.
+
+A SET DR's "Indicative Price" is ``underlying price x FX rate / conversion ratio`` in THB —
+the expression SET itself publishes per DR (see
+:mod:`settfex.services.set.stock.profile_dr`), e.g. GOOG80 →
+``NASDAQ:GOOG*FX_IDC:USDTHB/2000.0``. This service fetches every expression leg from
+TradingView's scanner in ONE batch request and evaluates the expression.
+
+TradingView specifics (live-probed 2026-08-03):
+
+- ``POST https://scanner.tradingview.com/global/scan`` is unauthenticated and returns the
+  ``close`` column as the last price — ~15-minute delayed for exchange legs
+  (``update_mode: "delayed_streaming_900"``), streaming for FX_IDC legs. The ``lp``/
+  ``lp_time``/``last_price`` columns come back null over plain HTTP (websocket-only) and are
+  deliberately not requested.
+- The host is foreign and STATELESS: never route it through SessionManager (the batch scan
+  is a POST, which the persistent-session path does not support anyway) — the service forces
+  ``use_session=False`` for TradingView calls while leaving the SET-host config untouched.
+- Unknown tickers do not error: the scan answers HTTP 200 with the row simply missing, so
+  missing rows are detected and raised explicitly.
+
+The indicative price moves whenever the underlying market does — including while SET is
+closed — so it routinely diverges from the DR's own last traded price on SET (probe: GOOG80
+indicative 5.94 THB vs SET last trade 5.75 after a US-session move).
+"""
+
+import math
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.exceptions import FetchError, InvalidSymbolError, raise_for_status
+from settfex.services.set.constants import (
+    TRADINGVIEW_ORIGIN,
+    TRADINGVIEW_REFERER,
+    TRADINGVIEW_SCAN_ENDPOINT,
+    TRADINGVIEW_SCANNER_BASE_URL,
+)
+from settfex.services.set.stock.chart_quotation import BANGKOK_TZ, Quotation
+from settfex.services.set.stock.profile_dr import DrProfile, DrProfileService
+from settfex.services.set.stock.utils import normalize_symbol
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import ResponseParseError, decode_json, validate_or_raise
+
+# Columns requested from the scanner, in wire order. `close` is the (delayed) last price;
+# `lp`/`lp_time` are excluded on purpose — they are null over plain HTTP (websocket-only).
+TRADINGVIEW_SCAN_COLUMNS: tuple[str, ...] = ("name", "close", "change", "currency", "update_mode")
+
+
+def _build_tradingview_headers() -> dict[str, str]:
+    """Build browser-like headers for the TradingView scanner.
+
+    No cookie/authorization is required (the host is stateless). ``Content-Type`` is set
+    automatically by curl_cffi when a JSON body is sent, so it is intentionally omitted.
+    """
+    return {
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "en-US,en;q=0.9,th;q=0.8",
+        "Origin": TRADINGVIEW_ORIGIN,
+        "Referer": TRADINGVIEW_REFERER,
+        "Sec-Ch-Ua": '"Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"',
+        "Sec-Ch-Ua-Mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"macOS"',
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+        ),
+    }
+
+
+class _TradingViewScanRow(BaseModel):
+    """Raw wire row: ticker + positional column values."""
+
+    s: str = Field(description="Ticker as requested, e.g. 'NASDAQ:GOOG'")
+    d: list[Any] = Field(default_factory=list, description="Column values, positional")
+
+
+class _TradingViewScanResponse(BaseModel):
+    """Raw wire response of POST /global/scan."""
+
+    total_count: int = Field(default=0, alias="totalCount")
+    data: list[_TradingViewScanRow] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TradingViewQuote(BaseModel):
+    """A single TradingView leg quote (delayed for exchange legs, streaming for FX)."""
+
+    ticker: str = Field(description="TradingView ticker, e.g. 'NASDAQ:GOOG' or 'FX_IDC:USDTHB'")
+    name: str | None = Field(default=None, description="Short name, e.g. 'GOOG'")
+    close: float | None = Field(
+        default=None, description="Last price (~15-min delayed for exchange legs)"
+    )
+    change: float | None = Field(default=None, description="Percent change per TradingView")
+    currency: str | None = Field(default=None, description="Quote currency, e.g. 'USD'/'THB'")
+    update_mode: str | None = Field(
+        default=None, description="e.g. 'delayed_streaming_900' or 'streaming'"
+    )
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+
+class DrIndicativePrice(BaseModel):
+    """A DR's indicative (fair-value) price computed from TradingView leg quotes."""
+
+    symbol: str = Field(description="DR symbol, e.g. 'GOOG80'")
+    indicative_price: float = Field(
+        description="Indicative price in THB: product of leg closes / ratio"
+    )
+    ratio: float = Field(description="Conversion-ratio divisor from the expression (e.g. 2000.0)")
+    expression: str = Field(description="Raw TradingView expression that was evaluated")
+    tradingview_url: str | None = Field(
+        default=None, description="SET's 'Indicative Price' TradingView chart URL"
+    )
+    legs: list[TradingViewQuote] = Field(description="Quotes for each expression leg, in order")
+    as_of: datetime = Field(description="Computation instant (aware, Asia/Bangkok)")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @property
+    def underlying(self) -> TradingViewQuote | None:
+        """The first non-FX leg (the underlying instrument quote)."""
+        for leg in self.legs:
+            if not leg.ticker.upper().startswith("FX_IDC:"):
+                return leg
+        return None
+
+    @property
+    def fx(self) -> TradingViewQuote | None:
+        """The first FX leg (the currency-conversion quote)."""
+        for leg in self.legs:
+            if leg.ticker.upper().startswith("FX_IDC:"):
+                return leg
+        return None
+
+    @property
+    def is_delayed(self) -> bool:
+        """True when any leg is delayed (exchange legs are ~15-min delayed over HTTP)."""
+        return any("delayed" in (leg.update_mode or "") for leg in self.legs)
+
+    def to_quotation(self) -> "DrIndicativeQuotation":
+        """Adapt to the ``Quotation`` shape used by ``Stock.get_latest_price()``.
+
+        ``price`` is the indicative price and ``quote_datetime`` the computation instant;
+        ``volume``/``value``/``change``/``percent_change`` are ``None`` (nothing traded —
+        this is a fair value, not a SET trade). The full computation stays available on
+        ``.indicative``.
+        """
+        return DrIndicativeQuotation(
+            quote_datetime=self.as_of,
+            local_datetime=self.as_of.replace(tzinfo=None),
+            price=self.indicative_price,
+            volume=None,
+            value=None,
+            change=None,
+            percent_change=None,
+            indicative=self,
+        )
+
+
+class DrIndicativeQuotation(Quotation):
+    """A synthesized :class:`Quotation` carrying DR indicative-price provenance.
+
+    Returned by ``Stock.get_latest_price()`` for DRs: ``price`` is the TradingView
+    indicative price (NOT a SET trade), so ``volume``/``value``/``change``/
+    ``percent_change`` are ``None``. Use ``isinstance(q, DrIndicativeQuotation)`` or the
+    ``.indicative`` field to tell it apart from a real SET quotation.
+    """
+
+    indicative: DrIndicativePrice = Field(
+        description="The indicative-price computation behind this quotation"
+    )
+
+
+class DrIndicativePriceService:
+    """
+    Service computing DR indicative prices from TradingView's scanner API.
+
+    Fetches all legs of a DR's indicative-price expression in one batch request and
+    evaluates ``product(closes) / ratio``.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """
+        Initialize the DR indicative price service.
+
+        Args:
+            config: Optional fetcher configuration. Used as-is for the SET-host DR-profile
+                fetch; for TradingView calls a copy with ``use_session=False`` is used (the
+                host is stateless and must never go through SessionManager).
+        """
+        self.config = config
+        # TradingView is a foreign, stateless host; never warm a SET session for it, and the
+        # batch scan is a POST (persistent sessions are GET-only).
+        self.tv_config = (config or FetcherConfig()).model_copy(update={"use_session": False})
+        self.base_url = TRADINGVIEW_SCANNER_BASE_URL
+        logger.info(f"DrIndicativePriceService initialized with base_url={self.base_url}")
+
+    async def _scan(self, tickers: Sequence[str]) -> tuple[list[str], Any]:
+        """POST one batch scan for ``tickers``; returns (deduped tickers, decoded JSON)."""
+        requested = [ticker.strip() for ticker in tickers if ticker and ticker.strip()]
+        if not requested:
+            raise ValueError("tickers cannot be empty")
+        deduped = list(dict.fromkeys(requested))
+
+        url = f"{self.base_url}{TRADINGVIEW_SCAN_ENDPOINT}"
+        body = {"symbols": {"tickers": deduped}, "columns": list(TRADINGVIEW_SCAN_COLUMNS)}
+
+        logger.info(f"Fetching TradingView quotes for {deduped} from {url}")
+
+        async with AsyncDataFetcher(config=self.tv_config) as fetcher:
+            response = await fetcher.fetch(
+                url, headers=_build_tradingview_headers(), method="POST", json_body=body
+            )
+
+        # AsyncDataFetcher retries exceptions only, never a non-2xx status — check explicitly
+        # so a 429/5xx surfaces as FetchError instead of a misleading JSON parse error.
+        if response.status_code != 200:
+            error_msg = f"TradingView scan failed (HTTP {response.status_code}) for {deduped}"
+            logger.error(error_msg)
+            raise_for_status(response.status_code, error_msg, suggest=False)
+
+        return deduped, decode_json(response.text, context=f"tradingview scan {deduped}")
+
+    async def fetch_quotes(self, tickers: Sequence[str]) -> dict[str, TradingViewQuote]:
+        """
+        Fetch quotes for TradingView tickers in one batch scan request.
+
+        Args:
+            tickers: TradingView tickers (e.g. ``["NASDAQ:GOOG", "FX_IDC:USDTHB"]``);
+                duplicates are deduped for the request.
+
+        Returns:
+            Dict keyed by UPPERCASED ticker → :class:`TradingViewQuote`.
+
+        Raises:
+            ValueError: If ``tickers`` is empty.
+            FetchError: On non-2xx/transport failures, or when the scan answers 200 but a
+                requested ticker's row is missing (TradingView's "unknown ticker" behavior).
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = DrIndicativePriceService()
+            >>> quotes = await service.fetch_quotes(["NASDAQ:GOOG", "FX_IDC:USDTHB"])
+            >>> print(quotes["NASDAQ:GOOG"].close, quotes["FX_IDC:USDTHB"].close)
+        """
+        deduped, data = await self._scan(tickers)
+        scan = validate_or_raise(
+            _TradingViewScanResponse, data, context=f"tradingview scan {deduped}"
+        )
+
+        quotes: dict[str, TradingViewQuote] = {}
+        for row in scan.data:
+            # Zip positional values with the requested columns, padding short rows with None.
+            values = list(row.d[: len(TRADINGVIEW_SCAN_COLUMNS)])
+            values += [None] * (len(TRADINGVIEW_SCAN_COLUMNS) - len(values))
+            payload = {"ticker": row.s, **dict(zip(TRADINGVIEW_SCAN_COLUMNS, values, strict=True))}
+            quotes[row.s.upper()] = validate_or_raise(
+                TradingViewQuote, payload, context=f"tradingview quote {row.s}"
+            )
+
+        missing = [ticker for ticker in deduped if ticker.upper() not in quotes]
+        if missing:
+            raise FetchError(
+                f"TradingView returned no data for ticker(s) {missing} (requested {deduped})"
+            )
+        return quotes
+
+    async def fetch_quotes_raw(self, tickers: Sequence[str]) -> dict[str, Any]:
+        """
+        Fetch the raw batch-scan response as a dictionary without per-row validation.
+
+        Args:
+            tickers: TradingView tickers to scan.
+
+        Returns:
+            Raw scan response, e.g. ``{"totalCount": 2, "data": [{"s": ..., "d": [...]}]}``.
+
+        Raises:
+            ValueError: If ``tickers`` is empty.
+            FetchError: On non-2xx or transport failures.
+            ResponseParseError: If the response cannot be parsed or is not a JSON object.
+        """
+        deduped, data = await self._scan(tickers)
+        if not isinstance(data, dict):
+            raise ResponseParseError(
+                f"Expected a JSON object for tradingview scan {deduped}, got {type(data).__name__}"
+            )
+        return data
+
+    async def fetch_indicative_price(
+        self, symbol: str, *, profile: DrProfile | None = None
+    ) -> DrIndicativePrice:
+        """
+        Compute the indicative price for a DR symbol.
+
+        Args:
+            symbol: DR symbol (e.g., "GOOG80", "MICRON01")
+            profile: Optional pre-fetched :class:`DrProfile` (skips the profile request —
+                pass it when you already hold one, e.g. from ``Stock.get_dr_profile()``)
+
+        Returns:
+            DrIndicativePrice with the THB fair value, the per-leg quotes, and provenance
+
+        Raises:
+            InvalidSymbolError: If the symbol is empty.
+            SymbolNotFoundError: If the symbol is not a DR (profile fetch 404).
+            FetchError: When no usable expression exists, a leg quote is missing or has a
+                null close, or on HTTP/transport failures.
+            ResponseParseError: If a response cannot be parsed.
+
+        Example:
+            >>> service = DrIndicativePriceService()
+            >>> price = await service.fetch_indicative_price("GOOG80")
+            >>> print(f"{price.symbol}: {price.indicative_price:.2f} THB "
+            ...       f"(underlying {price.underlying.close} {price.underlying.currency})")
+        """
+        symbol = normalize_symbol(symbol)
+        if not symbol:
+            error_msg = "Stock symbol cannot be empty"
+            logger.error(error_msg)
+            raise InvalidSymbolError(error_msg)
+
+        if profile is None:
+            profile = await DrProfileService(config=self.config).fetch_dr_profile(symbol)
+
+        expression = profile.indicative_expression
+        if expression is None:
+            raise FetchError(
+                f"No usable indicative price expression for DR '{symbol}' "
+                f"(indicativePriceSymbol and indicativePriceUrl both missing/unparseable)",
+                symbol=symbol,
+            )
+
+        quotes = await self.fetch_quotes(expression.tickers)
+
+        closes: list[float] = []
+        null_legs: list[str] = []
+        for ticker in expression.tickers:
+            close = quotes[ticker.upper()].close
+            if close is None:
+                null_legs.append(ticker)
+            else:
+                closes.append(close)
+        if null_legs:
+            raise FetchError(
+                f"TradingView returned a null close for leg(s) {null_legs} of DR '{symbol}' "
+                f"(expression {expression.expression!r})",
+                symbol=symbol,
+            )
+
+        indicative = math.prod(closes) / expression.ratio
+        result = DrIndicativePrice(
+            symbol=symbol,
+            indicative_price=indicative,
+            ratio=expression.ratio,
+            expression=expression.expression,
+            tradingview_url=profile.indicative_price_url,
+            legs=[quotes[ticker.upper()] for ticker in expression.tickers],
+            as_of=datetime.now(BANGKOK_TZ),
+        )
+        logger.info(
+            f"Indicative price for {symbol}: {indicative:.4f} THB "
+            f"(legs={[(leg.ticker, leg.close) for leg in result.legs]}, ratio={expression.ratio})"
+        )
+        return result
+
+
+# Convenience function for quick access
+async def get_dr_indicative_price(
+    symbol: str,
+    config: FetcherConfig | None = None,
+) -> DrIndicativePrice:
+    """
+    Convenience function to compute a DR's indicative price from TradingView.
+
+    Args:
+        symbol: DR symbol (e.g., "GOOG80", "MICRON01")
+        config: Optional fetcher configuration
+
+    Returns:
+        DrIndicativePrice with the THB fair value and per-leg quotes
+
+    Example:
+        >>> from settfex.services.set.stock import get_dr_indicative_price
+        >>> price = await get_dr_indicative_price("GOOG80")
+        >>> print(f"{price.symbol}: {price.indicative_price:.2f} THB (delayed={price.is_delayed})")
+    """
+    service = DrIndicativePriceService(config=config)
+    return await service.fetch_indicative_price(symbol)

--- a/settfex/services/set/stock/profile_dr.py
+++ b/settfex/services/set/stock/profile_dr.py
@@ -1,0 +1,395 @@
+"""SET DR Profile Service - Fetch Depositary Receipt details incl. the TradingView link.
+
+The ``/api/set/dr/{symbol}/profile`` endpoint backs the DR quote page
+(https://www.set.or.th/en/market/product/dr/quote/GOOG80/price) and returns issuer and
+underlying details, the conversion ratio, and the "Indicative Price" TradingView chart link —
+an ``underlying x FX / ratio`` fair-value expression such as
+``NASDAQ:GOOG*FX_IDC:USDTHB/2000.0``.
+
+Quirks (live-probed 2026-08-03):
+
+- Non-DR symbols — including perfectly valid listed ones like ``CPALL`` — get HTTP 404 with
+  body ``{"message": "Invalid DR"}``. A 404 here therefore means "not a DR", not "unknown
+  symbol", so the raised :class:`~settfex.exceptions.SymbolNotFoundError` deliberately skips
+  the "did you mean?" suggestion (it would suggest the symbol back to you).
+- ``indicativePriceSymbol`` is sometimes ``null`` (e.g. HERMES80, BYDCOM80, NDX01) while
+  ``indicativePriceUrl`` was always present — :attr:`DrProfile.indicative_expression`
+  recovers the expression from the URL's ``symbol`` query parameter in that case.
+"""
+
+from datetime import datetime
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from settfex.exceptions import InvalidSymbolError, raise_for_status
+from settfex.services.set.asset_type import AssetType
+from settfex.services.set.constants import SET_BASE_URL, SET_DR_PROFILE_ENDPOINT
+from settfex.services.set.stock.utils import Language, normalize_language, normalize_symbol
+from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
+from settfex.utils.parsing import ResponseParseError, decode_json, validate_or_raise
+
+
+class IndicativePriceExpression(BaseModel):
+    """Parsed form of a DR indicative-price expression (``NASDAQ:GOOG*FX_IDC:USDTHB/2000.0``)."""
+
+    expression: str = Field(description="Raw TradingView expression")
+    tickers: list[str] = Field(
+        description="Ordered TradingView tickers (the multiplied legs, 1..n)"
+    )
+    ratio: float = Field(description="Trailing conversion-ratio divisor (1.0 when absent)")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+def parse_indicative_price_expression(expression: str) -> IndicativePriceExpression:
+    """Parse a TradingView indicative-price expression defensively.
+
+    Grammar observed live: ``{EXCHANGE}:{TICKER}*FX_IDC:{CCY}THB/{ratio}`` — only the
+    structure is assumed: an optional trailing ``/<float>`` conversion-ratio divisor and one
+    or more ``*``-separated TradingView tickers. Exchange names and the FX-leg shape are not
+    validated (HKEX tickers are numeric, e.g. ``HKEX:1211``; future DRs may differ).
+
+    Args:
+        expression: Raw expression string.
+
+    Returns:
+        IndicativePriceExpression with tickers and ratio.
+
+    Raises:
+        ValueError: If the expression is empty, has no tickers, or carries a non-numeric or
+            non-positive ratio.
+    """
+    raw = expression.strip()
+    if not raw:
+        raise ValueError("Indicative price expression is empty")
+    head, sep, tail = raw.rpartition("/")
+    if sep:
+        try:
+            ratio = float(tail.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid ratio {tail!r} in indicative price expression {raw!r}"
+            ) from exc
+        if ratio <= 0:
+            raise ValueError(f"Non-positive ratio {ratio} in indicative price expression {raw!r}")
+    else:
+        head = raw
+        ratio = 1.0
+    tickers = [ticker.strip() for ticker in head.split("*") if ticker.strip()]
+    if not tickers:
+        raise ValueError(f"No tickers in indicative price expression {raw!r}")
+    return IndicativePriceExpression(expression=raw, tickers=tickers, ratio=ratio)
+
+
+def _expression_from_url(url: str | None) -> str | None:
+    """Recover the raw expression from a TradingView chart URL's ``symbol`` query parameter.
+
+    ``https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0`` →
+    ``NASDAQ:GOOG*FX_IDC:USDTHB/2000.0`` (percent-decoding is handled by ``parse_qs``).
+    """
+    if not url:
+        return None
+    try:
+        query = urlsplit(url).query
+    except ValueError:
+        return None
+    values = parse_qs(query).get("symbol")
+    return values[0] if values else None
+
+
+class DrProfile(BaseModel):
+    """Model for DR (Depositary Receipt) profile data.
+
+    Every field except ``symbol`` is optional — the payload shape was live-probed but is not
+    documented by SET, so absent/null keys must not break validation.
+    """
+
+    symbol: str = Field(description="DR symbol/ticker (e.g. 'GOOG80')")
+    name: str | None = Field(default=None, description="DR name")
+    market: str | None = Field(default=None, description="Market (SET)")
+    issuer: str | None = Field(default=None, description="Issuer symbol (e.g. 'KTB')")
+    issuer_name: str | None = Field(
+        default=None, alias="issuerName", description="Issuer full name"
+    )
+    url: str | None = Field(default=None, description="Issuer website URL")
+    address: str | None = Field(default=None, description="Issuer address")
+    telephone: str | None = Field(default=None, description="Issuer telephone")
+    fax: str | None = Field(default=None, description="Issuer fax")
+    security_type: str | None = Field(
+        default=None, alias="securityType", description="Security type code ('X' for DRs)"
+    )
+    security_type_name: str | None = Field(
+        default=None, alias="securityTypeName", description="Security type display name"
+    )
+    status: str | None = Field(default=None, description="Listing status (Listed, etc.)")
+    first_trade_date: datetime | None = Field(
+        default=None, alias="firstTradeDate", description="Date of first trade"
+    )
+    conversion_ratio: str | None = Field(
+        default=None,
+        alias="conversionRatio",
+        description="DR-per-underlying ratio, verbatim (e.g. '2,000 : 1')",
+    )
+    ipo: float | None = Field(default=None, description="IPO price")
+    par: float | None = Field(default=None, description="Par value")
+    listed_share: int | None = Field(
+        default=None, alias="listedShare", description="Number of listed DR units"
+    )
+    currency: str | None = Field(default=None, description="Trading currency (THB)")
+    isin: str | None = Field(default=None, description="ISIN code")
+    dr_type: str | None = Field(default=None, alias="drType", description="DR type description")
+    offering_type: str | None = Field(
+        default=None, alias="offeringType", description="Offering type (e.g. 'Direct Listing')"
+    )
+    underlying: str | None = Field(
+        default=None, description="Underlying instrument symbol (e.g. 'GOOG')"
+    )
+    underlying_name: str | None = Field(
+        default=None, alias="underlyingName", description="Underlying instrument full name"
+    )
+    underlying_class_name: str | None = Field(
+        default=None,
+        alias="underlyingClassName",
+        description="Underlying class (e.g. 'Foreign Common Stock')",
+    )
+    underlying_exchange: str | None = Field(
+        default=None, alias="underlyingExchange", description="Underlying's home exchange"
+    )
+    underlying_url: str | None = Field(
+        default=None, alias="underlyingUrl", description="Underlying info URL"
+    )
+    fractional_trade: bool | None = Field(
+        default=None, alias="fractionalTrade", description="True for fractional (DRx) trading"
+    )
+    outstanding_share: float | None = Field(
+        default=None, alias="outstandingShare", description="Outstanding DR units"
+    )
+    outstanding_date: datetime | None = Field(
+        default=None, alias="outstandingDate", description="Outstanding units as-of date"
+    )
+    listing_detail: Any = Field(
+        default=None, alias="listingDetail", description="Listing detail (null in all probes)"
+    )
+    memorandum_url: str | None = Field(
+        default=None, alias="memorandumUrl", description="Listing memorandum PDF URL"
+    )
+    trading_session: str | None = Field(
+        default=None,
+        alias="tradingSession",
+        description="Trading session (e.g. 'Day & Night Session')",
+    )
+    indicative_price_symbol: str | None = Field(
+        default=None,
+        alias="indicativePriceSymbol",
+        description=(
+            "TradingView fair-value expression (e.g. 'NASDAQ:GOOG*FX_IDC:USDTHB/2000.0'); "
+            "sometimes null — see indicative_expression"
+        ),
+    )
+    indicative_price_url: str | None = Field(
+        default=None,
+        alias="indicativePriceUrl",
+        description="TradingView chart URL for the indicative price ('Indicative Price' menu)",
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both field name and alias
+        str_strip_whitespace=True,  # Strip whitespace from strings
+    )
+
+    @property
+    def tradingview_url(self) -> str | None:
+        """The SET "Indicative Price" TradingView chart URL for this DR."""
+        return self.indicative_price_url
+
+    @property
+    def indicative_expression(self) -> IndicativePriceExpression | None:
+        """Parsed indicative-price expression, or ``None`` when unavailable/unparseable.
+
+        Prefers ``indicative_price_symbol``; when that is null (it sometimes is), recovers
+        the expression from ``indicative_price_url``'s ``symbol`` query parameter. Logs and
+        returns ``None`` on a parse failure — never raises.
+        """
+        raw = self.indicative_price_symbol or _expression_from_url(self.indicative_price_url)
+        if not raw:
+            return None
+        try:
+            return parse_indicative_price_expression(raw)
+        except ValueError as exc:
+            logger.warning(f"Unparseable indicative price expression for {self.symbol}: {exc}")
+            return None
+
+    @property
+    def asset_type(self) -> AssetType:
+        """Asset type derived from ``security_type`` (a DR profile is normally ``X`` → dr)."""
+        return AssetType.from_security_type(self.security_type)
+
+
+class DrProfileService:
+    """
+    Service for fetching DR (Depositary Receipt) profile data from the SET API.
+
+    Provides issuer/underlying details, the conversion ratio, and the TradingView
+    "Indicative Price" link for DR symbols such as GOOG80 or MICRON01.
+    """
+
+    def __init__(self, config: FetcherConfig | None = None) -> None:
+        """
+        Initialize the DR profile service.
+
+        Args:
+            config: Optional fetcher configuration (uses defaults if None)
+
+        Example:
+            >>> # Default: Uses SessionManager for automatic cookie handling
+            >>> service = DrProfileService()
+        """
+        self.config = config or FetcherConfig()
+        self.base_url = SET_BASE_URL
+        logger.info(f"DrProfileService initialized with base_url={self.base_url}")
+
+    async def _fetch_payload(self, symbol: str, lang: Language) -> tuple[str, Any]:
+        """Fetch and decode the DR profile payload; shared by both fetch tiers.
+
+        Returns the normalized symbol together with the decoded JSON. The status check runs
+        on BOTH tiers so a 404 surfaces as ``SymbolNotFoundError``, never as a JSON parse
+        error on the HTML/error body.
+        """
+        symbol = normalize_symbol(symbol)
+        lang = normalize_language(lang)
+
+        if not symbol:
+            error_msg = "Stock symbol cannot be empty"
+            logger.error(error_msg)
+            raise InvalidSymbolError(error_msg)
+
+        endpoint = SET_DR_PROFILE_ENDPOINT.format(symbol=symbol)
+        url = f"{self.base_url}{endpoint}?lang={lang}"
+
+        logger.info(f"Fetching DR profile for symbol '{symbol}' (lang={lang}) from {url}")
+
+        async with AsyncDataFetcher(config=self.config) as fetcher:
+            # Symbol-specific referer on the DR quote page is what the site itself sends;
+            # critical for the Incapsula bot-detection bypass.
+            referer = f"https://www.set.or.th/en/market/product/dr/quote/{symbol}/price"
+            headers = AsyncDataFetcher.get_set_api_headers(referer=referer)
+
+            response = await fetcher.fetch(url, headers=headers)
+
+            if response.status_code != 200:
+                if response.status_code == 404:
+                    # The endpoint 404s for every non-DR symbol (body {"message":"Invalid DR"}),
+                    # including valid listed stocks — suggest=False, or the suggester would
+                    # answer "CPALL not found — did you mean 'CPALL'?".
+                    error_msg = (
+                        f"Failed to fetch DR profile for {symbol}: HTTP 404 — "
+                        f"'{symbol}' is not a DR (the endpoint answers non-DR symbols "
+                        f"with 'Invalid DR')"
+                    )
+                    # Logged at debug, not error: a 404 here means "not a DR", which is a routine
+                    # answer — Stock.get_latest_price() uses it as the DR probe for EVERY symbol,
+                    # so logging it as an error would cry wolf on every ordinary stock.
+                    logger.debug(error_msg)
+                else:
+                    error_msg = (
+                        f"Failed to fetch DR profile for {symbol}: HTTP {response.status_code}"
+                    )
+                    logger.error(error_msg)
+                raise_for_status(response.status_code, error_msg, symbol=symbol, suggest=False)
+
+            return symbol, decode_json(response.text, context=f"{symbol} (dr-profile)")
+
+    async def fetch_dr_profile(self, symbol: str, lang: Language = "en") -> DrProfile:
+        """
+        Fetch DR profile data for a specific symbol.
+
+        Args:
+            symbol: DR symbol (e.g., "GOOG80", "MICRON01", "goog80")
+            lang: Language for response ('en' or 'th', default: 'en')
+
+        Returns:
+            DrProfile with issuer/underlying details, conversion ratio, and the
+            TradingView indicative-price link
+
+        Raises:
+            InvalidSymbolError: If the symbol is empty.
+            InvalidLanguageError: If the language is not recognized.
+            SymbolNotFoundError: If the symbol is not a DR (HTTP 404 — no suggestion attached).
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> service = DrProfileService()
+            >>> profile = await service.fetch_dr_profile("GOOG80")
+            >>> print(f"{profile.underlying} @ {profile.underlying_exchange}")
+            >>> print(f"TradingView: {profile.tradingview_url}")
+        """
+        symbol, data = await self._fetch_payload(symbol, lang)
+        profile = validate_or_raise(DrProfile, data, context=f"{symbol} (dr-profile)")
+        logger.info(
+            f"Successfully fetched DR profile for {symbol}: "
+            f"underlying={profile.underlying} ({profile.underlying_exchange}), "
+            f"ratio={profile.conversion_ratio}, "
+            f"indicative_expression={profile.indicative_price_symbol}"
+        )
+        return profile
+
+    async def fetch_dr_profile_raw(self, symbol: str, lang: Language = "en") -> dict[str, Any]:
+        """
+        Fetch DR profile data as a raw dictionary without Pydantic validation.
+
+        Useful for debugging or accessing fields not yet modeled. Unlike the raw tier of
+        some older services, this still checks the HTTP status first, so a non-DR symbol
+        raises ``SymbolNotFoundError`` instead of a JSON parse error.
+
+        Args:
+            symbol: DR symbol (e.g., "GOOG80")
+            lang: Language for response ('en' or 'th', default: 'en')
+
+        Returns:
+            Raw dictionary from the API
+
+        Raises:
+            InvalidSymbolError: If the symbol is empty.
+            InvalidLanguageError: If the language is not recognized.
+            SymbolNotFoundError: If the symbol is not a DR (HTTP 404 — no suggestion attached).
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed or is not a JSON object.
+        """
+        symbol, data = await self._fetch_payload(symbol, lang)
+        if not isinstance(data, dict):
+            raise ResponseParseError(
+                f"Expected a JSON object for {symbol} (dr-profile), got {type(data).__name__}"
+            )
+        logger.debug(f"Raw DR profile keys for {symbol}: {list(data.keys())}")
+        return data
+
+
+# Convenience function for quick access
+async def get_dr_profile(
+    symbol: str,
+    lang: Language = "en",
+    config: FetcherConfig | None = None,
+) -> DrProfile:
+    """
+    Convenience function to fetch DR profile data.
+
+    Args:
+        symbol: DR symbol (e.g., "GOOG80", "MICRON01")
+        lang: Language for response ('en' or 'th', default: 'en')
+        config: Optional fetcher configuration
+
+    Returns:
+        DrProfile with issuer/underlying details, conversion ratio, and the TradingView
+        indicative-price link
+
+    Example:
+        >>> from settfex.services.set.stock import get_dr_profile
+        >>> profile = await get_dr_profile("GOOG80")
+        >>> print(f"{profile.symbol}: {profile.tradingview_url}")
+    """
+    service = DrProfileService(config=config)
+    return await service.fetch_dr_profile(symbol=symbol, lang=lang)

--- a/settfex/services/set/stock/profile_stock.py
+++ b/settfex/services/set/stock/profile_stock.py
@@ -7,6 +7,7 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
 from settfex.exceptions import InvalidSymbolError, raise_for_status
+from settfex.services.set.asset_type import AssetType
 from settfex.services.set.constants import SET_BASE_URL, SET_STOCK_PROFILE_ENDPOINT
 from settfex.services.set.stock.utils import Language, normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import AsyncDataFetcher, FetcherConfig
@@ -93,6 +94,11 @@ class StockProfile(BaseModel):
         populate_by_name=True,  # Allow both field name and alias
         str_strip_whitespace=True,  # Strip whitespace from strings
     )
+
+    @property
+    def asset_type(self) -> AssetType:
+        """Asset type derived from ``security_type`` (e.g. ``"X"`` → depositary receipt)."""
+        return AssetType.from_security_type(self.security_type)
 
 
 class StockProfileService:

--- a/settfex/services/set/stock/stock.py
+++ b/settfex/services/set/stock/stock.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from settfex.exceptions import SymbolNotFoundError
+from settfex.services.set.asset_type import AssetType
 from settfex.services.set.stock.chart_quotation import (
     ChartQuotation,
     ChartQuotationService,
@@ -21,11 +23,16 @@ from settfex.services.set.stock.latest_historical_trading import (
     LatestHistoricalTrading,
     LatestHistoricalTradingService,
 )
-from settfex.services.set.stock.utils import Language, normalize_symbol
+from settfex.services.set.stock.utils import Language, normalize_language, normalize_symbol
 from settfex.utils.data_fetcher import FetcherConfig
 
 if TYPE_CHECKING:
     from settfex.services.set.news import NewsSearchResponse, NewsService
+    from settfex.services.set.stock.dr_indicative_price import (
+        DrIndicativePrice,
+        DrIndicativePriceService,
+    )
+    from settfex.services.set.stock.profile_dr import DrProfile, DrProfileService
     from settfex.services.set.stock.profile_stock import StockProfile, StockProfileService
     from settfex.services.set.stock.shareholder import ShareholderData, ShareholderService
 
@@ -77,6 +84,15 @@ class Stock:
         self._profile_service: StockProfileService | None = None
         self._shareholder_service: ShareholderService | None = None
         self._news_service: NewsService | None = None
+        self._dr_profile_service: DrProfileService | None = None
+        self._dr_indicative_price_service: DrIndicativePriceService | None = None
+
+        # Instance caches (static per listing; a new Stock instance starts clean).
+        self._asset_type: AssetType | None = None
+        self._dr_profiles: dict[str, DrProfile] = {}
+        # Tri-state: None = not probed yet, True/False = known (a DR-profile 404 means
+        # "not a DR" — the endpoint 404s for every non-DR symbol, even valid ones).
+        self._is_dr: bool | None = None
 
         logger.info(f"Stock instance created for symbol '{self.symbol}'")
 
@@ -157,32 +173,83 @@ class Stock:
         period: PeriodType = "1D",
         accumulated: bool = False,
         as_of: datetime | None = None,
+        prefer_dr_indicative: bool = True,
     ) -> Quotation | None:
         """
-        Fetch the latest *traded* quotation for this stock relative to ``as_of``.
+        Fetch the latest price quotation for this symbol relative to ``as_of``.
 
-        Returns the most recent quotation with a non-null volume at or before ``as_of`` (default:
-        now in Asia/Bangkok), excluding the pre-populated future/no-trade buckets. Returns None if
-        nothing has traded yet.
+        For regular symbols this returns the most recent SET quotation with a non-null volume
+        at or before ``as_of`` (default: now in Asia/Bangkok), excluding the pre-populated
+        future/no-trade buckets — or None if nothing has traded yet.
+
+        For **DR symbols** (e.g. GOOG80) this returns the TradingView **indicative price**
+        instead — ``underlying x FX / conversion ratio`` in THB, the same number behind the
+        "Indicative Price" menu on SET's DR pages. It keeps moving while SET is closed
+        (underlying markets trade on their own hours; exchange legs are ~15-min delayed).
+        The result is then a :class:`DrIndicativeQuotation` — a ``Quotation`` subclass whose
+        ``price`` is the indicative price, whose ``volume``/``value``/``change``/
+        ``percent_change`` are ``None`` (it is a fair value, not a SET trade), and whose
+        ``.indicative`` field carries the full computation (legs, ratio, delay flags). Any
+        failure on the TradingView path falls back gracefully to the SET chart data.
+
+        The DR path is skipped when ``prefer_dr_indicative=False`` or when an explicit
+        ``as_of`` is given (TradingView serves only "now" — it cannot answer a historical
+        instant); ``period``/``accumulated`` only affect the SET chart path.
 
         Args:
             period: Time period — one of '1D','5D','1M','3M','6M','1Y','3Y','5Y','MAX'
             accumulated: Whether to return accumulated volume/value (default: False)
             as_of: Reference instant; naive values are treated as Asia/Bangkok local time.
-                Defaults to now in Asia/Bangkok.
+                Defaults to now in Asia/Bangkok. Passing a value forces the SET chart path.
+            prefer_dr_indicative: Use the TradingView indicative price for DRs (default:
+                True). Pass False to always return the SET traded quotation.
 
         Returns:
-            The latest traded Quotation, or None if nothing has traded by ``as_of``
+            The latest Quotation (a DrIndicativeQuotation for DRs on the indicative path),
+            or None if nothing has traded by ``as_of``
 
         Example:
             >>> stock = Stock("CPALL")
             >>> q = await stock.get_latest_price()
             >>> if q:
             ...     print(f"{q.local_datetime}: {q.price} (vol {q.volume})")
+            >>>
+            >>> dr = Stock("GOOG80")
+            >>> q = await dr.get_latest_price()          # TradingView indicative price
+            >>> q = await dr.get_latest_price(prefer_dr_indicative=False)  # SET traded price
         """
+        if prefer_dr_indicative and as_of is None:
+            quotation = await self._get_dr_indicative_quotation()
+            if quotation is not None:
+                return quotation
+
         logger.debug(f"Fetching latest price for {self.symbol} period={period}")
         data = await self.get_chart_quotation(period=period, accumulated=accumulated)
         return data.get_latest_quotation(as_of)
+
+    async def _get_dr_indicative_quotation(self) -> Quotation | None:
+        """DR auto-switch for :meth:`get_latest_price` — the only place with fallback logic.
+
+        Returns the TradingView indicative price as a quotation, or ``None`` meaning "use the
+        SET chart path": the symbol is a known non-DR (cached after one 404 probe per
+        instance), or the indicative computation failed (any error → graceful fallback;
+        DR-ness is never cached off a transient failure).
+        """
+        if self._is_dr is False:
+            return None
+        try:
+            indicative = await self.get_indicative_price()
+        except SymbolNotFoundError:
+            # get_dr_profile already cached self._is_dr = False for this instance.
+            logger.debug(f"{self.symbol} is not a DR; using SET chart data for latest price")
+            return None
+        except Exception as exc:
+            logger.warning(
+                f"DR indicative price unavailable for {self.symbol}; "
+                f"falling back to SET chart data: {exc}"
+            )
+            return None
+        return indicative.to_quotation()
 
     @property
     def latest_historical_trading_service(self) -> LatestHistoricalTradingService:
@@ -248,6 +315,163 @@ class Stock:
         """
         logger.debug(f"Fetching profile for {self.symbol} (lang={lang})")
         return await self.profile_service.fetch_profile(symbol=self.symbol, lang=lang)
+
+    async def get_asset_type(self, refresh: bool = False) -> AssetType:
+        """
+        Classify this symbol's asset type (stock, ETF, DR, DW, warrant, ...).
+
+        Derived from the stock profile's ``securityType`` code and cached on the instance —
+        the first call fetches the profile once; later calls are network-free. Note there is
+        no ``BOND`` type: bonds do not appear in SET's stock APIs at all.
+
+        Args:
+            refresh: Refetch the profile instead of using the cached classification
+
+        Returns:
+            AssetType (``AssetType.UNKNOWN`` when SET serves an unrecognized code)
+
+        Raises:
+            SymbolNotFoundError: If the symbol is not found (HTTP 404).
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> stock = Stock("GOOG80")
+            >>> asset_type = await stock.get_asset_type()
+            >>> print(asset_type)                      # 'dr' (StrEnum renders the bare value)
+            >>> asset_type is AssetType.DEPOSITARY_RECEIPT
+            True
+        """
+        if self._asset_type is None or refresh:
+            profile = await self.get_profile()
+            self._asset_type = profile.asset_type
+        return self._asset_type
+
+    @property
+    def dr_profile_service(self) -> DrProfileService:
+        """
+        Get or create DR profile service instance.
+
+        Returns:
+            DrProfileService instance
+        """
+        if self._dr_profile_service is None:
+            from settfex.services.set.stock.profile_dr import DrProfileService
+
+            self._dr_profile_service = DrProfileService(config=self.config)
+        return self._dr_profile_service
+
+    async def get_dr_profile(self, lang: Language = "en", refresh: bool = False) -> DrProfile:
+        """
+        Fetch the DR (Depositary Receipt) profile for this symbol.
+
+        Includes issuer/underlying details, the conversion ratio, and the TradingView
+        "Indicative Price" link. Cached per language on the instance (the ratio and
+        expression are static per listing).
+
+        Args:
+            lang: Language for response ('en' or 'th', default: 'en')
+            refresh: Refetch instead of using the per-language cache
+
+        Returns:
+            DrProfile for this symbol
+
+        Raises:
+            InvalidLanguageError: If the language is not recognized.
+            SymbolNotFoundError: If this symbol is not a DR — the endpoint answers every
+                non-DR symbol (even valid listed ones) with HTTP 404 ``{"message":
+                "Invalid DR"}``, so no "did you mean?" suggestion is attached.
+            FetchError: On other HTTP or transport failures.
+            ResponseParseError: If the response cannot be parsed.
+
+        Example:
+            >>> stock = Stock("GOOG80")
+            >>> dr = await stock.get_dr_profile()
+            >>> print(f"{dr.underlying} @ {dr.underlying_exchange}, ratio {dr.conversion_ratio}")
+        """
+        lang_key = normalize_language(lang)
+        cached = self._dr_profiles.get(lang_key)
+        if cached is not None and not refresh:
+            return cached
+
+        logger.debug(f"Fetching DR profile for {self.symbol} (lang={lang_key})")
+        try:
+            profile = await self.dr_profile_service.fetch_dr_profile(
+                symbol=self.symbol, lang=lang_key
+            )
+        except SymbolNotFoundError:
+            self._is_dr = False
+            raise
+        self._is_dr = True
+        self._dr_profiles[lang_key] = profile
+        return profile
+
+    async def get_tradingview_url(self) -> str | None:
+        """
+        Get the TradingView "Indicative Price" chart URL for this symbol (DRs only).
+
+        This is the link behind the "Indicative Price" menu on SET's DR pages, e.g.
+        ``https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0``
+        for GOOG80.
+
+        Returns:
+            The TradingView chart URL, or ``None`` when this symbol is not a DR (other
+            failures propagate).
+
+        Example:
+            >>> stock = Stock("GOOG80")
+            >>> url = await stock.get_tradingview_url()
+            >>> print(url)
+        """
+        try:
+            profile = await self.get_dr_profile()
+        except SymbolNotFoundError:
+            logger.debug(f"{self.symbol} is not a DR; no TradingView indicative URL")
+            return None
+        return profile.tradingview_url
+
+    @property
+    def dr_indicative_price_service(self) -> DrIndicativePriceService:
+        """
+        Get or create DR indicative price service instance.
+
+        Returns:
+            DrIndicativePriceService instance
+        """
+        if self._dr_indicative_price_service is None:
+            from settfex.services.set.stock.dr_indicative_price import DrIndicativePriceService
+
+            self._dr_indicative_price_service = DrIndicativePriceService(config=self.config)
+        return self._dr_indicative_price_service
+
+    async def get_indicative_price(self) -> DrIndicativePrice:
+        """
+        Compute this DR's indicative price (underlying x FX / ratio) from TradingView.
+
+        Fetches the legs of SET's indicative-price expression from TradingView's scanner in
+        one batch request and evaluates it. Exchange legs are ~15-minute delayed; the value
+        moves while SET is closed, so it routinely diverges from the DR's own last traded
+        price on SET.
+
+        Returns:
+            DrIndicativePrice with the THB fair value, per-leg quotes, and provenance
+
+        Raises:
+            SymbolNotFoundError: If this symbol is not a DR.
+            FetchError: When no usable expression exists, a leg quote is missing/null, or on
+                HTTP/transport failures.
+            ResponseParseError: If a response cannot be parsed.
+
+        Example:
+            >>> stock = Stock("GOOG80")
+            >>> price = await stock.get_indicative_price()
+            >>> print(f"{price.indicative_price:.2f} THB (delayed={price.is_delayed})")
+        """
+        profile = await self.get_dr_profile()
+        logger.debug(f"Computing indicative price for {self.symbol}")
+        return await self.dr_indicative_price_service.fetch_indicative_price(
+            self.symbol, profile=profile
+        )
 
     @property
     def shareholder_service(self) -> ShareholderService:

--- a/tests/services/set/stock/test_dr_indicative_price.py
+++ b/tests/services/set/stock/test_dr_indicative_price.py
@@ -1,0 +1,499 @@
+"""Tests for the DR indicative price service (TradingView scan, math, Stock auto-switch)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.exceptions import FetchError
+from settfex.services.set.asset_type import AssetType
+from settfex.services.set.stock.chart_quotation import BANGKOK_TZ, Quotation
+from settfex.services.set.stock.dr_indicative_price import (
+    DrIndicativePrice,
+    DrIndicativePriceService,
+    DrIndicativeQuotation,
+    TradingViewQuote,
+    get_dr_indicative_price,
+)
+from settfex.services.set.stock.profile_dr import DrProfile
+from settfex.services.set.stock.stock import Stock
+from settfex.utils.data_fetcher import FetcherConfig, FetchResponse
+
+# Live-captured POST /global/scan response for GOOG80's two legs (2026-08-03).
+SAMPLE_SCAN: dict[str, Any] = {
+    "totalCount": 2,
+    "data": [
+        {
+            "s": "NASDAQ:GOOG",
+            "d": ["GOOG", 356.65, 6.8838408055622065, "USD", "delayed_streaming_900"],
+        },
+        {
+            "s": "FX_IDC:USDTHB",
+            "d": ["USDTHB", 33.33, -0.17969451931716762, "THB", "streaming"],
+        },
+    ],
+}
+
+# Live-captured GET /api/set/dr/GOOG80/profile payload (2026-08-03), trimmed to the fields
+# the indicative flow touches (the full payload is exercised in test_profile_dr.py).
+SAMPLE_DR_PROFILE: dict[str, Any] = {
+    "symbol": "GOOG80",
+    "securityType": "X",
+    "securityTypeName": "Depositary Receipts",
+    "conversionRatio": "2,000 : 1",
+    "underlying": "GOOG",
+    "indicativePriceSymbol": "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0",
+    "indicativePriceUrl": (
+        "https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0"
+    ),
+}
+
+SAMPLE_DR_PROFILE_NULL_EXPR: dict[str, Any] = {
+    **SAMPLE_DR_PROFILE,
+    "symbol": "HERMES80",
+    "underlying": "RMS",
+    "conversionRatio": "10,000 : 1",
+    "indicativePriceSymbol": None,
+    "indicativePriceUrl": (
+        "https://th.tradingview.com/chart/?symbol=EURONEXT%3ARMS*FX_IDC%3AEURTHB%2F10000.0"
+    ),
+}
+
+# Chart-quotation payload for fallback-path tests; timestamps are safely in the past so the
+# "now in Bangkok" cutoff always includes the traded bucket.
+SAMPLE_CHART: dict[str, Any] = {
+    "prior": 5.75,
+    "intermissions": [],
+    "quotations": [
+        {
+            "datetime": "2026-01-05T10:00:00+07:00",
+            "localDatetime": "2026-01-05T10:00:00",
+            "price": 5.70,
+            "volume": 100.0,
+            "value": 570.0,
+            "change": -0.05,
+            "percentChange": -0.87,
+        }
+    ],
+}
+
+# Minimal-but-complete StockProfile payload for get_asset_type tests.
+SAMPLE_STOCK_PROFILE: dict[str, Any] = {
+    "symbol": "GOOG80",
+    "name": "Depositary Receipt on GOOG Issued by KTB",
+    "market": "SET",
+    "industry": "",
+    "industryName": "",
+    "sector": "",
+    "sectorName": "",
+    "securityType": "X",
+    "securityTypeName": "Depositary Receipts",
+    "status": "Listed",
+    "listedDate": None,
+    "firstTradeDate": None,
+    "lastTradeDate": None,
+    "maturityDate": None,
+    "fiscalYearEnd": None,
+    "fiscalYearEndDisplay": None,
+    "accountForm": None,
+    "par": None,
+    "currency": "THB",
+    "listedShare": None,
+    "ipo": None,
+    "isinLocal": None,
+    "isinForeign": None,
+    "isinNVDR": None,
+    "percentFreeFloat": None,
+    "foreignLimitAsOf": None,
+    "percentForeignRoom": None,
+    "percentForeignLimit": None,
+    "foreignAvailable": None,
+    "underlying": None,
+    "exercisePrice": None,
+    "exerciseRatio": None,
+    "reservedShare": None,
+    "convertedShare": None,
+    "lastExerciseDate": None,
+    "issuedShare": None,
+}
+
+
+def _response(
+    payload: Any = None, *, status_code: int = 200, text: str | None = None
+) -> FetchResponse:
+    """Build a FetchResponse whose body is ``payload`` as JSON (or the literal ``text``)."""
+    body = text if text is not None else json.dumps(payload)
+    return FetchResponse(
+        status_code=status_code,
+        content=body.encode("utf-8"),
+        text=body,
+        headers={},
+        url="https://scanner.tradingview.com/global/scan",
+        elapsed=0.1,
+    )
+
+
+def _patched_fetcher(module: str):
+    """Context manager patching AsyncDataFetcher inside ``module``; yields the instance."""
+    patcher = patch(f"{module}.AsyncDataFetcher")
+    mock = patcher.start()
+    fetcher_instance = AsyncMock()
+    mock.return_value.__aenter__.return_value = fetcher_instance
+    mock.return_value.__aexit__.return_value = None
+    mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+    fetcher_instance.cls = mock
+    return patcher, fetcher_instance
+
+
+@pytest.fixture
+def mock_tv_fetcher():
+    """Fetcher inside dr_indicative_price (the TradingView leg)."""
+    patcher, instance = _patched_fetcher("settfex.services.set.stock.dr_indicative_price")
+    yield instance
+    patcher.stop()
+
+
+@pytest.fixture
+def mock_dr_profile_fetcher():
+    """Fetcher inside profile_dr (the SET DR-profile leg)."""
+    patcher, instance = _patched_fetcher("settfex.services.set.stock.profile_dr")
+    yield instance
+    patcher.stop()
+
+
+@pytest.fixture
+def mock_chart_fetcher():
+    """Fetcher inside chart_quotation (the SET fallback path)."""
+    patcher, instance = _patched_fetcher("settfex.services.set.stock.chart_quotation")
+    yield instance
+    patcher.stop()
+
+
+@pytest.fixture
+def mock_stock_profile_fetcher():
+    """Fetcher inside profile_stock (get_asset_type)."""
+    patcher, instance = _patched_fetcher("settfex.services.set.stock.profile_stock")
+    yield instance
+    patcher.stop()
+
+
+def _dr_profile(payload: dict[str, Any] | None = None) -> DrProfile:
+    return DrProfile.model_validate(payload or SAMPLE_DR_PROFILE)
+
+
+@pytest.mark.asyncio
+class TestTradingViewScan:
+    """fetch_quotes / fetch_quotes_raw wire behavior."""
+
+    async def test_posts_single_batch_request_with_exact_body(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG", "FX_IDC:USDTHB"])
+        assert mock_tv_fetcher.fetch.call_count == 1
+        call = mock_tv_fetcher.fetch.call_args
+        assert call.args[0] == "https://scanner.tradingview.com/global/scan"
+        assert call.kwargs["method"] == "POST"
+        assert call.kwargs["json_body"] == {
+            "symbols": {"tickers": ["NASDAQ:GOOG", "FX_IDC:USDTHB"]},
+            "columns": ["name", "close", "change", "currency", "update_mode"],
+        }
+
+    async def test_config_is_stateless_for_tradingview_only(self):
+        service = DrIndicativePriceService(config=FetcherConfig(timeout=60))
+        # TradingView leg: session off, custom settings preserved.
+        assert service.tv_config.use_session is False
+        assert service.tv_config.timeout == 60
+        # SET-host leg (DR profile) keeps the caller's config untouched.
+        assert service.config is not None
+        assert service.config.use_session is True
+
+    async def test_parses_rows_into_quotes(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        quotes = await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG", "FX_IDC:USDTHB"])
+        goog = quotes["NASDAQ:GOOG"]
+        assert goog.name == "GOOG"
+        assert goog.close == 356.65
+        assert goog.currency == "USD"
+        assert goog.update_mode == "delayed_streaming_900"
+        assert quotes["FX_IDC:USDTHB"].close == 33.33
+
+    async def test_short_d_array_pads_none(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(
+            {"totalCount": 1, "data": [{"s": "NASDAQ:GOOG", "d": ["GOOG", 356.65]}]}
+        )
+        quotes = await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG"])
+        goog = quotes["NASDAQ:GOOG"]
+        assert goog.close == 356.65
+        assert goog.change is None
+        assert goog.currency is None
+        assert goog.update_mode is None
+
+    async def test_non_2xx_raises_fetch_error(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(text="slow down", status_code=429)
+        with pytest.raises(FetchError) as excinfo:
+            await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG"])
+        assert excinfo.value.status_code == 429
+
+    async def test_missing_ticker_raises_fetch_error(self, mock_tv_fetcher):
+        # TradingView answers unknown tickers with HTTP 200 and the row simply missing.
+        mock_tv_fetcher.fetch.return_value = _response(
+            {"totalCount": 1, "data": [SAMPLE_SCAN["data"][0]]}
+        )
+        with pytest.raises(FetchError, match="no data for ticker"):
+            await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG", "FX_IDC:USDTHB"])
+
+    async def test_duplicate_tickers_deduped_in_request(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(
+            {"totalCount": 1, "data": [SAMPLE_SCAN["data"][0]]}
+        )
+        await DrIndicativePriceService().fetch_quotes(["NASDAQ:GOOG", "NASDAQ:GOOG"])
+        body = mock_tv_fetcher.fetch.call_args.kwargs["json_body"]
+        assert body["symbols"]["tickers"] == ["NASDAQ:GOOG"]
+
+    async def test_empty_tickers_raises_value_error(self, mock_tv_fetcher):
+        with pytest.raises(ValueError, match="empty"):
+            await DrIndicativePriceService().fetch_quotes([])
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_fetch_quotes_raw(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        raw = await DrIndicativePriceService().fetch_quotes_raw(["NASDAQ:GOOG"])
+        assert raw["totalCount"] == 2
+        assert raw["data"][0]["s"] == "NASDAQ:GOOG"
+
+
+@pytest.mark.asyncio
+class TestIndicativeComputation:
+    """fetch_indicative_price math and the DrIndicativePrice model helpers."""
+
+    async def test_verified_math_goog80(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await DrIndicativePriceService().fetch_indicative_price(
+            "GOOG80", profile=_dr_profile()
+        )
+        assert price.indicative_price == pytest.approx(356.65 * 33.33 / 2000.0)
+        assert price.ratio == 2000.0
+        assert price.expression == "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0"
+        assert price.tradingview_url == SAMPLE_DR_PROFILE["indicativePriceUrl"]
+        assert [leg.ticker for leg in price.legs] == ["NASDAQ:GOOG", "FX_IDC:USDTHB"]
+
+    async def test_single_leg_ratio_one(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(
+            {"totalCount": 1, "data": [SAMPLE_SCAN["data"][0]]}
+        )
+        profile = _dr_profile(
+            {
+                **SAMPLE_DR_PROFILE,
+                "indicativePriceSymbol": "NASDAQ:GOOG",
+                "indicativePriceUrl": None,
+            }
+        )
+        price = await DrIndicativePriceService().fetch_indicative_price("GOOG80", profile=profile)
+        assert price.indicative_price == pytest.approx(356.65)
+        assert price.ratio == 1.0
+
+    async def test_null_close_raises_fetch_error(self, mock_tv_fetcher):
+        scan = {
+            "totalCount": 2,
+            "data": [
+                SAMPLE_SCAN["data"][0],
+                {"s": "FX_IDC:USDTHB", "d": ["USDTHB", None, None, "THB", "streaming"]},
+            ],
+        }
+        mock_tv_fetcher.fetch.return_value = _response(scan)
+        with pytest.raises(FetchError, match="null close.*FX_IDC:USDTHB"):
+            await DrIndicativePriceService().fetch_indicative_price("GOOG80", profile=_dr_profile())
+
+    async def test_as_of_is_aware_bangkok(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await DrIndicativePriceService().fetch_indicative_price(
+            "GOOG80", profile=_dr_profile()
+        )
+        assert price.as_of.tzinfo is not None
+        assert price.as_of.utcoffset() == timedelta(hours=7)
+
+    async def test_underlying_fx_and_delay_helpers(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await DrIndicativePriceService().fetch_indicative_price(
+            "GOOG80", profile=_dr_profile()
+        )
+        assert price.underlying is not None
+        assert price.underlying.ticker == "NASDAQ:GOOG"
+        assert price.fx is not None
+        assert price.fx.ticker == "FX_IDC:USDTHB"
+        assert price.is_delayed is True  # the NASDAQ leg is delayed_streaming_900
+
+    def test_is_delayed_false_when_all_streaming(self):
+        price = DrIndicativePrice(
+            symbol="X01",
+            indicative_price=1.0,
+            ratio=1.0,
+            expression="FX_IDC:USDTHB",
+            legs=[TradingViewQuote(ticker="FX_IDC:USDTHB", update_mode="streaming")],
+            as_of=datetime.now(BANGKOK_TZ),
+        )
+        assert price.is_delayed is False
+
+    async def test_to_quotation_shape(self, mock_tv_fetcher):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await DrIndicativePriceService().fetch_indicative_price(
+            "GOOG80", profile=_dr_profile()
+        )
+        quotation = price.to_quotation()
+        assert isinstance(quotation, Quotation)
+        assert isinstance(quotation, DrIndicativeQuotation)
+        assert quotation.price == price.indicative_price
+        assert quotation.volume is None
+        assert quotation.value is None
+        assert quotation.change is None
+        assert quotation.percent_change is None
+        assert quotation.quote_datetime == price.as_of
+        assert quotation.local_datetime.tzinfo is None
+        assert quotation.local_datetime == price.as_of.replace(tzinfo=None)
+        assert quotation.indicative is price
+
+    async def test_no_expression_raises_fetch_error(self, mock_tv_fetcher):
+        profile = _dr_profile(
+            {**SAMPLE_DR_PROFILE, "indicativePriceSymbol": None, "indicativePriceUrl": None}
+        )
+        with pytest.raises(FetchError, match="No usable indicative price expression"):
+            await DrIndicativePriceService().fetch_indicative_price("GOOG80", profile=profile)
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_url_fallback_expression_used(self, mock_tv_fetcher):
+        scan = {
+            "totalCount": 2,
+            "data": [
+                {"s": "EURONEXT:RMS", "d": ["RMS", 1531.5, -1.2, "EUR", "delayed_streaming_900"]},
+                {"s": "FX_IDC:EURTHB", "d": ["EURTHB", 38.0, 0.1, "THB", "streaming"]},
+            ],
+        }
+        mock_tv_fetcher.fetch.return_value = _response(scan)
+        price = await DrIndicativePriceService().fetch_indicative_price(
+            "HERMES80", profile=_dr_profile(SAMPLE_DR_PROFILE_NULL_EXPR)
+        )
+        body = mock_tv_fetcher.fetch.call_args.kwargs["json_body"]
+        assert body["symbols"]["tickers"] == ["EURONEXT:RMS", "FX_IDC:EURTHB"]
+        assert price.indicative_price == pytest.approx(1531.5 * 38.0 / 10000.0)
+
+    async def test_end_to_end_profile_then_scan(self, mock_tv_fetcher, mock_dr_profile_fetcher):
+        mock_dr_profile_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await get_dr_indicative_price("GOOG80")
+        assert price.indicative_price == pytest.approx(356.65 * 33.33 / 2000.0)
+        assert mock_dr_profile_fetcher.fetch.call_count == 1
+        assert mock_tv_fetcher.fetch.call_count == 1
+
+    async def test_prefetched_profile_skips_profile_fetch(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher
+    ):
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        await DrIndicativePriceService().fetch_indicative_price("GOOG80", profile=_dr_profile())
+        mock_dr_profile_fetcher.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestStockLatestPriceAutoSwitch:
+    """Stock.get_latest_price DR behavior + get_asset_type/get_indicative_price wiring."""
+
+    async def test_stock_get_asset_type_fetches_once_and_caches(self, mock_stock_profile_fetcher):
+        mock_stock_profile_fetcher.fetch.return_value = _response(SAMPLE_STOCK_PROFILE)
+        stock = Stock("GOOG80")
+        assert await stock.get_asset_type() is AssetType.DEPOSITARY_RECEIPT
+        assert await stock.get_asset_type() is AssetType.DEPOSITARY_RECEIPT
+        assert mock_stock_profile_fetcher.fetch.call_count == 1
+
+    async def test_stock_get_indicative_price(self, mock_tv_fetcher, mock_dr_profile_fetcher):
+        mock_dr_profile_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        price = await Stock("GOOG80").get_indicative_price()
+        assert price.indicative_price == pytest.approx(356.65 * 33.33 / 2000.0)
+
+    async def test_dr_uses_indicative_and_skips_chart(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_dr_profile_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        mock_tv_fetcher.fetch.return_value = _response(SAMPLE_SCAN)
+        quotation = await Stock("GOOG80").get_latest_price()
+        assert isinstance(quotation, DrIndicativeQuotation)
+        assert quotation.price == pytest.approx(356.65 * 33.33 / 2000.0)
+        mock_chart_fetcher.fetch.assert_not_called()
+
+    async def test_dr_falls_back_to_chart_on_tv_http_error(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_dr_profile_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        mock_tv_fetcher.fetch.return_value = _response(text="down", status_code=503)
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        quotation = await Stock("GOOG80").get_latest_price()
+        assert quotation is not None
+        assert not isinstance(quotation, DrIndicativeQuotation)
+        assert quotation.price == 5.70
+
+    async def test_dr_falls_back_when_no_expression(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        payload = {
+            **SAMPLE_DR_PROFILE,
+            "indicativePriceSymbol": None,
+            "indicativePriceUrl": None,
+        }
+        mock_dr_profile_fetcher.fetch.return_value = _response(payload)
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        quotation = await Stock("GOOG80").get_latest_price()
+        assert quotation is not None
+        assert quotation.price == 5.70
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_non_dr_goes_straight_to_chart_and_caches_probe(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_dr_profile_fetcher.fetch.return_value = _response(
+            {"message": "Invalid DR"}, status_code=404
+        )
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        stock = Stock("CPALL")
+        first = await stock.get_latest_price()
+        second = await stock.get_latest_price()
+        assert first is not None and second is not None
+        assert first.price == 5.70
+        assert stock._is_dr is False
+        # The DR probe ran exactly once; the second call skipped it via the cache.
+        assert mock_dr_profile_fetcher.fetch.call_count == 1
+        assert mock_chart_fetcher.fetch.call_count == 2
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_explicit_as_of_skips_indicative(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        as_of = datetime(2026, 1, 5, 12, 0, tzinfo=timezone(timedelta(hours=7)))
+        quotation = await Stock("GOOG80").get_latest_price(as_of=as_of)
+        assert quotation is not None
+        assert quotation.price == 5.70
+        mock_dr_profile_fetcher.fetch.assert_not_called()
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_prefer_flag_false_forces_chart_for_dr(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        quotation = await Stock("GOOG80").get_latest_price(prefer_dr_indicative=False)
+        assert quotation is not None
+        assert quotation.price == 5.70
+        mock_dr_profile_fetcher.fetch.assert_not_called()
+        mock_tv_fetcher.fetch.assert_not_called()
+
+    async def test_dr_falls_back_when_profile_fetch_breaks(
+        self, mock_tv_fetcher, mock_dr_profile_fetcher, mock_chart_fetcher
+    ):
+        mock_dr_profile_fetcher.fetch.return_value = _response(text="oops", status_code=500)
+        mock_chart_fetcher.fetch.return_value = _response(SAMPLE_CHART)
+        stock = Stock("GOOG80")
+        quotation = await stock.get_latest_price()
+        assert quotation is not None
+        assert quotation.price == 5.70
+        # Transient failure must NOT cache DR-ness either way.
+        assert stock._is_dr is None
+        mock_tv_fetcher.fetch.assert_not_called()

--- a/tests/services/set/stock/test_profile_dr.py
+++ b/tests/services/set/stock/test_profile_dr.py
@@ -1,0 +1,333 @@
+"""Tests for the DR profile service (expression parsing, model, service, Stock wiring)."""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from settfex.exceptions import (
+    FetchError,
+    InvalidSymbolError,
+    SymbolNotFoundError,
+    register_symbol_suggester,
+)
+from settfex.services.set.asset_type import AssetType
+from settfex.services.set.list import suggest_symbol
+from settfex.services.set.stock.profile_dr import (
+    DrProfile,
+    DrProfileService,
+    get_dr_profile,
+    parse_indicative_price_expression,
+)
+from settfex.services.set.stock.stock import Stock
+from settfex.utils.data_fetcher import FetchResponse
+
+# Live-captured payload of GET /api/set/dr/GOOG80/profile?lang=en (2026-08-03).
+SAMPLE_DR_PROFILE: dict[str, Any] = {
+    "symbol": "GOOG80",
+    "name": "Depositary Receipt on GOOG Issued by KTB",
+    "market": "SET",
+    "issuer": "KTB",
+    "issuerName": "KRUNG THAI BANK PUBLIC COMPANY LIMITED",
+    "url": "https://krungthai.com",
+    "address": "35 SUKHUMVIT ROAD, KHLONG TOEI NUA, WATTANA Bangkok 10110",
+    "telephone": "0-2255-2222",
+    "fax": "0-2255-9391-6",
+    "securityType": "X",
+    "securityTypeName": "Depositary Receipts",
+    "status": "Listed",
+    "firstTradeDate": "2023-06-21T00:00:00+07:00",
+    "conversionRatio": "2,000 : 1",
+    "ipo": 2.18,
+    "par": None,
+    "listedShare": 6000000000,
+    "currency": "THB",
+    "isin": "TH0150120903",
+    "drType": "Depositary Receipt Representing Interest from Underlying Foreign Securities",
+    "offeringType": "Direct Listing",
+    "underlying": "GOOG",
+    "underlyingName": "ALPHABET INC. (GOOG)",
+    "underlyingClassName": "Foreign Common Stock",
+    "underlyingExchange": "The Nasdaq Global Select Market",
+    "underlyingUrl": "https://www.nasdaq.com/market-activity/stocks/goog",
+    "fractionalTrade": False,
+    "outstandingShare": 791482000.0,
+    "outstandingDate": "2026-07-31T00:00:00+07:00",
+    "listingDetail": None,
+    "memorandumUrl": "https://weblink.set.or.th/dat/security/00117657E.pdf",
+    "tradingSession": "Day & Night Session",
+    "indicativePriceSymbol": "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0",
+    "indicativePriceUrl": (
+        "https://th.tradingview.com/chart/?symbol=NASDAQ%3AGOOG*FX_IDC%3AUSDTHB%2F2000.0"
+    ),
+}
+
+# HERMES80-style: indicativePriceSymbol null, but the URL still carries the expression
+# (also live-observed for BYDCOM80 and NDX01).
+SAMPLE_DR_PROFILE_NULL_EXPR: dict[str, Any] = {
+    **SAMPLE_DR_PROFILE,
+    "symbol": "HERMES80",
+    "underlying": "RMS",
+    "conversionRatio": "10,000 : 1",
+    "indicativePriceSymbol": None,
+    "indicativePriceUrl": (
+        "https://th.tradingview.com/chart/?symbol=EURONEXT%3ARMS*FX_IDC%3AEURTHB%2F10000.0"
+    ),
+}
+
+
+def _response(
+    payload: Any = None, *, status_code: int = 200, text: str | None = None
+) -> FetchResponse:
+    """Build a FetchResponse whose body is ``payload`` as JSON (or the literal ``text``)."""
+    body = text if text is not None else json.dumps(payload)
+    return FetchResponse(
+        status_code=status_code,
+        content=body.encode("utf-8"),
+        text=body,
+        headers={},
+        url="https://www.set.or.th/api/set/dr/GOOG80/profile?lang=en",
+        elapsed=0.1,
+    )
+
+
+@pytest.fixture
+def mock_fetcher():
+    """Patch AsyncDataFetcher inside the profile_dr module; yield its async instance."""
+    with patch("settfex.services.set.stock.profile_dr.AsyncDataFetcher") as mock:
+        fetcher_instance = AsyncMock()
+        mock.return_value.__aenter__.return_value = fetcher_instance
+        mock.return_value.__aexit__.return_value = None
+        mock.get_set_api_headers = Mock(return_value={"Accept": "application/json"})
+        fetcher_instance.cls = mock
+        yield fetcher_instance
+
+
+class TestExpressionParsing:
+    """parse_indicative_price_expression against observed and defensive grammar."""
+
+    def test_two_leg_nasdaq_with_ratio(self):
+        expr = parse_indicative_price_expression("NASDAQ:GOOG*FX_IDC:USDTHB/2000.0")
+        assert expr.tickers == ["NASDAQ:GOOG", "FX_IDC:USDTHB"]
+        assert expr.ratio == 2000.0
+        assert expr.expression == "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0"
+
+    def test_numeric_hkex_ticker(self):
+        expr = parse_indicative_price_expression("HKEX:1211*FX_IDC:HKDTHB/1000.0")
+        assert expr.tickers == ["HKEX:1211", "FX_IDC:HKDTHB"]
+        assert expr.ratio == 1000.0
+
+    def test_no_ratio_defaults_to_one(self):
+        expr = parse_indicative_price_expression("NASDAQ:GOOG*FX_IDC:USDTHB")
+        assert expr.tickers == ["NASDAQ:GOOG", "FX_IDC:USDTHB"]
+        assert expr.ratio == 1.0
+
+    def test_single_leg(self):
+        expr = parse_indicative_price_expression("NASDAQ:GOOG")
+        assert expr.tickers == ["NASDAQ:GOOG"]
+        assert expr.ratio == 1.0
+
+    def test_three_legs(self):
+        expr = parse_indicative_price_expression("A:X*B:Y*C:Z/5.0")
+        assert expr.tickers == ["A:X", "B:Y", "C:Z"]
+        assert expr.ratio == 5.0
+
+    def test_whitespace_tolerated(self):
+        expr = parse_indicative_price_expression("  NASDAQ:GOOG * FX_IDC:USDTHB / 2000.0  ")
+        assert expr.tickers == ["NASDAQ:GOOG", "FX_IDC:USDTHB"]
+        assert expr.ratio == 2000.0
+
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_indicative_price_expression("   ")
+
+    def test_bad_ratio_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid ratio"):
+            parse_indicative_price_expression("NASDAQ:GOOG/abc")
+
+    def test_zero_or_negative_ratio_raises(self):
+        with pytest.raises(ValueError, match="Non-positive ratio"):
+            parse_indicative_price_expression("NASDAQ:GOOG/0")
+        with pytest.raises(ValueError, match="Non-positive ratio"):
+            parse_indicative_price_expression("NASDAQ:GOOG/-2.0")
+
+
+class TestDrProfileModel:
+    """DrProfile aliases and derived properties."""
+
+    def test_full_payload_aliases(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE)
+        assert profile.symbol == "GOOG80"
+        assert profile.issuer_name == "KRUNG THAI BANK PUBLIC COMPANY LIMITED"
+        assert profile.security_type == "X"
+        assert profile.underlying == "GOOG"
+        assert profile.underlying_exchange == "The Nasdaq Global Select Market"
+        assert profile.fractional_trade is False
+        assert profile.trading_session == "Day & Night Session"
+        assert profile.indicative_price_symbol == "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0"
+
+    def test_conversion_ratio_kept_verbatim(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE)
+        assert profile.conversion_ratio == "2,000 : 1"
+
+    def test_indicative_expression_from_symbol_field(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE)
+        expr = profile.indicative_expression
+        assert expr is not None
+        assert expr.tickers == ["NASDAQ:GOOG", "FX_IDC:USDTHB"]
+        assert expr.ratio == 2000.0
+
+    def test_indicative_expression_recovered_from_url_when_symbol_null(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE_NULL_EXPR)
+        expr = profile.indicative_expression
+        assert expr is not None
+        # %3A / %2F in the URL must decode back to ':' and '/'
+        assert expr.tickers == ["EURONEXT:RMS", "FX_IDC:EURTHB"]
+        assert expr.ratio == 10000.0
+
+    def test_indicative_expression_none_when_both_unusable(self):
+        payload = {
+            **SAMPLE_DR_PROFILE,
+            "indicativePriceSymbol": None,
+            "indicativePriceUrl": None,
+        }
+        profile = DrProfile.model_validate(payload)
+        assert profile.indicative_expression is None
+
+    def test_indicative_expression_none_on_unparseable(self):
+        payload = {
+            **SAMPLE_DR_PROFILE,
+            "indicativePriceSymbol": "NASDAQ:GOOG/abc",
+            "indicativePriceUrl": None,
+        }
+        profile = DrProfile.model_validate(payload)
+        assert profile.indicative_expression is None  # logged, never raises
+
+    def test_tradingview_url_property(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE)
+        assert profile.tradingview_url == SAMPLE_DR_PROFILE["indicativePriceUrl"]
+
+    def test_asset_type_is_dr(self):
+        profile = DrProfile.model_validate(SAMPLE_DR_PROFILE)
+        assert profile.asset_type is AssetType.DEPOSITARY_RECEIPT
+
+    def test_minimal_payload_tolerates_missing_keys(self):
+        profile = DrProfile.model_validate({"symbol": "GOOG80"})
+        assert profile.symbol == "GOOG80"
+        assert profile.indicative_price_url is None
+        assert profile.indicative_expression is None
+        assert profile.asset_type is AssetType.UNKNOWN
+
+
+@pytest.mark.asyncio
+class TestDrProfileService:
+    """Service I/O against the mocked fetcher."""
+
+    async def test_fetch_success(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        profile = await DrProfileService().fetch_dr_profile("GOOG80")
+        assert profile.symbol == "GOOG80"
+        assert profile.underlying == "GOOG"
+
+    async def test_fetch_url_and_lang_param(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        await DrProfileService().fetch_dr_profile("GOOG80", lang="th")
+        url = mock_fetcher.fetch.call_args[0][0]
+        assert url == "https://www.set.or.th/api/set/dr/GOOG80/profile?lang=th"
+
+    async def test_fetch_referer_is_dr_quote_page(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        await DrProfileService().fetch_dr_profile("GOOG80")
+        referer = mock_fetcher.cls.get_set_api_headers.call_args.kwargs["referer"]
+        assert referer == "https://www.set.or.th/en/market/product/dr/quote/GOOG80/price"
+
+    async def test_symbol_normalization(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        await DrProfileService().fetch_dr_profile("  goog80  ")
+        url = mock_fetcher.fetch.call_args[0][0]
+        assert "/api/set/dr/GOOG80/profile" in url
+
+    async def test_empty_symbol_raises_invalid_symbol(self, mock_fetcher):
+        with pytest.raises(InvalidSymbolError):
+            await DrProfileService().fetch_dr_profile("   ")
+        mock_fetcher.fetch.assert_not_called()
+
+    async def test_404_raises_symbol_not_found_without_suggestion(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response({"message": "Invalid DR"}, status_code=404)
+        # Even with a suggester registered, the DR 404 must NOT suggest — the endpoint 404s
+        # for perfectly valid non-DR symbols ("did you mean 'CPALL'?" for CPALL is nonsense).
+        register_symbol_suggester(lambda symbol: "CPALL")
+        try:
+            with pytest.raises(SymbolNotFoundError) as excinfo:
+                await DrProfileService().fetch_dr_profile("CPALL")
+        finally:
+            register_symbol_suggester(suggest_symbol)  # restore the real suggester
+        assert excinfo.value.status_code == 404
+        assert excinfo.value.suggestion is None
+        assert "not a DR" in str(excinfo.value)
+
+    async def test_other_http_error_raises_fetch_error(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(text="oops", status_code=500)
+        with pytest.raises(FetchError) as excinfo:
+            await DrProfileService().fetch_dr_profile("GOOG80")
+        assert excinfo.value.status_code == 500
+
+    async def test_fetch_raw_success(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        raw = await DrProfileService().fetch_dr_profile_raw("GOOG80")
+        assert raw["indicativePriceSymbol"] == "NASDAQ:GOOG*FX_IDC:USDTHB/2000.0"
+
+    async def test_fetch_raw_404_raises_symbol_not_found(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response({"message": "Invalid DR"}, status_code=404)
+        with pytest.raises(SymbolNotFoundError):
+            await DrProfileService().fetch_dr_profile_raw("CPALL")
+
+
+@pytest.mark.asyncio
+class TestConvenienceFunction:
+    async def test_get_dr_profile(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        profile = await get_dr_profile("GOOG80")
+        assert isinstance(profile, DrProfile)
+        assert profile.symbol == "GOOG80"
+
+
+@pytest.mark.asyncio
+class TestStockIntegration:
+    """Stock.get_dr_profile caching and Stock.get_tradingview_url."""
+
+    async def test_stock_get_dr_profile_cached_single_fetch(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        stock = Stock("GOOG80")
+        first = await stock.get_dr_profile()
+        second = await stock.get_dr_profile()
+        assert first is second
+        assert mock_fetcher.fetch.call_count == 1
+        assert stock._is_dr is True
+
+    async def test_stock_get_dr_profile_refresh_refetches(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        stock = Stock("GOOG80")
+        await stock.get_dr_profile()
+        await stock.get_dr_profile(refresh=True)
+        assert mock_fetcher.fetch.call_count == 2
+
+    async def test_stock_get_dr_profile_caches_per_language(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        stock = Stock("GOOG80")
+        await stock.get_dr_profile(lang="en")
+        await stock.get_dr_profile(lang="th")
+        await stock.get_dr_profile(lang="en")
+        assert mock_fetcher.fetch.call_count == 2
+
+    async def test_stock_get_tradingview_url(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response(SAMPLE_DR_PROFILE)
+        url = await Stock("GOOG80").get_tradingview_url()
+        assert url == SAMPLE_DR_PROFILE["indicativePriceUrl"]
+
+    async def test_stock_get_tradingview_url_none_for_non_dr(self, mock_fetcher):
+        mock_fetcher.fetch.return_value = _response({"message": "Invalid DR"}, status_code=404)
+        stock = Stock("CPALL")
+        assert await stock.get_tradingview_url() is None
+        assert stock._is_dr is False

--- a/tests/services/set/test_asset_type.py
+++ b/tests/services/set/test_asset_type.py
@@ -1,0 +1,121 @@
+"""Tests for the AssetType classification enum and its StockProfile integration."""
+
+from typing import Any
+
+import pytest
+
+from settfex.services.set.asset_type import SECURITY_TYPE_TO_ASSET_TYPE, AssetType
+from settfex.services.set.stock.profile_stock import StockProfile
+
+
+def _profile_payload(security_type: str = "S") -> dict[str, Any]:
+    """Minimal but complete StockProfile payload (all keys present, nullable ones null)."""
+    return {
+        "symbol": "TEST",
+        "name": "Test Security",
+        "market": "SET",
+        "industry": "",
+        "industryName": "",
+        "sector": "",
+        "sectorName": "",
+        "securityType": security_type,
+        "securityTypeName": "Anything",
+        "status": "Listed",
+        "listedDate": None,
+        "firstTradeDate": None,
+        "lastTradeDate": None,
+        "maturityDate": None,
+        "fiscalYearEnd": None,
+        "fiscalYearEndDisplay": None,
+        "accountForm": None,
+        "par": None,
+        "currency": None,
+        "listedShare": None,
+        "ipo": None,
+        "isinLocal": None,
+        "isinForeign": None,
+        "isinNVDR": None,
+        "percentFreeFloat": None,
+        "foreignLimitAsOf": None,
+        "percentForeignRoom": None,
+        "percentForeignLimit": None,
+        "foreignAvailable": None,
+        "underlying": None,
+        "exercisePrice": None,
+        "exerciseRatio": None,
+        "reservedShare": None,
+        "convertedShare": None,
+        "lastExerciseDate": None,
+        "issuedShare": None,
+    }
+
+
+class TestAssetTypeEnum:
+    """StrEnum semantics and the securityType code mapping (live-probed 2026-08-03)."""
+
+    def test_is_strenum_str_renders_bare_value(self) -> None:
+        assert str(AssetType.DEPOSITARY_RECEIPT) == "dr"
+        assert f"{AssetType.ETF}" == "etf"
+
+    def test_equality_with_plain_string(self) -> None:
+        # Widen to AssetType first — mypy's strict-equality otherwise flags the
+        # Literal-member vs literal-str comparison even though StrEnum subclasses str.
+        dr: AssetType = AssetType.DEPOSITARY_RECEIPT
+        stock: AssetType = AssetType.STOCK
+        dw: AssetType = AssetType.DERIVATIVE_WARRANT
+        assert dr == "dr"
+        assert stock == "stock"
+        assert dw == "dw"
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("S", AssetType.STOCK),
+            ("F", AssetType.STOCK_FOREIGN),
+            ("P", AssetType.PREFERRED_STOCK),
+            ("Q", AssetType.PREFERRED_STOCK_FOREIGN),
+            ("W", AssetType.WARRANT),
+            ("V", AssetType.DERIVATIVE_WARRANT),
+            ("L", AssetType.ETF),
+            ("U", AssetType.UNIT_TRUST),
+            ("X", AssetType.DEPOSITARY_RECEIPT),
+        ],
+    )
+    def test_all_probed_codes_map(self, code: str, expected: AssetType) -> None:
+        assert AssetType.from_security_type(code) is expected
+
+    def test_code_is_case_and_whitespace_insensitive(self) -> None:
+        assert AssetType.from_security_type(" x ") is AssetType.DEPOSITARY_RECEIPT
+        assert AssetType.from_security_type("s") is AssetType.STOCK
+
+    def test_unknown_code_maps_to_unknown(self) -> None:
+        assert AssetType.from_security_type("Z") is AssetType.UNKNOWN
+        assert AssetType.from_security_type("XYZ") is AssetType.UNKNOWN
+
+    def test_none_and_empty_map_to_unknown(self) -> None:
+        assert AssetType.from_security_type(None) is AssetType.UNKNOWN
+        assert AssetType.from_security_type("") is AssetType.UNKNOWN
+
+    def test_no_bond_member_documented_limitation(self) -> None:
+        # Bonds do not appear in SET's stock APIs at all — deliberately no BOND member.
+        assert "BOND" not in AssetType.__members__
+
+    def test_mapping_covers_every_member_except_unknown(self) -> None:
+        assert set(SECURITY_TYPE_TO_ASSET_TYPE.values()) == set(AssetType) - {AssetType.UNKNOWN}
+
+
+class TestStockProfileAssetType:
+    """The derived asset_type property on StockProfile."""
+
+    def test_asset_type_property_dr(self) -> None:
+        profile = StockProfile.model_validate(_profile_payload("X"))
+        assert profile.asset_type is AssetType.DEPOSITARY_RECEIPT
+
+    def test_asset_type_property_common_stock(self) -> None:
+        profile = StockProfile.model_validate(_profile_payload("S"))
+        assert profile.asset_type is AssetType.STOCK
+
+    def test_asset_type_not_in_model_dump(self) -> None:
+        # Plain @property, not a computed field — serialization output stays unchanged.
+        profile = StockProfile.model_validate(_profile_payload("X"))
+        assert "asset_type" not in profile.model_dump()

--- a/tests/services/set/test_list.py
+++ b/tests/services/set/test_list.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from settfex.services.set.asset_type import AssetType
 from settfex.services.set.index.composition import IndexCompositionResponse
 from settfex.services.set.index.list import IndexListResponse, IndexSymbol
 from settfex.services.set.list import (
@@ -16,14 +17,16 @@ from settfex.services.set.list import (
 from settfex.utils.data_fetcher import FetcherConfig
 
 
-def _stock(symbol: str, market: str = "SET", industry: str = "SERVICE") -> dict[str, Any]:
+def _stock(
+    symbol: str, market: str = "SET", industry: str = "SERVICE", security_type: str = "S"
+) -> dict[str, Any]:
     """Build one realistic securitySymbols row."""
     return {
         "symbol": symbol,
         "nameTH": f"{symbol} (TH)",
         "nameEN": f"{symbol} (EN)",
         "market": market,
-        "securityType": "S",
+        "securityType": security_type,
         "typeSequence": 1,
         "industry": industry,
         "sector": "COMM",
@@ -160,6 +163,47 @@ class TestStockListResponse:
 
     def test_filter_by_index_unknown_returns_empty(self, response):
         assert response.filter_by_index("SETHD") == []
+
+
+class TestAssetTypeFiltering:
+    """StockSymbol.asset_type and StockListResponse.filter_by_asset_type."""
+
+    @pytest.fixture
+    def response(self) -> StockListResponse:
+        return StockListResponse.model_validate(
+            {
+                "securitySymbols": [
+                    _stock("CPALL"),
+                    _stock("GOOG80", security_type="X"),
+                    _stock("MICRON01", security_type="X"),
+                    _stock("1DIV", security_type="L"),
+                    _stock("AAV01C2609T", security_type="V"),
+                ]
+            }
+        )
+
+    def test_stock_symbol_asset_type_property(self, response):
+        goog = response.get_symbol("GOOG80")
+        cpall = response.get_symbol("CPALL")
+        assert goog is not None and cpall is not None
+        assert goog.asset_type is AssetType.DEPOSITARY_RECEIPT
+        assert cpall.asset_type is AssetType.STOCK
+
+    def test_filter_by_asset_type_enum(self, response):
+        drs = response.filter_by_asset_type(AssetType.DEPOSITARY_RECEIPT)
+        assert [s.symbol for s in drs] == ["GOOG80", "MICRON01"]
+
+    def test_filter_by_asset_type_value_string_case_insensitive(self, response):
+        assert [s.symbol for s in response.filter_by_asset_type("DR")] == ["GOOG80", "MICRON01"]
+        assert [s.symbol for s in response.filter_by_asset_type("etf")] == ["1DIV"]
+
+    def test_filter_by_asset_type_raw_set_code(self, response):
+        assert [s.symbol for s in response.filter_by_asset_type("X")] == ["GOOG80", "MICRON01"]
+        assert [s.symbol for s in response.filter_by_asset_type("V")] == ["AAV01C2609T"]
+
+    def test_filter_by_asset_type_unknown_raises_value_error(self, response):
+        with pytest.raises(ValueError, match="Unknown asset type"):
+            response.filter_by_asset_type("bond")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -3090,7 +3090,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Why

SET lists ETFs, DRs, DWs, warrants, preferred shares and unit trusts through the **same APIs** as common stocks — told apart only by a single-letter `securityType` code. The `Stock` class had no way to answer "what kind of instrument is this?".

For **Depositary Receipts** (`GOOG80`, `MICRON01`, …) there is a second gap: SET's DR pages carry an *"Indicative Price"* menu linking to a TradingView chart of `underlying × FX ÷ conversion ratio` — the DR's fair value in THB, which keeps moving while SET is closed. The library exposed neither the link nor the number.

## What

**1. Asset types** — `AssetType` StrEnum mapping the nine live-probed `securityType` codes:

| Code | Type | Live count |
|---|---|---|
| `S` / `F` | `stock` / `stock_foreign` | 930 / 864 |
| `P` / `Q` | `preferred_stock` / `preferred_stock_foreign` | 8 / 8 |
| `W` / `V` | `warrant` / `dw` | 85 / 1651 |
| `L` / `U` | `etf` / `unit_trust` | 13 / 2 |
| `X` | `dr` | 493 |

Exposed as `StockProfile.asset_type`, `StockSymbol.asset_type`, `StockListResponse.filter_by_asset_type()` and a cached `Stock.get_asset_type()`. Unrecognized codes degrade to `UNKNOWN` rather than raising. There is deliberately **no `BOND`** member — bonds appear nowhere in these APIs.

**2. DR profile** — `GET /api/set/dr/{symbol}/profile`: issuer, underlying (symbol/name/exchange), conversion ratio, DRx flag, and the TradingView link. `indicative_expression` parses the pricing formula and recovers it from the URL when `indicativePriceSymbol` is `null` (HERMES80, BYDCOM80, NDX01). Reached via `get_dr_profile()`, `Stock.get_dr_profile()`, `Stock.get_tradingview_url()`.

**3. DR indicative price** — evaluates the expression with **one** batch `POST scanner.tradingview.com/global/scan` for all legs. `Stock.get_latest_price()` now returns this for DRs as a `DrIndicativeQuotation`, falling back to SET chart data on any failure.

```python
price = await get_dr_indicative_price("GOOG80")
# 356.65 USD x 33.31 THB/USD / 2,000 = 5.9400 THB
```

## Behavior change

`Stock.get_latest_price()` returns a `DrIndicativeQuotation` for DR symbols (`volume`/`change` are `None` — it is a fair value, not a trade; `.indicative` carries the legs and ratio). Non-DR symbols are unchanged apart from one cached DR probe on first call. Opt out with `prefer_dr_indicative=False`; an explicit `as_of` always uses the SET chart path since TradingView only answers "now".

## Notable design points

- **TradingView is a stateless foreign host** — kept off `SessionManager` (`use_session=False`), with an explicit status check because `AsyncDataFetcher.fetch()` retries exceptions only, never a non-2xx. Unknown tickers return HTTP 200 with the row missing, so missing rows raise explicitly.
- **A DR-profile 404 means "not a DR"**, not "unknown symbol" — it fires for valid listed stocks like `CPALL`, so the error skips the "did you mean?" suggester (it would suggest the symbol back), and is logged at `debug` so ordinary stocks don't cry wolf on every first `get_latest_price()`.
- `close` is the only usable price column over plain HTTP (`lp`/`lp_time` are websocket-only) and is ~15 min delayed for exchange legs — so indicative vs SET-close divergence is expected, not a bug.

## Drive-by doc fixes

Two pre-existing errors found while auditing: the README chart-quotation snippet called `Quotation.close` (the field is `price`), and `CLAUDE.md` advertised `stock.get_balance_sheet()`, which the `Stock` class has never had.

## Testing

- 106 new offline tests (660 total passing, 85.7% coverage); `ruff check`, `ruff format --check`, `mypy` strict all green.
- Two live verification scripts pass 5/5 against the real SET + TradingView APIs.
- New example notebook `examples/set/18_dr_and_asset_type.ipynb` is **executed live** — its saved outputs are real.

Releases as **0.16.0** (`pyproject.toml`, `__init__.py`, `uv.lock` in sync; CHANGELOG section added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)