### PR TITLE
docs(prompts): align the agent prompts with the enforced 85% coverage floor

### DIFF
--- a/.github/prompts/Coding.prompt.md
+++ b/.github/prompts/Coding.prompt.md
@@ -148,7 +148,8 @@ from module.submodule import something
 ## 🧪 Testing Requirements (NO EXCEPTIONS)
 
 1. **Test Coverage:**
-   - Minimum 90% code coverage
+   - Minimum 85% code coverage — this is the *enforced* CI floor
+     (`--cov-fail-under=85` in `pyproject.toml`), not an aspiration
    - 100% coverage for public APIs
    - Edge cases and error conditions MUST be tested
 
@@ -275,7 +276,7 @@ A task is only complete when:
 2. ✅ All todos marked as completed in sequence
 3. ✅ All quality gates passed
 4. ✅ Documentation is comprehensive
-5. ✅ Tests are passing (90%+ coverage)
+5. ✅ Tests are passing (85%+ coverage — the enforced floor)
 6. ✅ Code follows all architectural guidelines
 7. ✅ Git commit message follows standards
 8. ✅ User receives detailed summary

--- a/.github/prompts/Python-Architect.prompt.md
+++ b/.github/prompts/Python-Architect.prompt.md
@@ -28,7 +28,7 @@ description: Provides architectural guidance and ensures code quality standards 
 
 ### Testing Strategy Guidance
 - Guide testing strategy and coverage requirements
-- Ensure minimum 90% code coverage
+- Ensure minimum 85% code coverage (the enforced CI floor, `--cov-fail-under=85`)
 - Validate test patterns and mocking strategies
 - Review integration test approaches
 
@@ -61,7 +61,7 @@ description: Provides architectural guidance and ensures code quality standards 
 1. **Type Safety**: Complete type annotations for all code
 2. **Async Patterns**: async/await for all I/O operations
 3. **Pydantic Models**: Data validation and settings management
-4. **Testing**: Comprehensive test coverage (90%+)
+4. **Testing**: Comprehensive test coverage (85%+, the enforced CI floor)
 5. **Documentation**: Complete docstrings for public APIs
 
 ### Prohibited Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- The two AI-agent prompt files under `.github/prompts/` asked for **90% coverage** while the
+  enforced gate is **85%** (`--cov-fail-under`), so an agent following them was working to a number
+  the repo does not check. Both now state 85% and name the setting that enforces it, so the figure
+  points at its instrument rather than drifting again: `Coding.prompt.md` (the requirement and the
+  completion checklist) and `Python-Architect.prompt.md` (the strategy guidance and the review
+  checklist) — four surfaces in total. `Coding.prompt.md`'s separate "100% coverage for public
+  APIs" line is left as-is: it is a narrower, stricter target and does not conflict with a
+  repo-wide floor.
+
 ## [0.19.0] - 2026-08-25
 
 ### Changed


### PR DESCRIPTION
Follow-up to #102, which raised the coverage floor 45% → 85%.

The two AI-agent prompt files under `.github/prompts/` still asked for **90%** — so an agent following them was working to a number the repo does not check, while the number it *does* check sat 5 points lower.

## Four surfaces, in two files

The second file was not obvious from the original request:

| File | Where |
|---|---|
| `Coding.prompt.md` | testing requirement + completion checklist |
| `Python-Architect.prompt.md` | strategy guidance + review checklist |

Each now names the setting that enforces it (`--cov-fail-under=85` in `pyproject.toml`) rather than restating a bare figure — so the number points at its instrument instead of drifting again the next time the floor moves.

There are now **no `90% coverage` claims left anywhere in the repo.**

## Deliberately left alone

`Coding.prompt.md`'s separate *"100% coverage for public APIs"* line. That is a narrower, stricter target for a specific scope and does not conflict with a repo-wide floor — harmonising it would be lowering a bar, not fixing an inconsistency.

Docs only; no runtime code. Suite unaffected: 882 passed, 86.65%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZTjyrMDpg7nMHBepbQNT