### PR TITLE
chore(release): 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-25
+
 ### Changed
 
 - **pandas 3 support (2.3.3 → 3.0.5), and it changes what `to_dataframe()` gives you.** settfex
@@ -58,7 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   superseded it.
 
 - Dev/CI dependency bumps (lockfile only — no `pyproject.toml` constraint changes): notebook
-  7.6.0 → 7.6.1, pre-commit 4.6.0 → 4.6.1, twine 6.2.0 → 7.0.0. `twine` is a break-glass tool
+  7.6.0 → **7.6.2**, pre-commit 4.6.0 → **4.6.2**, tqdm 4.69.0 → **4.70.0**, twine 6.2.0 → 7.0.0.
+  (notebook, pre-commit and tqdm landed in two rounds — the second round was raised by Dependabot
+  only after the queue below was unblocked.) `twine` is a break-glass tool
   only — the release path publishes through `pypa/gh-action-pypi-publish` over OIDC and invokes
   no workflow that uses it.
 - `astral-sh/setup-uv` bumped v9.0.0 → v10.0.1 across all six workflow steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.18.0"
+version = "0.19.0"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3101,7 +3101,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Cuts **0.19.0**. Minor rather than patch: `to_dataframe()` changes behaviour for consumers, and the core HTTP dependency moved three minor versions.

## Changed — this one affects users

**pandas 2.3.3 → 3.0.5**, with `pandas>=2.0.0` still supported, so *the same call differs by installed pandas*:

- A **missing value in a string column is `NaN` on pandas 3** where it was **`None` on pandas 2**. `value is None` silently stops matching — **`pd.isna(value)`** is the portable check. Visible on every nullable string the library exposes (`research_url` for a broker with no PDF, `youtube_url` for an upcoming call).
- Tz-aware datetime columns move `datetime64[ns, +07:00]` → `[us, +07:00]`. **No test caught this** — found by running one fixture through both majors and diffing.
- `NaN` is not valid JSON, so `json.dumps(df.to_dict("records"))` emits a bare `NaN`. Use `df.to_json()`.
- Verified safe: `df.attrs` survives, and pyarrow is **not** required.

Suite is green on **both** majors — 882 passed under 3.0.5 and under 2.3.3.

## Fixed

A docstring, and its copy in the service doc, claimed `last_update_date` is typed `object`. It never was, on either pandas major.

## Internal

- **curl-cffi 0.13.0 → 0.16.1**, verified **live** against SET / Settrade / TradingView / ThaiBMA — the mocked suite structurally cannot test impersonation. A control probe confirms the check isn't vacuous: the SET endpoint 403s a bare request even with `impersonate="chrome120"`.
- **Coverage floor 45% → 85%**, plus `--cov-branch` so a local run measures what CI measures.
- **ruff frozen at 0.13.2** and removed from Dependabot's watch list after three rejections.
- Dependency queue cleared: notebook 7.6.2, pre-commit 4.6.2, tqdm 4.70.0, twine 7.0.0, setup-uv v10.0.1.

## Release checks

```
pyproject.toml / __init__.py / uv.lock   all 0.19.0 (release.yml validates this)
uv sync --group dev --frozen             clean
ruff check / format / mypy strict        clean
pytest                                   882 passed, 86.65% (floor 85)
python -m build + twine check            both artifacts PASSED
```

Merging this, then pushing `v0.19.0` to trigger the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZTjyrMDpg7nMHBepbQNT