### PR TITLE
chore(release): 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-26
+
 ### Internal
 
 - The AI-agent prompt files under `.github/prompts/` asked for **90% coverage** while the enforced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "settfex"
-version = "0.19.0"
+version = "0.19.1"
 description = "Async Python library for fetching real-time and historical data from the Stock Exchange of Thailand (SET) and Thailand Futures Exchange (TFEX)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/settfex/__init__.py
+++ b/settfex/__init__.py
@@ -35,7 +35,7 @@ Usage:
     >>> asyncio.run(main())
 """
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 __author__ = "batt"
 __license__ = "MIT"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3101,7 +3101,7 @@ wheels = [
 
 [[package]]
 name = "settfex"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Cuts **0.19.1** — a documentation-only patch.

## Scope, stated plainly

**There are zero changes under `settfex/` since v0.19.0**, and the wheel packages only that (`[tool.hatch.build.targets.wheel] packages = ["settfex"]`). So the installed package behaves identically to 0.19.0. What this release actually delivers is the tag, the GitHub Release, and an sdist carrying the updated CHANGELOG.

```
git diff --stat v0.19.0..HEAD
 .github/prompts/Coding.prompt.md           | 6 +++---
 .github/prompts/Prompt-Engineer.prompt.md  | 2 +-
 .github/prompts/Python-Architect.prompt.md | 4 ++--
 CHANGELOG.md                               | …
```

## What changed

- The AI-agent prompt files under `.github/prompts/` asked for **90% coverage** while the enforced gate is **85%** — an agent following them was working to a number the repo does not check. **Five surfaces across three files** now state 85% and name `--cov-fail-under=85` as the thing enforcing it, so the figure points at its instrument instead of drifting again.
- `Coding.prompt.md`'s **"100% coverage for public APIs"** requirement was **removed rather than rescaled**. Nothing measured it: coverage is enforced repo-wide and has no notion of a public-API subset, so the line could never pass or fail anything.

## Release checks

```
pyproject.toml / __init__.py / uv.lock   all 0.19.1 (release.yml validates this)
uv sync --group dev --frozen             clean
ruff check / format / mypy strict        clean
pytest                                   882 passed, 86.65% (floor 85)
python -m build + twine check            both artifacts PASSED
```

Merging this, then pushing `v0.19.1` to trigger the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZTjyrMDpg7nMHBepbQNT