### PR TITLE
docs(guide): the best-practices guide asked for >80%, below the enforced floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- `docs/guide/PYTHON_LIBRARY_BEST_PRACTICES.md` still said "Aim for >80% coverage". It reads as
+  generic advice but is explicitly a document about *this* library ("best practices followed in the
+  `settfex` library"), so it was a repo claim sitting **below the enforced 85% floor** — the last
+  one left after the 0.19.1 prompt sweep. It now names `--cov-fail-under=85` and says the floor is
+  enforced rather than aspirational. `CLAUDE.md` needed no change: both of its figures already read
+  86.65% and remain accurate.
+
 ## [0.19.1] - 2026-08-26
 
 ### Internal

--- a/docs/guide/PYTHON_LIBRARY_BEST_PRACTICES.md
+++ b/docs/guide/PYTHON_LIBRARY_BEST_PRACTICES.md
@@ -129,7 +129,7 @@ strict = true
 2. **Use pytest**: Modern testing framework
 3. **`conftest.py`**: Shared fixtures
 4. **Test Naming**: `test_*.py`, `test_*()` functions
-5. **Coverage**: Aim for >80% coverage
+5. **Coverage**: 85% is the enforced CI floor (`--cov-fail-under=85` in `pyproject.toml`), not a target to aim at — `uv run pytest` fails below it
 
 ### Example Structure
 


### PR DESCRIPTION
## CLAUDE.md needed no change

The request was to update CLAUDE.md's coverage number to 86.65%. **It already says 86.65%**, in both places, set back in `650794f`. I re-ran the suite to check the figure is still *accurate* rather than merely present — it reports exactly **86.65%**. So no edit there; a no-op commit would only add noise.

## But the sweep found the real one

`docs/guide/PYTHON_LIBRARY_BEST_PRACTICES.md:132` still said *"**Coverage**: Aim for >80% coverage"*.

That reads like generic Python advice, which is presumably why it survived every previous pass. It isn't — the document opens with *"the best practices followed in the `settfex` library"* and names settfex 11 times. So it was **a claim about this repo sitting 5 points below the gate that actually fails builds**, and phrased as something to "aim for" rather than something enforced.

It now names `--cov-fail-under=85` and states the floor is enforced, matching how every other coverage figure in the repo now reads.

## Repo-wide state

This was the **last non-historical coverage figure** that wasn't the enforced `85` or the measured `86.65`:

| Location | Figure |
|---|---|
| `pyproject.toml` | 85 floor / 86.65 actual |
| `CLAUDE.md` ×2 | 85 floor / 86.65 actual |
| `.github/prompts/` ×5 | 85 |
| `docs/guide/…BEST_PRACTICES.md` | 85 ← this PR |

Remaining `>80%` / `49%` / `90%` mentions live in `CHANGELOG.md` and `COMPREHENSIVE_AUDIT.md`, where they are point-in-time history and correct as such.

Docs only. Suite unaffected: 882 passed, 86.65%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZTjyrMDpg7nMHBepbQNT